### PR TITLE
hotfix(types): rateLimitの型指定の不整合を修正

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -75,7 +75,7 @@ export const useSearch = (): UseSearchResult => {
             // (例: document.getElementById("docbase-token")?.focus();)
             // ただし、フックから直接DOM操作するのは避けた方が良い場合もあるので、コンポーネント側で対応する方が望ましい
             break
-          case 'rateLimit':
+          case 'rate_limit':
             toast.error('Docbase APIが混み合っています。しばらくしてから再試行してください。')
             setCanRetry(true) // レートリミットの場合は手動再試行を許可
             break

--- a/src/lib/docbaseClient.ts
+++ b/src/lib/docbaseClient.ts
@@ -139,7 +139,7 @@ export const fetchDocbasePosts = async (
             return fetchDocbasePosts(domain, token, keyword, advancedFilters, retries - 1, backoff * 2)
           }
           const error: RateLimitApiError = {
-            type: 'rateLimit',
+            type: 'rate_limit',
             message: `Docbase APIのレートリミットに達しました (ページ ${currentPage} 取得時)。何度か再試行しましたが改善しませんでした。`,
           }
           return err(error)


### PR DESCRIPTION
## 概要
GitHub Actions のビルドで発生していたTypeScriptの型エラーを修正しました。

## 変更内容
- `src/hooks/useSearch.ts`
    - `case 'rateLimit'` を `case 'rate_limit'` に修正
- `src/lib/docbaseClient.ts`
    - `type: 'rateLimit'` を `type: 'rate_limit'` に修正

## エラー原因
エラータイプを文字列で比較または代入する箇所で、`"rateLimit"` (キャメルケース) と `"rate_limit"` (スネークケース) が混在していたため、型エラーが発生していました。

## 確認事項
- `npm run type-check` がエラーなく通ること。