### PR TITLE
feat(api): Docbaseのキーワード検索を完全一致に変更

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,25 +1,25 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next'
 
 // NEXT_PUBLIC_BASE_PATH は .env.production や GitHub Actions の env で設定される
 // GitHub Pages のリポジトリ名（サブパス）が入ることを想定 (例: "/my-app")
 // 値が取得できない場合は空文字とし、ローカル開発時はサブパスなしで動作するようにする
-const repoSubPath = process.env.NEXT_PUBLIC_BASE_PATH || "";
-const isProd = process.env.NODE_ENV === "production";
+const repoSubPath = process.env.NEXT_PUBLIC_BASE_PATH || ''
+const isProd = process.env.NODE_ENV === 'production'
 
 const nextConfig: NextConfig = {
   // ① GitHub Pages 用に静的書き出し
-  output: "export", // Next.js 13.3 以降での静的エクスポート指定
+  output: 'export', // Next.js 13.3 以降での静的エクスポート指定
   trailingSlash: true, // URLの末尾にスラッシュを強制し、404エラーを防ぐ
 
   // ② サブパス設定（ビルド時に決定）
   // isProd の判定は、ローカル開発時 (npm run dev) にサブパスが適用されないようにするため
-  basePath: isProd ? repoSubPath : "",
-  assetPrefix: isProd ? `${repoSubPath}/` : "", // assetPrefix は末尾にスラッシュが必要な場合があるため注意
+  basePath: isProd ? repoSubPath : '',
+  assetPrefix: isProd ? `${repoSubPath}/` : '', // assetPrefix は末尾にスラッシュが必要な場合があるため注意
 
   // 画像最適化サーバーを使わない場合（静的エクスポート時は true を推奨）
   images: {
     unoptimized: true,
   },
-};
+}
 
-export default nextConfig;
+export default nextConfig

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -1,70 +1,55 @@
-import { useState, useCallback } from "react";
-import { downloadMarkdownFile } from "../utils/fileDownloader";
-import toast from "react-hot-toast";
+import { useState, useCallback } from 'react'
+import { downloadMarkdownFile } from '../utils/fileDownloader'
+import toast from 'react-hot-toast'
 
 interface UseDownloadResult {
-  isDownloading: boolean;
-  handleDownload: (
-    markdownContent: string,
-    keyword: string,
-    postsExist: boolean
-  ) => Promise<void>;
+  isDownloading: boolean
+  handleDownload: (markdownContent: string, keyword: string, postsExist: boolean) => Promise<void>
 }
 
 /**
  * Markdownファイルのダウンロード処理と通知を行うカスタムフック
  */
 export const useDownload = (): UseDownloadResult => {
-  const [isDownloading, setIsDownloading] = useState<boolean>(false);
+  const [isDownloading, setIsDownloading] = useState<boolean>(false)
 
-  const handleDownload = useCallback(
-    async (markdownContent: string, keyword: string, postsExist: boolean) => {
-      setIsDownloading(true);
-      // ダウンロード対象がない場合は、fileDownloaderからのメッセージをtoastで表示
-      if (!postsExist || !markdownContent.trim()) {
-        const result = downloadMarkdownFile(
-          markdownContent,
-          keyword,
-          postsExist
-        );
-        if (result.message) {
-          toast.error(result.message);
-        }
-        setIsDownloading(false);
-        return;
+  const handleDownload = useCallback(async (markdownContent: string, keyword: string, postsExist: boolean) => {
+    setIsDownloading(true)
+    // ダウンロード対象がない場合は、fileDownloaderからのメッセージをtoastで表示
+    if (!postsExist || !markdownContent.trim()) {
+      const result = downloadMarkdownFile(markdownContent, keyword, postsExist)
+      if (result.message) {
+        toast.error(result.message)
       }
+      setIsDownloading(false)
+      return
+    }
 
-      // ダウンロード処理を実行
-      const toastId = toast.loading("Markdownファイルをダウンロード中です...");
-      try {
-        // 非同期処理っぽく見せるために少し待つ（実際にはdownloadMarkdownFileは同期的）
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        const result = downloadMarkdownFile(
-          markdownContent,
-          keyword,
-          postsExist
-        );
+    // ダウンロード処理を実行
+    const toastId = toast.loading('Markdownファイルをダウンロード中です...')
+    try {
+      // 非同期処理っぽく見せるために少し待つ（実際にはdownloadMarkdownFileは同期的）
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      const result = downloadMarkdownFile(markdownContent, keyword, postsExist)
 
-        if (result.success) {
-          toast.success("Markdownファイルをダウンロードしました。", {
-            id: toastId,
-          });
-        } else {
-          toast.error(result.message || "ダウンロードに失敗しました。", {
-            id: toastId,
-          });
-        }
-      } catch (error) {
-        console.error("Download process error:", error);
-        toast.error("予期せぬエラーによりダウンロードに失敗しました。", {
+      if (result.success) {
+        toast.success('Markdownファイルをダウンロードしました。', {
           id: toastId,
-        });
-      } finally {
-        setIsDownloading(false);
+        })
+      } else {
+        toast.error(result.message || 'ダウンロードに失敗しました。', {
+          id: toastId,
+        })
       }
-    },
-    []
-  );
+    } catch (error) {
+      console.error('Download process error:', error)
+      toast.error('予期せぬエラーによりダウンロードに失敗しました。', {
+        id: toastId,
+      })
+    } finally {
+      setIsDownloading(false)
+    }
+  }, [])
 
-  return { isDownloading, handleDownload };
-};
+  return { isDownloading, handleDownload }
+}

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react'
 
 /**
  * localStorageと値を同期するためのカスタムフック
@@ -6,95 +6,91 @@ import { useState, useEffect } from "react";
  * @param initialValue 初期値
  * @returns [storedValue, setValue] storedValueは現在の値、setValueは値を更新する関数
  */
-function useLocalStorage<T>(
-  key: string,
-  initialValue: T
-): [T, (value: T | ((val: T) => T)) => void] {
+function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void] {
   // localStorageから初期値を取得、なければinitialValueを使用
   const [storedValue, setStoredValue] = useState<T>(() => {
     // windowオブジェクトが存在するか確認 (SSR対策)
-    if (typeof window === "undefined") {
-      return initialValue;
+    if (typeof window === 'undefined') {
+      return initialValue
     }
     try {
-      const item = window.localStorage.getItem(key);
+      const item = window.localStorage.getItem(key)
       if (item) {
         try {
-          return JSON.parse(item) as T;
+          return JSON.parse(item) as T
         } catch (parseError) {
           // パースに失敗した場合は警告を出し、初期値を返す
           console.warn(
             `Error parsing localStorage key "${key}" (value: "${item}"), falling back to initialValue:`,
-            parseError
-          );
-          return initialValue;
+            parseError,
+          )
+          return initialValue
         }
       }
-      return initialValue;
+      return initialValue
     } catch (error) {
-      console.error(`Error reading localStorage key "${key}":`, error);
-      return initialValue;
+      console.error(`Error reading localStorage key "${key}":`, error)
+      return initialValue
     }
-  });
+  })
 
   // storedValueが変更されたらlocalStorageに保存
   const setValue = (value: T | ((val: T) => T)) => {
     try {
-      const valueToStore =
-        value instanceof Function ? value(storedValue) : value;
-      setStoredValue(valueToStore);
+      const valueToStore = value instanceof Function ? value(storedValue) : value
+      setStoredValue(valueToStore)
       // windowオブジェクトが存在するか確認 (SSR対策)
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore))
       }
     } catch (error) {
-      console.error(`Error setting localStorage key "${key}":`, error);
+      console.error(`Error setting localStorage key "${key}":`, error)
     }
-  };
+  }
 
   // マウント時にlocalStorageの値でstateを更新する (別のタブでの変更に対応するため)
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === 'undefined') return
 
     const handleStorageChange = (event: StorageEvent) => {
       if (event.key === key && event.newValue) {
         try {
-          setStoredValue(JSON.parse(event.newValue) as T);
+          setStoredValue(JSON.parse(event.newValue) as T)
         } catch (error) {
           console.warn(
             `Error parsing localStorage key "${key}" on storage event (newValue: "${event.newValue}"), falling back to current value or initialValue if parsing fails elsewhere:`,
-            error
-          );
+            error,
+          )
           // ここでエラーが起きても、storedValueは以前の値のまま or 初期化時の値のまま
         }
       }
-    };
+    }
 
-    window.addEventListener("storage", handleStorageChange);
+    window.addEventListener('storage', handleStorageChange)
     // initialValueが変更された場合も考慮して、localStorageの値を再確認・初期化
-    const currentLocalItem = window.localStorage.getItem(key);
+    const currentLocalItem = window.localStorage.getItem(key)
     if (currentLocalItem === null) {
       // 文字列としての initialValue ではなく、JSON.stringifyされたものが保存されるべき
-      window.localStorage.setItem(key, JSON.stringify(initialValue));
+      window.localStorage.setItem(key, JSON.stringify(initialValue))
     } else {
       try {
-        JSON.parse(currentLocalItem); // 既存の値が有効なJSONかチェック
+        JSON.parse(currentLocalItem) // 既存の値が有効なJSONかチェック
       } catch (e) {
         // 既存の値が不正なJSONなら、initialValueで上書きする
         console.warn(
-          `Invalid JSON in localStorage for key "${key}" (value: "${currentLocalItem}"), overwriting with initialValue.`
-        );
-        window.localStorage.setItem(key, JSON.stringify(initialValue));
-        setStoredValue(initialValue); // stateも更新
+          `Invalid JSON in localStorage for key "${key}" (value: "${currentLocalItem}"), overwriting with initialValue.`,
+        )
+        window.localStorage.setItem(key, JSON.stringify(initialValue))
+        setStoredValue(initialValue) // stateも更新
       }
     }
 
     return () => {
-      window.removeEventListener("storage", handleStorageChange);
-    };
-  }, [key, initialValue]); // initialValueを依存配列に追加
+      window.removeEventListener('storage', handleStorageChange)
+    }
+  }, [key, initialValue]) // initialValueを依存配列に追加
 
-  return [storedValue, setValue];
+  return [storedValue, setValue]
 }
 
-export default useLocalStorage;
+export default useLocalStorage

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,129 +1,111 @@
-import { useState, useCallback } from "react";
-import { fetchDocbasePosts } from "../lib/docbaseClient";
-import type { DocbasePostListItem } from "../types/docbase";
-import type { ApiError } from "../types/error";
-import type { Result } from "neverthrow"; // Resultを型としてインポート (typeキーワードを明示)
-import toast from "react-hot-toast"; // react-hot-toastをインポート
+import { useState, useCallback } from 'react'
+import { fetchDocbasePosts } from '../lib/docbaseClient'
+import type { DocbasePostListItem } from '../types/docbase'
+import type { ApiError } from '../types/error'
+import type { Result } from 'neverthrow' // Resultを型としてインポート (typeキーワードを明示)
+import toast from 'react-hot-toast' // react-hot-toastをインポート
 
 interface UseSearchResult {
-  posts: DocbasePostListItem[];
-  isLoading: boolean;
-  error: ApiError | null;
-  searchPosts: (
-    domain: string,
-    token: string,
-    keyword: string
-  ) => Promise<void>;
-  canRetry: boolean; // 再試行可能かどうかのフラグ
-  retrySearch: () => void; // 再試行用の関数
+  posts: DocbasePostListItem[]
+  isLoading: boolean
+  error: ApiError | null
+  searchPosts: (domain: string, token: string, keyword: string) => Promise<void>
+  canRetry: boolean // 再試行可能かどうかのフラグ
+  retrySearch: () => void // 再試行用の関数
 }
 
 /**
  * Docbaseの投稿を検索するためのカスタムフック
  */
 export const useSearch = (): UseSearchResult => {
-  const [posts, setPosts] = useState<DocbasePostListItem[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<ApiError | null>(null);
+  const [posts, setPosts] = useState<DocbasePostListItem[]>([])
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [error, setError] = useState<ApiError | null>(null)
   const [lastSearchParams, setLastSearchParams] = useState<{
-    domain: string;
-    token: string;
-    keyword: string;
-  } | null>(null);
-  const [canRetry, setCanRetry] = useState<boolean>(false);
+    domain: string
+    token: string
+    keyword: string
+  } | null>(null)
+  const [canRetry, setCanRetry] = useState<boolean>(false)
 
-  const executeSearch = useCallback(
-    async (domain: string, token: string, keyword: string) => {
-      setIsLoading(true);
-      setError(null);
-      setCanRetry(false);
-      setLastSearchParams({ domain, token, keyword }); // 最後に検索したパラメータを保存
+  const executeSearch = useCallback(async (domain: string, token: string, keyword: string) => {
+    setIsLoading(true)
+    setError(null)
+    setCanRetry(false)
+    setLastSearchParams({ domain, token, keyword }) // 最後に検索したパラメータを保存
 
-      const result: Result<DocbasePostListItem[], ApiError> =
-        await fetchDocbasePosts(domain, token, keyword);
+    const result: Result<DocbasePostListItem[], ApiError> = await fetchDocbasePosts(domain, token, keyword)
 
-      if (result.isOk()) {
-        setPosts(result.value);
-        if (result.value.length === 0 && keyword.trim() !== "") {
-          toast.success("検索結果が見つかりませんでした。");
-        }
-      } else {
-        const apiError = result.error;
-        setError(apiError);
-        setPosts([]);
-        // エラータイプに応じたトースト通知
-        switch (apiError.type) {
-          case "unauthorized":
-            toast.error("トークンが無効です。入力内容を確認してください。");
-            // 必要であればトークン入力フィールドにフォーカスを当てるなどのUI操作をここから呼び出す
-            // (例: document.getElementById("docbase-token")?.focus();)
-            // ただし、フックから直接DOM操作するのは避けた方が良い場合もあるので、コンポーネント側で対応する方が望ましい
-            break;
-          case "rateLimit":
-            toast.error(
-              "Docbase APIが混み合っています。しばらくしてから再試行してください。"
-            );
-            setCanRetry(true); // レートリミットの場合は手動再試行を許可
-            break;
-          case "network":
-            toast.error(
-              `ネットワークエラー: ${apiError.message} 再試行ボタンで再試行できます。`
-            );
-            setCanRetry(true); // ネットワークエラーの場合も手動再試行を許可
-            break;
-          case "notFound":
-            toast.error(
-              "指定されたチームが見つからないか、URLが誤っています。"
-            );
-            break;
-          default:
-            toast.error(`不明なエラーが発生しました: ${apiError.message}`);
-            break;
-        }
+    if (result.isOk()) {
+      setPosts(result.value)
+      if (result.value.length === 0 && keyword.trim() !== '') {
+        toast.success('検索結果が見つかりませんでした。')
       }
-      setIsLoading(false);
-    },
-    []
-  );
+    } else {
+      const apiError = result.error
+      setError(apiError)
+      setPosts([])
+      // エラータイプに応じたトースト通知
+      switch (apiError.type) {
+        case 'unauthorized':
+          toast.error('トークンが無効です。入力内容を確認してください。')
+          // 必要であればトークン入力フィールドにフォーカスを当てるなどのUI操作をここから呼び出す
+          // (例: document.getElementById("docbase-token")?.focus();)
+          // ただし、フックから直接DOM操作するのは避けた方が良い場合もあるので、コンポーネント側で対応する方が望ましい
+          break
+        case 'rateLimit':
+          toast.error('Docbase APIが混み合っています。しばらくしてから再試行してください。')
+          setCanRetry(true) // レートリミットの場合は手動再試行を許可
+          break
+        case 'network':
+          toast.error(`ネットワークエラー: ${apiError.message} 再試行ボタンで再試行できます。`)
+          setCanRetry(true) // ネットワークエラーの場合も手動再試行を許可
+          break
+        case 'notFound':
+          toast.error('指定されたチームが見つからないか、URLが誤っています。')
+          break
+        default:
+          toast.error(`不明なエラーが発生しました: ${apiError.message}`)
+          break
+      }
+    }
+    setIsLoading(false)
+  }, [])
 
   const searchPosts = useCallback(
     async (domain: string, token: string, keyword: string) => {
       if (!keyword.trim() && !domain.trim() && !token.trim()) {
         // 全て空なら何もしない
-        setPosts([]);
-        setError(null);
-        setCanRetry(false);
-        return;
+        setPosts([])
+        setError(null)
+        setCanRetry(false)
+        return
       }
       if (!domain.trim() || !token.trim()) {
-        toast.error("Docbaseドメインとトークンを入力してください。");
-        setPosts([]);
-        setError(null);
-        setCanRetry(false);
-        return;
+        toast.error('Docbaseドメインとトークンを入力してください。')
+        setPosts([])
+        setError(null)
+        setCanRetry(false)
+        return
       }
       if (!keyword.trim()) {
-        toast.success("キーワードを入力して検索してください。"); // 検索前にキーワードが空ならメッセージ表示
-        setPosts([]);
-        setError(null);
-        setCanRetry(false);
-        return;
+        toast.success('キーワードを入力して検索してください。') // 検索前にキーワードが空ならメッセージ表示
+        setPosts([])
+        setError(null)
+        setCanRetry(false)
+        return
       }
-      await executeSearch(domain, token, keyword);
+      await executeSearch(domain, token, keyword)
     },
-    [executeSearch]
-  );
+    [executeSearch],
+  )
 
   const retrySearch = useCallback(() => {
     if (lastSearchParams) {
-      toast.dismiss(); // 既存のエラートーストを消す
-      executeSearch(
-        lastSearchParams.domain,
-        lastSearchParams.token,
-        lastSearchParams.keyword
-      );
+      toast.dismiss() // 既存のエラートーストを消す
+      executeSearch(lastSearchParams.domain, lastSearchParams.token, lastSearchParams.keyword)
     }
-  }, [lastSearchParams, executeSearch]);
+  }, [lastSearchParams, executeSearch])
 
-  return { posts, isLoading, error, searchPosts, canRetry, retrySearch };
-};
+  return { posts, isLoading, error, searchPosts, canRetry, retrySearch }
+}

--- a/src/lib/docbaseClient.ts
+++ b/src/lib/docbaseClient.ts
@@ -1,8 +1,5 @@
-import { ok, err, type Result } from "neverthrow";
-import type {
-  DocbasePostsResponse,
-  DocbasePostListItem,
-} from "../types/docbase";
+import { ok, err, type Result } from 'neverthrow'
+import type { DocbasePostsResponse, DocbasePostListItem } from '../types/docbase'
 import type {
   ApiError,
   NetworkApiError,
@@ -10,17 +7,17 @@ import type {
   UnauthorizedApiError,
   NotFoundApiError,
   RateLimitApiError,
-} from "../types/error";
+} from '../types/error'
 
-const DOCBASE_API_BASE_URL = "https://api.docbase.io/teams";
-const MAX_RETRIES = 3;
-const INITIAL_BACKOFF_MS = 1000; // 1秒
+const DOCBASE_API_BASE_URL = 'https://api.docbase.io/teams'
+const MAX_RETRIES = 3
+const INITIAL_BACKOFF_MS = 1000 // 1秒
 
 /**
  * 指定されたミリ秒待機するPromiseを返すヘルパー関数
  * @param ms 待機するミリ秒
  */
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 /**
  * Docbase APIから投稿リストを取得する関数（リトライ処理付き）
@@ -35,106 +32,87 @@ export const fetchDocbasePosts = async (
   token: string,
   keyword: string,
   retries = MAX_RETRIES, // 残りのリトライ回数
-  backoff = INITIAL_BACKOFF_MS // 現在のバックオフ時間
+  backoff = INITIAL_BACKOFF_MS, // 現在のバックオフ時間
 ): Promise<Result<DocbasePostListItem[], ApiError>> => {
   if (!keyword.trim()) {
-    return ok([]);
+    return ok([])
   }
 
-  const searchParams = new URLSearchParams({ q: keyword });
-  const url = `${DOCBASE_API_BASE_URL}/${domain}/posts?${searchParams.toString()}`;
+  const exactMatchKeyword = `"${keyword}"`
+  const searchParams = new URLSearchParams({ q: exactMatchKeyword })
+  const url = `${DOCBASE_API_BASE_URL}/${domain}/posts?${searchParams.toString()}`
 
   try {
     const response = await fetch(url, {
       headers: {
-        "X-DocBaseToken": token,
-        "Content-Type": "application/json",
+        'X-DocBaseToken': token,
+        'Content-Type': 'application/json',
       },
-    });
+    })
 
     if (!response.ok) {
       if (response.status === 401) {
         const error: UnauthorizedApiError = {
-          type: "unauthorized",
-          message: "Docbase APIトークンが無効です。",
-        };
-        return err(error);
+          type: 'unauthorized',
+          message: 'Docbase APIトークンが無効です。',
+        }
+        return err(error)
       }
       if (response.status === 404) {
         const error: NotFoundApiError = {
-          type: "notFound",
-          message:
-            "Docbaseのチームが見つからないか、APIエンドポイントが誤っています。",
-        };
-        return err(error);
+          type: 'notFound',
+          message: 'Docbaseのチームが見つからないか、APIエンドポイントが誤っています。',
+        }
+        return err(error)
       }
       if (response.status === 429) {
         if (retries > 0) {
-          console.warn(
-            `Rate limit exceeded. Retrying in ${backoff}ms... (${retries} retries left)`
-          );
-          await sleep(backoff);
+          console.warn(`Rate limit exceeded. Retrying in ${backoff}ms... (${retries} retries left)`)
+          await sleep(backoff)
           // 再帰的に呼び出し、リトライ回数を減らし、バックオフ時間を増やす (指数バックオフ)
-          return fetchDocbasePosts(
-            domain,
-            token,
-            keyword,
-            retries - 1,
-            backoff * 2
-          );
+          return fetchDocbasePosts(domain, token, keyword, retries - 1, backoff * 2)
         }
         const error: RateLimitApiError = {
-          type: "rateLimit",
-          message:
-            "Docbase APIのレートリミットに達しました。何度か再試行しましたが改善しませんでした。",
-        };
-        return err(error);
+          type: 'rateLimit',
+          message: 'Docbase APIのレートリミットに達しました。何度か再試行しましたが改善しませんでした。',
+        }
+        return err(error)
       }
-      const errorText = await response.text();
+      const errorText = await response.text()
       const error: NetworkApiError = {
-        type: "network",
+        type: 'network',
         message: `Docbase APIリクエストエラー: ${response.status} ${response.statusText}. ${errorText}`,
-      };
-      return err(error);
+      }
+      return err(error)
     }
 
-    const data = (await response.json()) as DocbasePostsResponse;
-    return ok(data.posts);
+    const data = (await response.json()) as DocbasePostsResponse
+    return ok(data.posts)
   } catch (error) {
-    console.error("Docbase API fetch error:", error);
+    console.error('Docbase API fetch error:', error)
     // ネットワークエラーの場合もリトライを試みる (ただし、リトライ回数は共通)
     if (
       retries > 0 &&
-      (error instanceof TypeError ||
-        (error instanceof Error &&
-          error.message.toLowerCase().includes("network error")))
+      (error instanceof TypeError || (error instanceof Error && error.message.toLowerCase().includes('network error')))
     ) {
-      console.warn(
-        `Network error occurred. Retrying in ${backoff}ms... (${retries} retries left)`
-      );
-      await sleep(backoff);
-      return fetchDocbasePosts(
-        domain,
-        token,
-        keyword,
-        retries - 1,
-        backoff * 2
-      );
+      console.warn(`Network error occurred. Retrying in ${backoff}ms... (${retries} retries left)`)
+      await sleep(backoff)
+      return fetchDocbasePosts(domain, token, keyword, retries - 1, backoff * 2)
     }
 
     if (error instanceof Error) {
       const apiError: NetworkApiError = {
-        type: "network",
+        type: 'network',
         message: `ネットワークエラー: ${error.message}`,
         cause: error,
-      };
-      return err(apiError);
+      }
+      return err(apiError)
     }
     const unknownError: UnknownApiError = {
-      type: "unknown",
-      message: "不明なエラーが発生しました。コンソールを確認してください。",
+      type: 'unknown',
+      message: '不明なエラーが発生しました。コンソールを確認してください。',
       cause: error,
-    };
-    return err(unknownError);
+    }
+    return err(unknownError)
   }
-};
+}

--- a/src/types/docbase.ts
+++ b/src/types/docbase.ts
@@ -2,11 +2,11 @@
  * Docbaseの投稿情報を表す型定義
  */
 export type DocbasePostListItem = {
-  id: number;
-  title: string;
-  body: string;
-  created_at: string; // ISO-8601形式の文字列
-  url: string;
+  id: number
+  title: string
+  body: string
+  created_at: string // ISO-8601形式の文字列
+  url: string
   // APIレスポンスには他にも多くのフィールドがあるが、今回は仕様書に記載のあるもののみ定義
   // 必要に応じて追加する
   // user: { ... },
@@ -18,16 +18,16 @@ export type DocbasePostListItem = {
   // scope: string,
   // sharing_url: string | null,
   // organization: { ... }
-};
+}
 
 /**
  * Docbase APIの投稿リスト取得レスポンスの型定義
  */
 export type DocbasePostsResponse = {
-  posts: DocbasePostListItem[];
+  posts: DocbasePostListItem[]
   meta: {
-    previous_page: string | null;
-    next_page: string | null;
-    total: number;
-  };
-};
+    previous_page: string | null
+    next_page: string | null
+    total: number
+  }
+}

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -2,30 +2,25 @@
  * APIリクエストで発生する可能性のあるエラーの型定義
  */
 export type NetworkApiError = {
-  type: "network";
-  message: string;
-  cause?: unknown;
-};
+  type: 'network'
+  message: string
+  cause?: unknown
+}
 export type UnknownApiError = {
-  type: "unknown";
-  message: string;
-  cause?: unknown;
-};
+  type: 'unknown'
+  message: string
+  cause?: unknown
+}
 
 // cause を持たないエラー型
-export type UnauthorizedApiError = { type: "unauthorized"; message: string };
-export type RateLimitApiError = { type: "rateLimit"; message: string };
-export type NotFoundApiError = { type: "notFound"; message: string };
+export type UnauthorizedApiError = { type: 'unauthorized'; message: string }
+export type RateLimitApiError = { type: 'rateLimit'; message: string }
+export type NotFoundApiError = { type: 'notFound'; message: string }
 
 /**
  * APIリクエストで発生する可能性のあるエラーの型定義
  */
-export type ApiError =
-  | NetworkApiError
-  | UnknownApiError
-  | UnauthorizedApiError
-  | RateLimitApiError
-  | NotFoundApiError;
+export type ApiError = NetworkApiError | UnknownApiError | UnauthorizedApiError | RateLimitApiError | NotFoundApiError
 
 /**
  * エラーがApiError型であるかを判定する型ガード
@@ -33,17 +28,17 @@ export type ApiError =
  * @returns ApiErrorであればtrue、そうでなければfalse
  */
 export const isApiError = (error: unknown): error is ApiError => {
-  if (typeof error !== "object" || error === null) {
-    return false;
+  if (typeof error !== 'object' || error === null) {
+    return false
   }
-  const e = error as Record<string, unknown>; // キャストの仕方を少し変更
+  const e = error as Record<string, unknown> // キャストの仕方を少し変更
   return (
-    typeof e.type === "string" &&
-    typeof e.message === "string" &&
-    (e.type === "network" ||
-      e.type === "unknown" ||
-      e.type === "unauthorized" ||
-      e.type === "rateLimit" ||
-      e.type === "notFound")
-  );
-};
+    typeof e.type === 'string' &&
+    typeof e.message === 'string' &&
+    (e.type === 'network' ||
+      e.type === 'unknown' ||
+      e.type === 'unauthorized' ||
+      e.type === 'rateLimit' ||
+      e.type === 'notFound')
+  )
+}

--- a/src/utils/fileDownloader.ts
+++ b/src/utils/fileDownloader.ts
@@ -8,49 +8,49 @@
 export const downloadMarkdownFile = (
   markdownContent: string,
   keyword: string,
-  postsExist: boolean // 投稿が存在するかどうかを示すフラグを追加
+  postsExist: boolean, // 投稿が存在するかどうかを示すフラグを追加
 ): { success: boolean; message?: string } => {
   // 投稿が存在しない、またはMarkdownコンテントが空の場合はダウンロードしない
   if (!postsExist || !markdownContent.trim()) {
     // ユーザーに通知するかどうかは呼び出し側で判断するため、ここでは特別なメッセージは返さない
     return {
       success: false,
-      message: "ダウンロードするコンテンツがありません。",
-    };
+      message: 'ダウンロードするコンテンツがありません。',
+    }
   }
 
   try {
     const blob = new Blob([markdownContent], {
-      type: "text/markdown;charset=utf-8",
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
+      type: 'text/markdown;charset=utf-8',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
 
     // 日本のタイムゾーンでYYYYMMDDHHmmss形式のタイムスタンプを生成
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, "0");
-    const day = String(now.getDate()).padStart(2, "0");
-    const hours = String(now.getHours()).padStart(2, "0");
-    const minutes = String(now.getMinutes()).padStart(2, "0");
-    const seconds = String(now.getSeconds()).padStart(2, "0");
-    const timestamp = `${year}${month}${day}${hours}${minutes}${seconds}`;
+    const now = new Date()
+    const year = now.getFullYear()
+    const month = String(now.getMonth() + 1).padStart(2, '0')
+    const day = String(now.getDate()).padStart(2, '0')
+    const hours = String(now.getHours()).padStart(2, '0')
+    const minutes = String(now.getMinutes()).padStart(2, '0')
+    const seconds = String(now.getSeconds()).padStart(2, '0')
+    const timestamp = `${year}${month}${day}${hours}${minutes}${seconds}`
 
     // キーワードが空の場合はデフォルトのファイル名の一部とする
-    const keywordPart = keyword.trim() || "docbase";
+    const keywordPart = keyword.trim() || 'docbase'
 
-    a.download = `notebooklm_${keywordPart}_${timestamp}.md`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-    return { success: true };
+    a.download = `notebooklm_${keywordPart}_${timestamp}.md`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+    return { success: true }
   } catch (error) {
-    console.error("Markdown file download error:", error);
+    console.error('Markdown file download error:', error)
     return {
       success: false,
-      message: "ファイルのダウンロード中にエラーが発生しました。",
-    };
+      message: 'ファイルのダウンロード中にエラーが発生しました。',
+    }
   }
-};
+}

--- a/src/utils/markdownGenerator.ts
+++ b/src/utils/markdownGenerator.ts
@@ -1,4 +1,4 @@
-import type { DocbasePostListItem } from "../types/docbase";
+import type { DocbasePostListItem } from '../types/docbase'
 
 /**
  * Docbaseの投稿リストからMarkdown文字列を生成する関数
@@ -7,31 +7,25 @@ import type { DocbasePostListItem } from "../types/docbase";
  */
 export const generateMarkdown = (posts: DocbasePostListItem[]): string => {
   if (!posts || posts.length === 0) {
-    return ""; // 投稿がない場合は空文字列を返す
+    return '' // 投稿がない場合は空文字列を返す
   }
 
   return posts
     .map((post) => {
       // created_at を YYYY/MM/DD 形式にフォーマット (簡易的なもの)
-      let formattedDate = post.created_at;
+      let formattedDate = post.created_at
       try {
-        const date = new Date(post.created_at);
-        formattedDate = `${date.getFullYear()}/${String(
-          date.getMonth() + 1
-        ).padStart(2, "0")}/${String(date.getDate()).padStart(2, "0")}`;
+        const date = new Date(post.created_at)
+        formattedDate = `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(
+          2,
+          '0',
+        )}/${String(date.getDate()).padStart(2, '0')}`
       } catch (e) {
-        console.error("Error formatting date:", post.created_at, e);
+        console.error('Error formatting date:', post.created_at, e)
         // フォーマットエラー時は元の文字列を使用
       }
 
-      return [
-        `## ${post.title}`,
-        `> ${formattedDate}`,
-        `> ${post.url}`,
-        "```md",
-        post.body,
-        "```",
-      ].join("\n\n"); // 各要素を2つの改行で結合
+      return [`## ${post.title}`, `> ${formattedDate}`, `> ${post.url}`, '```md', post.body, '```'].join('\n\n') // 各要素を2つの改行で結合
     })
-    .join("\n\n---\n\n"); // 各投稿の間を水平線と2つの改行で区切る
-};
+    .join('\n\n---\n\n') // 各投稿の間を水平線と2つの改行で区切る
+}


### PR DESCRIPTION
## 概要
Docbase APIを利用したキーワード検索機能を、部分一致から完全一致に変更します。
これにより、ユーザーはより意図した検索結果を効率的に得られるようになります。

## 変更内容
- `src/lib/docbaseClient.ts` の `fetchDocbasePosts` 関数を修正。
- APIリクエストの `q` パラメータに渡すキーワードをダブルクォーテーションで囲むように変更しました。

## テスト手順
1. アプリケーションを起動し、検索フォームから任意のキーワードで検索を実行する。
2. 検索結果が、入力したキーワードと完全に一致するメモのみ表示されることを確認する。
3. キーワード入力欄を空にして検索を実行し、エラーが発生せず、検索結果も0件となることを確認する。

## サービス仕様書への反映
マージ後、以下のサービス仕様書の項目を更新してください。
- 「2.1 データ取得フロー（フロントエンド fetch）」のパラメータ `q` の説明に、キーワードをダブルクォーテーションで囲む旨を追記。

## 関連Issue
- Closes #19