### PR TITLE
feat(api): Docbase API検索機能とエラー型定義の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "notebooklm-collector",
       "version": "0.1.0",
       "dependencies": {
+        "neverthrow": "^8.2.0",
         "next": "15.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1103,6 +1104,19 @@
       "engines": {
         "node": ">=12.4.0"
       }
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.0.tgz",
+      "integrity": "sha512-XMLeKjyH8NsEDCRptf6LO8lJk23o9wvB+dJwcXMaH6ZQbbkHu2dbGIUindbMtRN6ux1xKi16iXWu6q9mu7gDhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -4712,6 +4726,18 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/neverthrow": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-8.2.0.tgz",
+      "integrity": "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.24.0"
+      }
     },
     "node_modules/next": {
       "version": "15.3.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "neverthrow": "^8.2.0",
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from "react";
+import { fetchDocbasePosts } from "../lib/docbaseClient";
+import type { DocbasePostListItem } from "../types/docbase";
+import type { ApiError } from "../types/error";
+import type { Result } from "neverthrow"; // Resultを型としてインポート (typeキーワードを明示)
+
+interface UseSearchResult {
+  posts: DocbasePostListItem[];
+  isLoading: boolean;
+  error: ApiError | null;
+  searchPosts: (
+    domain: string,
+    token: string,
+    keyword: string
+  ) => Promise<void>;
+}
+
+/**
+ * Docbaseの投稿を検索するためのカスタムフック
+ */
+export const useSearch = (): UseSearchResult => {
+  const [posts, setPosts] = useState<DocbasePostListItem[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<ApiError | null>(null);
+
+  const searchPosts = useCallback(
+    async (domain: string, token: string, keyword: string) => {
+      if (!keyword.trim()) {
+        setPosts([]);
+        setError(null);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      const result: Result<DocbasePostListItem[], ApiError> =
+        await fetchDocbasePosts(domain, token, keyword);
+
+      if (result.isOk()) {
+        setPosts(result.value);
+      } else {
+        setError(result.error);
+        setPosts([]); // エラー時は投稿リストをクリア
+      }
+      setIsLoading(false);
+    },
+    []
+  );
+
+  return { posts, isLoading, error, searchPosts };
+};

--- a/src/lib/docbaseClient.ts
+++ b/src/lib/docbaseClient.ts
@@ -1,0 +1,108 @@
+import { ok, err, type Result } from "neverthrow";
+import type {
+  DocbasePostsResponse,
+  DocbasePostListItem,
+} from "../types/docbase";
+import type {
+  ApiError,
+  NetworkApiError,
+  UnknownApiError,
+  UnauthorizedApiError,
+  NotFoundApiError,
+  RateLimitApiError,
+} from "../types/error";
+
+const DOCBASE_API_BASE_URL = "https://api.docbase.io/teams";
+
+/**
+ * Docbase APIから投稿リストを取得する関数
+ *
+ * @param domain Docbaseのチームドメイン
+ * @param token Docbase APIトークン
+ * @param keyword 検索キーワード
+ * @returns 成功時はDocbasePostListItemの配列、失敗時はApiErrorを含むResult型
+ */
+export const fetchDocbasePosts = async (
+  domain: string,
+  token: string,
+  keyword: string
+): Promise<Result<DocbasePostListItem[], ApiError>> => {
+  // キーワードが空の場合は検索を実行しない
+  if (!keyword.trim()) {
+    return ok([]); // 空の配列を成功として返す
+  }
+
+  const searchParams = new URLSearchParams({
+    q: keyword,
+    // per_page: '100', // 必要に応じて取得件数を調整
+  });
+
+  const url = `${DOCBASE_API_BASE_URL}/${domain}/posts?${searchParams.toString()}`;
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "X-DocBaseToken": token,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        // UnauthorizedApiError を使用
+        const error: UnauthorizedApiError = {
+          type: "unauthorized",
+          message: "Docbase APIトークンが無効です。",
+        };
+        return err(error);
+      }
+      if (response.status === 404) {
+        // NotFoundApiError を使用
+        const error: NotFoundApiError = {
+          type: "notFound",
+          message:
+            "Docbaseのチームが見つからないか、APIエンドポイントが誤っています。",
+        };
+        return err(error);
+      }
+      if (response.status === 429) {
+        // RateLimitApiError を使用
+        const error: RateLimitApiError = {
+          type: "rateLimit",
+          message:
+            "Docbase APIのレートリミットに達しました。時間をおいて再度お試しください。",
+        };
+        return err(error);
+      }
+      // その他のHTTPエラー
+      const errorText = await response.text();
+      // NetworkApiError を使用 (causeなし)
+      const error: NetworkApiError = {
+        type: "network",
+        message: `Docbase APIリクエストエラー: ${response.status} ${response.statusText}. ${errorText}`,
+      };
+      return err(error);
+    }
+
+    const data = (await response.json()) as DocbasePostsResponse;
+    return ok(data.posts);
+  } catch (error) {
+    console.error("Docbase API fetch error:", error);
+    if (error instanceof Error) {
+      // NetworkApiError を使用 (causeあり)
+      const apiError: NetworkApiError = {
+        type: "network",
+        message: `ネットワークエラー: ${error.message}`,
+        cause: error,
+      };
+      return err(apiError);
+    }
+    // UnknownApiError を使用
+    const unknownError: UnknownApiError = {
+      type: "unknown",
+      message: "不明なエラーが発生しました。コンソールを確認してください。",
+      cause: error,
+    };
+    return err(unknownError);
+  }
+};

--- a/src/types/docbase.ts
+++ b/src/types/docbase.ts
@@ -1,0 +1,33 @@
+/**
+ * Docbaseの投稿情報を表す型定義
+ */
+export type DocbasePostListItem = {
+  id: number;
+  title: string;
+  body: string;
+  created_at: string; // ISO-8601形式の文字列
+  url: string;
+  // APIレスポンスには他にも多くのフィールドがあるが、今回は仕様書に記載のあるもののみ定義
+  // 必要に応じて追加する
+  // user: { ... },
+  // tags: [ ... ],
+  // comments: [ ... ],
+  // groups: [ ... ],
+  // draft: boolean,
+  // archieved: boolean,
+  // scope: string,
+  // sharing_url: string | null,
+  // organization: { ... }
+};
+
+/**
+ * Docbase APIの投稿リスト取得レスポンスの型定義
+ */
+export type DocbasePostsResponse = {
+  posts: DocbasePostListItem[];
+  meta: {
+    previous_page: string | null;
+    next_page: string | null;
+    total: number;
+  };
+};

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,0 +1,49 @@
+/**
+ * APIリクエストで発生する可能性のあるエラーの型定義
+ */
+export type NetworkApiError = {
+  type: "network";
+  message: string;
+  cause?: unknown;
+};
+export type UnknownApiError = {
+  type: "unknown";
+  message: string;
+  cause?: unknown;
+};
+
+// cause を持たないエラー型
+export type UnauthorizedApiError = { type: "unauthorized"; message: string };
+export type RateLimitApiError = { type: "rateLimit"; message: string };
+export type NotFoundApiError = { type: "notFound"; message: string };
+
+/**
+ * APIリクエストで発生する可能性のあるエラーの型定義
+ */
+export type ApiError =
+  | NetworkApiError
+  | UnknownApiError
+  | UnauthorizedApiError
+  | RateLimitApiError
+  | NotFoundApiError;
+
+/**
+ * エラーがApiError型であるかを判定する型ガード
+ * @param error 判定対象のエラー
+ * @returns ApiErrorであればtrue、そうでなければfalse
+ */
+export const isApiError = (error: unknown): error is ApiError => {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const e = error as Record<string, unknown>; // キャストの仕方を少し変更
+  return (
+    typeof e.type === "string" &&
+    typeof e.message === "string" &&
+    (e.type === "network" ||
+      e.type === "unknown" ||
+      e.type === "unauthorized" ||
+      e.type === "rateLimit" ||
+      e.type === "notFound")
+  );
+};


### PR DESCRIPTION
## 概要
Issue #2 の実装として、Docbase APIから投稿を検索し、結果やエラーを表示する機能を実装しました。

## 変更内容
- **APIクライアントの作成 (`src/lib/docbaseClient.ts`)**
  - `fetchDocbasePosts` 関数を実装し、指定されたキーワードでDocbase APIから投稿を取得します。
  - `neverthrow` を使用して `Result` 型で結果を返します。
- **カスタムフックの作成 (`src/hooks/useSearch.ts`)**
  - `useSearch` フックを作成し、検索状態（投稿リスト、ローディング状態、エラー情報）を管理します。
  - `fetchDocbasePosts` を呼び出す検索実行関数を提供します。
- **型定義の作成・更新**
  - `src/types/docbase.ts`: `DocbasePostListItem` と `DocbasePostsResponse` 型を定義しました。
  - `src/types/error.ts`: `ApiError` 型を、`cause` を持つ型（`NetworkApiError`, `UnknownApiError`）と持たない型に分離して再定義しました。
- **検索フォームの更新 (`src/components/SearchForm.tsx`)**
  - `useSearch` フックを統合し、検索ボタンクリック時にAPI検索を実行するようにしました。
  - ローディング中は入力フィールドと検索ボタンを無効化し、ローディング状態を表示します。
  - APIエラー発生時にはエラーメッセージ（該当する場合は `cause` も含む）を表示します。
  - 検索結果（投稿タイトルリスト）を簡易的に表示します（MarkdownプレビューはIssue #3で対応）。

## テスト手順
1. `npm run dev` を実行します。
2. アプリケーションにアクセスし、検索フォームが表示されることを確認します。
3. **正常系テスト**:
   - 有効なDocbaseドメイン、トークン、検索キーワードを入力し、「検索」ボタンをクリックします。
   - ローディング表示（例：「検索中...」）が一時的に表示されることを確認します。
   - 検索結果が存在する場合、投稿タイトルのリストが表示されることを確認します。
   - 検索結果が存在しない場合、リストが表示されないことを確認します。
4. **異常系テスト（トークン無効）**:
   - 無効なDocbaseトークンを入力し、検索を実行します。
   - 「エラー: Docbase APIトークンが無効です。」のようなエラーメッセージが表示されることを確認します。
5. **異常系テスト（ドメイン無効/存在しないチーム）**:
   - 存在しないDocbaseドメインを入力し、検索を実行します。
   - 「エラー: Docbaseのチームが見つからないか、APIエンドポイントが誤っています。」のようなエラーメッセージが表示されることを確認します。
6. **異常系テスト（キーワード空）**:
   - キーワードを空にして検索を実行した場合、APIリクエストが発生せず、エラーも表示されない（または結果がクリアされる）ことを確認します。

## 関連Issue
- Closes #2