### PR TITLE
feat(error): APIエラーハンドリングの強化とリトライ実装

### DIFF
--- a/src/components/DocbaseTokenInput.tsx
+++ b/src/components/DocbaseTokenInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { forwardRef } from "react";
 
 interface Props {
   value: string;
@@ -12,20 +12,25 @@ interface Props {
  * @param value 入力値
  * @param onChange 入力値変更ハンドラ
  */
-const DocbaseTokenInput = ({ value, onChange }: Props) => {
-  return (
-    <div>
-      <label htmlFor="docbase-token">Docbase Token:</label>
-      <input
-        id="docbase-token"
-        type="password"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder="Your API Token"
-        className="border p-2 rounded"
-      />
-    </div>
-  );
-};
+const DocbaseTokenInput = forwardRef<HTMLInputElement, Props>(
+  ({ value, onChange }, ref) => {
+    return (
+      <div>
+        <label htmlFor="docbase-token">Docbase Token:</label>
+        <input
+          id="docbase-token"
+          type="password"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Your API Token"
+          className="border p-2 rounded"
+          ref={ref}
+        />
+      </div>
+    );
+  }
+);
+
+DocbaseTokenInput.displayName = "DocbaseTokenInput";
 
 export default DocbaseTokenInput;

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, type FormEvent, useEffect } from "react";
+import React, { useState, type FormEvent, useEffect, useRef } from "react";
 import DocbaseDomainInput from "./DocbaseDomainInput";
 import DocbaseTokenInput from "./DocbaseTokenInput";
 import { useSearch } from "../hooks/useSearch";
@@ -28,8 +28,11 @@ const SearchForm = () => {
   );
   const [markdownContent, setMarkdownContent] = useState("");
 
-  const { posts, isLoading, error, searchPosts } = useSearch();
+  const { posts, isLoading, error, searchPosts, canRetry, retrySearch } =
+    useSearch();
   const { isDownloading, handleDownload } = useDownload();
+
+  const tokenInputRef = useRef<HTMLInputElement>(null);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -45,6 +48,12 @@ const SearchForm = () => {
       setMarkdownContent("");
     }
   }, [posts]);
+
+  useEffect(() => {
+    if (error?.type === "unauthorized") {
+      tokenInputRef.current?.focus();
+    }
+  }, [error]);
 
   const handleDownloadClick = () => {
     const postsExist = posts && posts.length > 0;
@@ -97,6 +106,15 @@ const SearchForm = () => {
         >
           {isDownloading ? "ダウンロード中..." : "Markdownダウンロード"}
         </button>
+        {canRetry && !isLoading && (
+          <button
+            type="button"
+            onClick={retrySearch}
+            className="bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded"
+          >
+            再試行
+          </button>
+        )}
       </div>
 
       {error && (

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -3,6 +3,7 @@ import { fetchDocbasePosts } from "../lib/docbaseClient";
 import type { DocbasePostListItem } from "../types/docbase";
 import type { ApiError } from "../types/error";
 import type { Result } from "neverthrow"; // Resultを型としてインポート (typeキーワードを明示)
+import toast from "react-hot-toast"; // react-hot-toastをインポート
 
 interface UseSearchResult {
   posts: DocbasePostListItem[];
@@ -13,6 +14,8 @@ interface UseSearchResult {
     token: string,
     keyword: string
   ) => Promise<void>;
+  canRetry: boolean; // 再試行可能かどうかのフラグ
+  retrySearch: () => void; // 再試行用の関数
 }
 
 /**
@@ -22,31 +25,105 @@ export const useSearch = (): UseSearchResult => {
   const [posts, setPosts] = useState<DocbasePostListItem[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<ApiError | null>(null);
+  const [lastSearchParams, setLastSearchParams] = useState<{
+    domain: string;
+    token: string;
+    keyword: string;
+  } | null>(null);
+  const [canRetry, setCanRetry] = useState<boolean>(false);
 
-  const searchPosts = useCallback(
+  const executeSearch = useCallback(
     async (domain: string, token: string, keyword: string) => {
-      if (!keyword.trim()) {
-        setPosts([]);
-        setError(null);
-        return;
-      }
-
       setIsLoading(true);
       setError(null);
+      setCanRetry(false);
+      setLastSearchParams({ domain, token, keyword }); // 最後に検索したパラメータを保存
 
       const result: Result<DocbasePostListItem[], ApiError> =
         await fetchDocbasePosts(domain, token, keyword);
 
       if (result.isOk()) {
         setPosts(result.value);
+        if (result.value.length === 0 && keyword.trim() !== "") {
+          toast.success("検索結果が見つかりませんでした。");
+        }
       } else {
-        setError(result.error);
-        setPosts([]); // エラー時は投稿リストをクリア
+        const apiError = result.error;
+        setError(apiError);
+        setPosts([]);
+        // エラータイプに応じたトースト通知
+        switch (apiError.type) {
+          case "unauthorized":
+            toast.error("トークンが無効です。入力内容を確認してください。");
+            // 必要であればトークン入力フィールドにフォーカスを当てるなどのUI操作をここから呼び出す
+            // (例: document.getElementById("docbase-token")?.focus();)
+            // ただし、フックから直接DOM操作するのは避けた方が良い場合もあるので、コンポーネント側で対応する方が望ましい
+            break;
+          case "rateLimit":
+            toast.error(
+              "Docbase APIが混み合っています。しばらくしてから再試行してください。"
+            );
+            setCanRetry(true); // レートリミットの場合は手動再試行を許可
+            break;
+          case "network":
+            toast.error(
+              `ネットワークエラー: ${apiError.message} 再試行ボタンで再試行できます。`
+            );
+            setCanRetry(true); // ネットワークエラーの場合も手動再試行を許可
+            break;
+          case "notFound":
+            toast.error(
+              "指定されたチームが見つからないか、URLが誤っています。"
+            );
+            break;
+          default:
+            toast.error(`不明なエラーが発生しました: ${apiError.message}`);
+            break;
+        }
       }
       setIsLoading(false);
     },
     []
   );
 
-  return { posts, isLoading, error, searchPosts };
+  const searchPosts = useCallback(
+    async (domain: string, token: string, keyword: string) => {
+      if (!keyword.trim() && !domain.trim() && !token.trim()) {
+        // 全て空なら何もしない
+        setPosts([]);
+        setError(null);
+        setCanRetry(false);
+        return;
+      }
+      if (!domain.trim() || !token.trim()) {
+        toast.error("Docbaseドメインとトークンを入力してください。");
+        setPosts([]);
+        setError(null);
+        setCanRetry(false);
+        return;
+      }
+      if (!keyword.trim()) {
+        toast.success("キーワードを入力して検索してください。"); // 検索前にキーワードが空ならメッセージ表示
+        setPosts([]);
+        setError(null);
+        setCanRetry(false);
+        return;
+      }
+      await executeSearch(domain, token, keyword);
+    },
+    [executeSearch]
+  );
+
+  const retrySearch = useCallback(() => {
+    if (lastSearchParams) {
+      toast.dismiss(); // 既存のエラートーストを消す
+      executeSearch(
+        lastSearchParams.domain,
+        lastSearchParams.token,
+        lastSearchParams.keyword
+      );
+    }
+  }, [lastSearchParams, executeSearch]);
+
+  return { posts, isLoading, error, searchPosts, canRetry, retrySearch };
 };


### PR DESCRIPTION
## 概要
Issue #6 の実装として、Docbase API連携におけるエラーハンドリングを強化し、ユーザーへのフィードバックを改善しました。

## 変更内容
- **Docbase APIクライアントの強化 (`src/lib/docbaseClient.ts`)**
  - 429 (Rate Limit) エラーおよび一般的なネットワークエラー発生時に、指数バックオフ（初期1秒、最大3回）による自動リトライ処理を実装しました。
  - リトライ試行中および最終的な失敗時には、コンソールに警告メッセージを出力します。
- **検索フックの改善 (`src/hooks/useSearch.ts`)**
  - APIエラーの種類に応じて、より具体的で分かりやすいトースト通知を表示するようにしました:
    - **401 (Unauthorized)**: 「トークンが無効です。入力内容を確認してください。」
    - **429 (Rate Limit)**: 「Docbase APIが混み合っています。しばらくしてから再試行してください。」
    - **Network Error**: 「ネットワークエラー: {エラー詳細} 再試行ボタンで再試行できます。」
    - **NotFound**: 「指定されたチームが見つからないか、URLが誤っています。」
    - **その他**: 「不明なエラーが発生しました: {エラー詳細}」
  - レートリミットエラーやネットワークエラーの場合に、ユーザーが手動で検索を再試行できる「再試行」ボタンを表示するための `canRetry` フラグと `retrySearch` 関数を公開しました。
  - 検索実行前に、ドメイン・トークン・キーワードのいずれかが空の場合、ユーザーに適切な入力を促すトースト通知を表示するようにしました。
- **検索フォームの機能拡張 (`src/components/SearchForm.tsx`)**
  - `useSearch` フックから `canRetry` と `retrySearch` を利用し、該当するエラー発生時に「再試行」ボタンを表示するようにしました。
  - 401エラー（トークン無効）がAPIから返された場合、ユーザーの利便性向上のため、自動的にトークン入力フィールドにフォーカスを移動させる処理を追加しました。
- **トークン入力コンポーネントの修正 (`src/components/DocbaseTokenInput.tsx`)**
  - `React.forwardRef` を使用してコンポーネントをラップし、`ref` を内部の `input` 要素に渡せるように変更しました。これにより、親コンポーネントからトークン入力フィールドへのフォーカス制御が可能になりました。

## テスト手順
1. `npm run dev` を実行します。
2. アプリケーションにアクセスします。
3. **401エラーテスト**:
   - 無効なDocbaseトークンを入力し、検索を実行します。
   - 「トークンが無効です。入力内容を確認してください。」というトーストが表示されることを確認します。
   - Docbaseトークン入力フィールドに自動的にフォーカスが移動することを確認します。
4. **429エラーテスト（擬似的）**:
   - （可能であれば）Docbase APIのレートリミットを意図的に発生させるか、`fetchDocbasePosts` を一時的に変更して429エラーを返すようにします。
   - 検索を実行すると、コンソールにリトライ処理の警告が表示され、最終的に「Docbase APIが混み合っています。しばらくしてから再試行してください。」というトーストと「再試行」ボタンが表示されることを確認します。
   - 「再試行」ボタンをクリックすると、再度検索が実行されることを確認します。
5. **ネットワークエラーテスト（擬似的）**:
   - ブラウザの開発者ツールでネットワークをオフラインにするか、`fetchDocbasePosts` を一時的に変更してネットワークエラーを発生させます。
   - 検索を実行すると、コンソールにリトライ処理の警告が表示され、最終的にネットワークエラーを示すトースト（例：「ネットワークエラー: Failed to fetch 再試行ボタンで再試行できます。」）と「再試行」ボタンが表示されることを確認します。
   - 「再試行」ボタンをクリックすると、再度検索が実行されることを確認します。
6. **入力フィールド空のテスト**:
   - ドメイン、トークン、またはキーワードのいずれか（またはすべて）を空にして検索ボタンをクリックします。
   - 「Docbaseドメインとトークンを入力してください。」や「キーワードを入力して検索してください。」といった適切なエラー（または案内）トーストが表示されることを確認します。

## 関連Issue
- Closes #6