### PR TITLE
feat(download): Markdownファイルダウンロード機能の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "next": "15.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hot-toast": "^2.5.2",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1"
       },
@@ -3747,6 +3748,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6366,6 +6376,23 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hot-toast": "^2.5.2",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 "use client"; // クライアントコンポーネントとしてマーク
 
 import SearchForm from "../components/SearchForm"; // パスを修正
+import { Toaster } from "react-hot-toast"; // Toasterをインポート
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <Toaster position="top-right" /> {/* Toasterコンポーネントを配置 */}
       <h1 className="text-4xl font-bold mb-8">Docbase NotebookLM Collector</h1>
       <div className="w-full max-w-lg">
         <SearchForm />

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -4,6 +4,7 @@ import React, { useState, type FormEvent, useEffect } from "react";
 import DocbaseDomainInput from "./DocbaseDomainInput";
 import DocbaseTokenInput from "./DocbaseTokenInput";
 import { useSearch } from "../hooks/useSearch";
+import { useDownload } from "../hooks/useDownload";
 import type { ApiError } from "../types/error";
 import { generateMarkdown } from "../utils/markdownGenerator";
 import MarkdownPreview from "./MarkdownPreview";
@@ -18,9 +19,11 @@ const SearchForm = () => {
   const [markdownContent, setMarkdownContent] = useState("");
 
   const { posts, isLoading, error, searchPosts } = useSearch();
+  const { isDownloading, handleDownload } = useDownload();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setMarkdownContent("");
     await searchPosts(domain, token, keyword);
   };
 
@@ -32,6 +35,11 @@ const SearchForm = () => {
       setMarkdownContent("");
     }
   }, [posts]);
+
+  const handleDownloadClick = () => {
+    const postsExist = posts && posts.length > 0;
+    handleDownload(markdownContent, keyword, postsExist);
+  };
 
   const renderErrorCause = (currentError: ApiError | null) => {
     if (!currentError) return null;
@@ -58,18 +66,28 @@ const SearchForm = () => {
           onChange={(e) => setKeyword(e.target.value)}
           placeholder="検索キーワード"
           className="border p-2 rounded w-full"
-          disabled={isLoading}
+          disabled={isLoading || isDownloading}
         />
       </div>
       <DocbaseDomainInput value={domain} onChange={setDomain} />
       <DocbaseTokenInput value={token} onChange={setToken} />
-      <button
-        type="submit"
-        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:bg-gray-400"
-        disabled={isLoading}
-      >
-        {isLoading ? "検索中..." : "検索"}
-      </button>
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:bg-gray-400"
+          disabled={isLoading || isDownloading}
+        >
+          {isLoading ? "検索中..." : "検索"}
+        </button>
+        <button
+          type="button"
+          onClick={handleDownloadClick}
+          className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded disabled:bg-gray-400"
+          disabled={isLoading || isDownloading || !markdownContent.trim()}
+        >
+          {isDownloading ? "ダウンロード中..." : "Markdownダウンロード"}
+        </button>
+      </div>
 
       {error && (
         <div className="mt-4 p-2 text-red-700 bg-red-100 border border-red-400 rounded">

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -1,0 +1,70 @@
+import { useState, useCallback } from "react";
+import { downloadMarkdownFile } from "../utils/fileDownloader";
+import toast from "react-hot-toast";
+
+interface UseDownloadResult {
+  isDownloading: boolean;
+  handleDownload: (
+    markdownContent: string,
+    keyword: string,
+    postsExist: boolean
+  ) => Promise<void>;
+}
+
+/**
+ * Markdownファイルのダウンロード処理と通知を行うカスタムフック
+ */
+export const useDownload = (): UseDownloadResult => {
+  const [isDownloading, setIsDownloading] = useState<boolean>(false);
+
+  const handleDownload = useCallback(
+    async (markdownContent: string, keyword: string, postsExist: boolean) => {
+      setIsDownloading(true);
+      // ダウンロード対象がない場合は、fileDownloaderからのメッセージをtoastで表示
+      if (!postsExist || !markdownContent.trim()) {
+        const result = downloadMarkdownFile(
+          markdownContent,
+          keyword,
+          postsExist
+        );
+        if (result.message) {
+          toast.error(result.message);
+        }
+        setIsDownloading(false);
+        return;
+      }
+
+      // ダウンロード処理を実行
+      const toastId = toast.loading("Markdownファイルをダウンロード中です...");
+      try {
+        // 非同期処理っぽく見せるために少し待つ（実際にはdownloadMarkdownFileは同期的）
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        const result = downloadMarkdownFile(
+          markdownContent,
+          keyword,
+          postsExist
+        );
+
+        if (result.success) {
+          toast.success("Markdownファイルをダウンロードしました。", {
+            id: toastId,
+          });
+        } else {
+          toast.error(result.message || "ダウンロードに失敗しました。", {
+            id: toastId,
+          });
+        }
+      } catch (error) {
+        console.error("Download process error:", error);
+        toast.error("予期せぬエラーによりダウンロードに失敗しました。", {
+          id: toastId,
+        });
+      } finally {
+        setIsDownloading(false);
+      }
+    },
+    []
+  );
+
+  return { isDownloading, handleDownload };
+};

--- a/src/utils/fileDownloader.ts
+++ b/src/utils/fileDownloader.ts
@@ -1,0 +1,56 @@
+/**
+ * Markdown文字列をファイルとしてダウンロードする関数
+ *
+ * @param markdownContent ダウンロードするMarkdown文字列
+ * @param keyword ファイル名に使用するキーワード
+ * @param_posts 投稿があったかどうか
+ */
+export const downloadMarkdownFile = (
+  markdownContent: string,
+  keyword: string,
+  postsExist: boolean // 投稿が存在するかどうかを示すフラグを追加
+): { success: boolean; message?: string } => {
+  // 投稿が存在しない、またはMarkdownコンテントが空の場合はダウンロードしない
+  if (!postsExist || !markdownContent.trim()) {
+    // ユーザーに通知するかどうかは呼び出し側で判断するため、ここでは特別なメッセージは返さない
+    return {
+      success: false,
+      message: "ダウンロードするコンテンツがありません。",
+    };
+  }
+
+  try {
+    const blob = new Blob([markdownContent], {
+      type: "text/markdown;charset=utf-8",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+
+    // 日本のタイムゾーンでYYYYMMDDHHmmss形式のタイムスタンプを生成
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    const hours = String(now.getHours()).padStart(2, "0");
+    const minutes = String(now.getMinutes()).padStart(2, "0");
+    const seconds = String(now.getSeconds()).padStart(2, "0");
+    const timestamp = `${year}${month}${day}${hours}${minutes}${seconds}`;
+
+    // キーワードが空の場合はデフォルトのファイル名の一部とする
+    const keywordPart = keyword.trim() || "docbase";
+
+    a.download = `notebooklm_${keywordPart}_${timestamp}.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    return { success: true };
+  } catch (error) {
+    console.error("Markdown file download error:", error);
+    return {
+      success: false,
+      message: "ファイルのダウンロード中にエラーが発生しました。",
+    };
+  }
+};


### PR DESCRIPTION
## 概要
Issue #4 の実装として、生成されたMarkdownコンテンツをファイルとしてダウンロードする機能、および関連する通知機能を実装しました。

## 変更内容
- **ファイルダウンロードユーティリティの作成 (`src/utils/fileDownloader.ts`)**
  - `downloadMarkdownFile` 関数を実装し、Markdown文字列からBlobオブジェクトを生成し、動的に作成した `<a>` タグ経由でダウンロードを実行します。
  - ファイル名は `notebooklm_{keyword}_{YYYYMMDDHHmmss}.md` の形式で、UTF-8エンコーディングを指定しています。
  - ダウンロードするコンテンツがない場合は、その旨を示す結果を返します。
- **ダウンロード用カスタムフックの作成 (`src/hooks/useDownload.ts`)**
  - `useDownload` フックを作成し、ダウンロード処理の呼び出しと状態（`isDownloading`）を管理します。
  - `react-hot-toast` を利用して、ダウンロード中、成功、失敗、コンテンツなしの各ケースでユーザーにトースト通知を表示します。
- **検索フォームの更新 (`src/components/SearchForm.tsx`)**
  - 「Markdownダウンロード」ボタンを追加しました。
  - `useDownload` フックを統合し、ボタンクリックで `handleDownload` を呼び出してダウンロード処理を実行します。
  - Markdownコンテンツが存在し、かつローディング中でない場合にのみダウンロードボタンが有効になります。
  - 検索実行時には、古いMarkdownプレビューが残らないようにクリア処理を追加しました。
- **ページコンポーネントの更新 (`src/app/page.tsx`)**
  - `react-hot-toast` の `<Toaster />` コンポーネントを配置し、アプリケーション全体でトースト通知が表示されるようにしました。
- **依存関係の追加**
  - `react-hot-toast` をプロジェクトに追加しました。

## テスト手順
1. `npm run dev` を実行します。
2. アプリケーションにアクセスし、検索フォームが表示されることを確認します。
3. 有効なDocbaseドメイン、トークン、検索キーワードを入力し、「検索」ボタンをクリックします。
4. 検索が成功し、Markdownプレビューが表示された状態であることを確認します。
5. 「Markdownダウンロード」ボタンが有効になっていることを確認します。
6. **ダウンロード成功テスト**:
   - 「Markdownダウンロード」ボタンをクリックします。
   - 「Markdownファイルをダウンロード中です...」というトーストが表示された後、「Markdownファイルをダウンロードしました。」という成功トーストが表示されることを確認します。
   - ブラウザでファイル（例: `notebooklm_テスト_20250521223000.md`）がダウンロードされることを確認します。
   - ダウンロードされたファイルを開き、プレビューされていたMarkdownコンテンツが正しく保存されていることを確認します。
7. **コンテンツなしテスト**:
   - 検索キーワードを空にするなどして、Markdownプレビューが表示されていない状態にします。
   - 「Markdownダウンロード」ボタンが無効になっていることを確認します。
   - （もしボタンが押せる状態であれば）クリックしても、「ダウンロードするコンテンツがありません。」のようなトーストが表示され、ファイルダウンロードが実行されないことを確認します。
8. **エラーテスト（ダウンロード処理自体のエラーは擬似的に発生させるのが難しいため、主に `downloadMarkdownFile` 関数のエラーハンドリングが機能することを確認）**:
   -  開発者ツールなどで `Blob` の作成や `URL.createObjectURL` が失敗するような状況を擬似的に作り出せる場合、エラー発生時に「ダウンロードに失敗しました。」または「予期せぬエラーによりダウンロードに失敗しました。」のトーストが表示されることを確認します（このテストは任意）。

## 関連Issue
- Closes #4