### PR TITLE
feat(storage): ドメインとトークンのlocalStorage保存・自動補完

### DIFF
--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -5,17 +5,27 @@ import DocbaseDomainInput from "./DocbaseDomainInput";
 import DocbaseTokenInput from "./DocbaseTokenInput";
 import { useSearch } from "../hooks/useSearch";
 import { useDownload } from "../hooks/useDownload";
+import useLocalStorage from "../hooks/useLocalStorage";
 import type { ApiError } from "../types/error";
 import { generateMarkdown } from "../utils/markdownGenerator";
 import MarkdownPreview from "./MarkdownPreview";
+
+const LOCAL_STORAGE_DOMAIN_KEY = "docbaseDomain";
+const LOCAL_STORAGE_TOKEN_KEY = "docbaseToken";
 
 /**
  * 検索フォームコンポーネント
  */
 const SearchForm = () => {
   const [keyword, setKeyword] = useState("");
-  const [domain, setDomain] = useState("");
-  const [token, setToken] = useState("");
+  const [domain, setDomain] = useLocalStorage<string>(
+    LOCAL_STORAGE_DOMAIN_KEY,
+    ""
+  );
+  const [token, setToken] = useLocalStorage<string>(
+    LOCAL_STORAGE_TOKEN_KEY,
+    ""
+  );
   const [markdownContent, setMarkdownContent] = useState("");
 
   const { posts, isLoading, error, searchPosts } = useSearch();

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect } from "react";
+
+/**
+ * localStorageと値を同期するためのカスタムフック
+ * @param key localStorageのキー
+ * @param initialValue 初期値
+ * @returns [storedValue, setValue] storedValueは現在の値、setValueは値を更新する関数
+ */
+function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T | ((val: T) => T)) => void] {
+  // localStorageから初期値を取得、なければinitialValueを使用
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    // windowオブジェクトが存在するか確認 (SSR対策)
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+    try {
+      const item = window.localStorage.getItem(key);
+      if (item) {
+        try {
+          return JSON.parse(item) as T;
+        } catch (parseError) {
+          // パースに失敗した場合は警告を出し、初期値を返す
+          console.warn(
+            `Error parsing localStorage key "${key}" (value: "${item}"), falling back to initialValue:`,
+            parseError
+          );
+          return initialValue;
+        }
+      }
+      return initialValue;
+    } catch (error) {
+      console.error(`Error reading localStorage key "${key}":`, error);
+      return initialValue;
+    }
+  });
+
+  // storedValueが変更されたらlocalStorageに保存
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      setStoredValue(valueToStore);
+      // windowオブジェクトが存在するか確認 (SSR対策)
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      console.error(`Error setting localStorage key "${key}":`, error);
+    }
+  };
+
+  // マウント時にlocalStorageの値でstateを更新する (別のタブでの変更に対応するため)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === key && event.newValue) {
+        try {
+          setStoredValue(JSON.parse(event.newValue) as T);
+        } catch (error) {
+          console.warn(
+            `Error parsing localStorage key "${key}" on storage event (newValue: "${event.newValue}"), falling back to current value or initialValue if parsing fails elsewhere:`,
+            error
+          );
+          // ここでエラーが起きても、storedValueは以前の値のまま or 初期化時の値のまま
+        }
+      }
+    };
+
+    window.addEventListener("storage", handleStorageChange);
+    // initialValueが変更された場合も考慮して、localStorageの値を再確認・初期化
+    const currentLocalItem = window.localStorage.getItem(key);
+    if (currentLocalItem === null) {
+      // 文字列としての initialValue ではなく、JSON.stringifyされたものが保存されるべき
+      window.localStorage.setItem(key, JSON.stringify(initialValue));
+    } else {
+      try {
+        JSON.parse(currentLocalItem); // 既存の値が有効なJSONかチェック
+      } catch (e) {
+        // 既存の値が不正なJSONなら、initialValueで上書きする
+        console.warn(
+          `Invalid JSON in localStorage for key "${key}" (value: "${currentLocalItem}"), overwriting with initialValue.`
+        );
+        window.localStorage.setItem(key, JSON.stringify(initialValue));
+        setStoredValue(initialValue); // stateも更新
+      }
+    }
+
+    return () => {
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, [key, initialValue]); // initialValueを依存配列に追加
+
+  return [storedValue, setValue];
+}
+
+export default useLocalStorage;


### PR DESCRIPTION
## 概要
Issue #5 の実装として、ユーザーが入力したDocbaseのドメインとトークンをlocalStorageに保存し、次回アクセス時に自動的に入力フィールドに値を補完する機能を追加しました。

## 変更内容
- **`useLocalStorage` カスタムフックの作成 (`src/hooks/useLocalStorage.ts`)**
  - 指定されたキーと初期値を使用して、stateとlocalStorageを同期します。
  - SSR実行時（`window` オブジェクト未定義時）のエラーを回避します。
  - 他のタブやウィンドウでlocalStorageが変更された場合に、`storage` イベントを購読して値を同期します。
  - コンポーネントマウント時にlocalStorageに該当キーの値が存在しない場合、初期値を保存します。
- **検索フォームの更新 (`src/components/SearchForm.tsx`)**
  - ドメイン (`domain`) とトークン (`token`) のstate管理を、作成した `useLocalStorage` フックに置き換えました。
  - これにより、ユーザーがこれらの値を入力すると自動的にlocalStorageに保存され、次回ページを開いた際には保存された値が自動的に入力フィールドに設定されます。
  - キーワード (`keyword`) はlocalStorage保存の対象外としています。

## テスト手順
1. `npm run dev` を実行します。
2. アプリケーションにアクセスし、検索フォームが表示されることを確認します。
3. **初回アクセス時**: DocbaseドメインとDocbaseトークンの入力フィールドが空であることを確認します。
4. **情報入力と保存**: ドメインとトークンに任意の値を入力し、キーワードにも何か入力して「検索」ボタンをクリックします（実際に検索が成功する必要はありません）。
5. **ページ再読み込み**: ブラウザのページを再読み込みします。
6. **自動補完の確認**: 再読み込み後、手順4で入力したドメインとトークンがそれぞれの入力フィールドに自動的に補完されていることを確認します。キーワードフィールドは空のままであることを確認します。
7. **別タブでの動作確認（任意）**:
   - 別のブラウザタブで同じページを開きます。
   - 一方のタブでドメインまたはトークンの値を変更します。
   - もう一方のタブで、値が（少し遅れて）同期されて更新されることを確認します（`storage` イベントによる同期）。
8. **localStorageの直接確認（任意）**:
   - ブラウザの開発者ツールを開き、「Application」タブ（または類似のタブ）のlocalStorageを確認します。
   - `docbaseDomain` と `docbaseToken` というキーで値が保存されていることを確認します。

## 関連Issue
- Closes #5