### PR TITLE
feat(api): Docbase APIからの投稿取得件数を最大500件に拡張

### DIFF
--- a/src/components/DocbaseTokenInput.tsx
+++ b/src/components/DocbaseTokenInput.tsx
@@ -1,10 +1,15 @@
-import type { FC } from 'react'
+import React, { type FC, forwardRef, useImperativeHandle, useRef } from 'react'
 
 type DocbaseTokenInputProps = {
   token: string
   onTokenChange: (token: string) => void
   error?: string
   disabled?: boolean
+}
+
+// focusメソッドを持つRefの型を定義
+export type DocbaseTokenInputRef = {
+  focus: () => void
 }
 
 /**
@@ -14,27 +19,39 @@ type DocbaseTokenInputProps = {
  * @param error エラーメッセージ
  * @param disabled 非活性状態にするかどうか
  */
-export const DocbaseTokenInput: FC<DocbaseTokenInputProps> = ({ token, onTokenChange, error, disabled }) => {
-  return (
-    <div className="mb-4">
-      <label htmlFor="docbase-token" className="block text-base font-medium text-docbase-text mb-1">
-        Docbase APIトークン
-      </label>
-      <input
-        type="password"
-        id="docbase-token"
-        value={token}
-        onChange={(e) => onTokenChange(e.target.value)}
-        placeholder="APIトークンを入力"
-        disabled={disabled}
-        className={`block w-full px-4 py-3 border ${error ? 'border-red-500' : 'border-gray-400'} rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500' : 'focus:ring-docbase-primary focus:border-docbase-primary'} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
-        aria-describedby={error ? 'docbase-token-error' : undefined}
-      />
-      {error && (
-        <p id="docbase-token-error" className="mt-1 text-xs text-red-600">
-          {error}
-        </p>
-      )}
-    </div>
-  )
-}
+export const DocbaseTokenInput = forwardRef<DocbaseTokenInputRef, DocbaseTokenInputProps>(
+  ({ token, onTokenChange, error, disabled }, ref) => {
+    const inputRef = useRef<HTMLInputElement>(null) // input要素への参照を作成
+
+    // 親コンポーネントから呼び出せるメソッドを定義
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        inputRef.current?.focus()
+      },
+    }))
+
+    return (
+      <div className="mb-4">
+        <label htmlFor="docbase-token" className="block text-base font-medium text-docbase-text mb-1">
+          Docbase APIトークン
+        </label>
+        <input
+          type="password"
+          id="docbase-token"
+          ref={inputRef} // input要素にrefを渡す
+          value={token}
+          onChange={(e) => onTokenChange(e.target.value)}
+          placeholder="APIトークンを入力"
+          disabled={disabled}
+          className={`block w-full px-4 py-3 border ${error ? 'border-red-500' : 'border-gray-400'} rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500' : 'focus:ring-docbase-primary focus:border-docbase-primary'} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
+          aria-describedby={error ? 'docbase-token-error' : undefined}
+        />
+        {error && (
+          <p id="docbase-token-error" className="mt-1 text-xs text-red-600">
+            {error}
+          </p>
+        )}
+      </div>
+    )
+  },
+)

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -35,7 +35,7 @@ const SearchForm = () => {
 
   useEffect(() => {
     if (posts && posts.length > 0) {
-      const md = generateMarkdown(posts)
+      const md = generateMarkdown(posts.slice(0, 10))
       setMarkdownContent(md)
     } else {
       setMarkdownContent('')
@@ -192,6 +192,11 @@ const SearchForm = () => {
               {posts && posts.length > 0 && <p className="text-sm text-docbase-text-sub">取得件数: {posts.length}件</p>}
             </div>
             <MarkdownPreview markdown={markdownContent} />
+            {posts && posts.length > 10 && (
+              <p className="mt-2 text-sm text-docbase-text-sub">
+                プレビューには最初の10件のみ表示されています。すべての内容を確認するには、ファイルをダウンロードしてください。
+              </p>
+            )}
           </div>
         )}
       </form>

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -185,9 +185,12 @@ const SearchForm = () => {
           </div>
         )}
 
-        {markdownContent && !isLoading && !error && (
+        {markdownContent && !isLoading && !error && posts && posts.length > 0 && (
           <div className="mt-6 pt-5 border-t border-gray-200">
-            <h3 className="text-lg font-semibold mb-3 text-docbase-text">Markdownプレビュー</h3>
+            <div className="flex justify-between items-center mb-3">
+              <h3 className="text-lg font-semibold text-docbase-text">Markdownプレビュー</h3>
+              <span className="text-sm text-docbase-text-sub">(取得記事数: {posts.length}件)</span>
+            </div>
             <MarkdownPreview markdown={markdownContent} />
           </div>
         )}

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -185,11 +185,11 @@ const SearchForm = () => {
           </div>
         )}
 
-        {markdownContent && !isLoading && !error && posts && posts.length > 0 && (
+        {markdownContent && !isLoading && !error && (
           <div className="mt-6 pt-5 border-t border-gray-200">
             <div className="flex justify-between items-center mb-3">
               <h3 className="text-lg font-semibold text-docbase-text">Markdownプレビュー</h3>
-              <span className="text-sm text-docbase-text-sub">(取得記事数: {posts.length}件)</span>
+              {posts && posts.length > 0 && <p className="text-sm text-docbase-text-sub">取得件数: {posts.length}件</p>}
             </div>
             <MarkdownPreview markdown={markdownContent} />
           </div>

--- a/src/lib/docbaseClient.ts
+++ b/src/lib/docbaseClient.ts
@@ -42,7 +42,7 @@ export const fetchDocbasePosts = async (
   const allPosts: DocbasePostListItem[] = []
   let currentPage = 1
   const postsPerPage = 100 // 1ページあたりの取得件数
-  const maxPages = 5 // 最大取得ページ数
+  const maxPages = 3 // 最大取得ページ数
 
   // リトライ処理をページネーションの外側に移動するため、
   // この関数がリトライされるときは、特定のページからではなく、常に最初のページから再試行する。

--- a/src/lib/docbaseClient.ts
+++ b/src/lib/docbaseClient.ts
@@ -39,80 +39,117 @@ export const fetchDocbasePosts = async (
   }
 
   const exactMatchKeyword = `"${keyword}"`
-  const searchParams = new URLSearchParams({ q: exactMatchKeyword })
-  const url = `${DOCBASE_API_BASE_URL}/${domain}/posts?${searchParams.toString()}`
+  const allPosts: DocbasePostListItem[] = []
+  let currentPage = 1
+  const postsPerPage = 100 // 1ページあたりの取得件数
+  const maxPages = 5 // 最大取得ページ数
 
-  try {
-    const response = await fetch(url, {
-      headers: {
-        'X-DocBaseToken': token,
-        'Content-Type': 'application/json',
-      },
+  // リトライ処理をページネーションの外側に移動するため、
+  // この関数がリトライされるときは、特定のページからではなく、常に最初のページから再試行する。
+  // 個別のページ取得失敗時のリトライはここでは扱わず、全体としてのリトライに任せる。
+
+  while (currentPage <= maxPages) {
+    const searchParams = new URLSearchParams({
+      q: exactMatchKeyword,
+      page: currentPage.toString(),
+      per_page: postsPerPage.toString(),
     })
+    const url = `${DOCBASE_API_BASE_URL}/${domain}/posts?${searchParams.toString()}`
 
-    if (!response.ok) {
-      if (response.status === 401) {
-        const error: UnauthorizedApiError = {
-          type: 'unauthorized',
-          message: 'Docbase APIトークンが無効です。',
-        }
-        return err(error)
-      }
-      if (response.status === 404) {
-        const error: NotFoundApiError = {
-          type: 'notFound',
-          message: 'Docbaseのチームが見つからないか、APIエンドポイントが誤っています。',
-        }
-        return err(error)
-      }
-      if (response.status === 429) {
-        if (retries > 0) {
-          console.warn(`Rate limit exceeded. Retrying in ${backoff}ms... (${retries} retries left)`)
-          await sleep(backoff)
-          // 再帰的に呼び出し、リトライ回数を減らし、バックオフ時間を増やす (指数バックオフ)
-          return fetchDocbasePosts(domain, token, keyword, retries - 1, backoff * 2)
-        }
-        const error: RateLimitApiError = {
-          type: 'rateLimit',
-          message: 'Docbase APIのレートリミットに達しました。何度か再試行しましたが改善しませんでした。',
-        }
-        return err(error)
-      }
-      const errorText = await response.text()
-      const error: NetworkApiError = {
-        type: 'network',
-        message: `Docbase APIリクエストエラー: ${response.status} ${response.statusText}. ${errorText}`,
-      }
-      return err(error)
-    }
+    try {
+      const response = await fetch(url, {
+        headers: {
+          'X-DocBaseToken': token,
+          'Content-Type': 'application/json',
+        },
+      })
 
-    const data = (await response.json()) as DocbasePostsResponse
-    return ok(data.posts)
-  } catch (error) {
-    console.error('Docbase API fetch error:', error)
-    // ネットワークエラーの場合もリトライを試みる (ただし、リトライ回数は共通)
-    if (
-      retries > 0 &&
-      (error instanceof TypeError || (error instanceof Error && error.message.toLowerCase().includes('network error')))
-    ) {
-      console.warn(`Network error occurred. Retrying in ${backoff}ms... (${retries} retries left)`)
-      await sleep(backoff)
-      return fetchDocbasePosts(domain, token, keyword, retries - 1, backoff * 2)
-    }
+      if (!response.ok) {
+        if (response.status === 401) {
+          const error: UnauthorizedApiError = {
+            type: 'unauthorized',
+            message: 'Docbase APIトークンが無効です。',
+          }
+          return err(error) // 認証エラーは即時エラー
+        }
+        if (response.status === 404) {
+          const error: NotFoundApiError = {
+            type: 'notFound',
+            message: 'Docbaseのチームが見つからないか、APIエンドポイントが誤っています。',
+          }
+          return err(error) // Not Foundも即時エラー
+        }
+        if (response.status === 429) {
+          // レートリミットの場合、この関数全体をリトライする
+          if (retries > 0) {
+            console.warn(
+              `Rate limit exceeded during page ${currentPage} fetch. Retrying entire fetch operation in ${backoff}ms... (${retries} retries left)`,
+            )
+            await sleep(backoff)
+            // fetchDocbasePosts を再度呼び出すが、retries と backoff を渡して再帰的にリトライ
+            // ループ処理は中断し、関数の最初から再試行する
+            return fetchDocbasePosts(domain, token, keyword, retries - 1, backoff * 2)
+          }
+          const error: RateLimitApiError = {
+            type: 'rateLimit',
+            message: `Docbase APIのレートリミットに達しました (ページ ${currentPage} 取得時)。何度か再試行しましたが改善しませんでした。`,
+          }
+          return err(error)
+        }
+        // その他のネットワークエラー
+        const errorText = await response.text()
+        const error: NetworkApiError = {
+          type: 'network',
+          message: `Docbase APIリクエストエラー (ページ ${currentPage} 取得時): ${response.status} ${response.statusText}. ${errorText}`,
+        }
+        return err(error) // その他のエラーも即時エラー
+      }
 
-    if (error instanceof Error) {
-      const apiError: NetworkApiError = {
-        type: 'network',
-        message: `ネットワークエラー: ${error.message}`,
+      const data = (await response.json()) as DocbasePostsResponse
+      if (data.posts && data.posts.length > 0) {
+        allPosts.push(...data.posts)
+        // 取得した件数がper_page未満なら、それが最終ページなのでループを抜ける
+        if (data.posts.length < postsPerPage) {
+          break
+        }
+      } else {
+        // 投稿が空なら、それ以上ページはないのでループを抜ける
+        break
+      }
+      currentPage++
+      // 短い待機時間を挟んでAPIへの負荷を軽減（任意）
+      // await sleep(200); // 例: 200ミリ秒待機
+    } catch (error) {
+      console.error(`Docbase API fetch error (page ${currentPage}):`, error)
+      // ネットワークエラーの場合もこの関数全体をリトライする
+      if (
+        retries > 0 &&
+        (error instanceof TypeError ||
+          (error instanceof Error && error.message.toLowerCase().includes('network error')))
+      ) {
+        console.warn(
+          `Network error occurred during page ${currentPage} fetch. Retrying entire fetch operation in ${backoff}ms... (${retries} retries left)`,
+        )
+        await sleep(backoff)
+        return fetchDocbasePosts(domain, token, keyword, retries - 1, backoff * 2)
+      }
+
+      if (error instanceof Error) {
+        const apiError: NetworkApiError = {
+          type: 'network',
+          message: `ネットワークエラー (ページ ${currentPage} 取得時): ${error.message}`,
+          cause: error,
+        }
+        return err(apiError)
+      }
+      const unknownError: UnknownApiError = {
+        type: 'unknown',
+        message: `不明なエラーが発生しました (ページ ${currentPage} 取得時)。コンソールを確認してください。`,
         cause: error,
       }
-      return err(apiError)
+      return err(unknownError)
     }
-    const unknownError: UnknownApiError = {
-      type: 'unknown',
-      message: '不明なエラーが発生しました。コンソールを確認してください。',
-      cause: error,
-    }
-    return err(unknownError)
-  }
+  } // whileループの終わり
+
+  return ok(allPosts)
 }

--- a/src/lib/docbaseClient.ts
+++ b/src/lib/docbaseClient.ts
@@ -42,7 +42,7 @@ export const fetchDocbasePosts = async (
   const allPosts: DocbasePostListItem[] = []
   let currentPage = 1
   const postsPerPage = 100 // 1ページあたりの取得件数
-  const maxPages = 3 // 最大取得ページ数
+  const maxPages = 5 // 最大取得ページ数を3から5に変更
 
   // リトライ処理をページネーションの外側に移動するため、
   // この関数がリトライされるときは、特定のページからではなく、常に最初のページから再試行する。


### PR DESCRIPTION
## 概要
Docbase APIから取得するメモの件数を、現状のデフォルトから最大500件（100件/ページ × 5ページ）に拡張します。
これにより、ユーザーはより多くの情報を一度に収集できるようになります。

## 変更内容
- `src/lib/docbaseClient.ts` の `fetchDocbasePosts` 関数を修正。
- 1ページあたり100件として、最大5ページ分の投稿を取得するように変更しました。
- 各ページの取得結果を結合して返します。
- APIのレートリミットエラー（429）が発生した場合は、処理全体をリトライします。

## テスト手順
1. アプリケーションを起動し、検索フォームから任意のキーワードで検索を実行する。
2. 検索結果が最大500件（または存在する全件数が500件未満の場合はその件数）取得できていることを確認する。
3. 投稿件数が少ないキーワードで検索し、正しく取得できることを確認する。
4. （可能であれば）レートリミットを意図的に発生させ、リトライ処理が動作することを確認する。

## サービス仕様書への反映
マージ後、以下のサービス仕様書の項目を更新してください。
- 「2.1 データ取得フロー（フロントエンド fetch）」の表を更新。
    - メソッド & エンドポイント: `GET /teams/{domain}/posts` (最大5回実行)
    - パラメータ: `q` (keyword), `page` (1～5), `per_page` (100固定)
    - 目的: 該当メモの **ID・title・created_at・url・body** を最大500件取得

## 関連Issue
- Closes #17