### PR TITLE
feat(slack): SlackのMarkdownプレビューをDocbaseと完全統一

### DIFF
--- a/src/app/docbase/page.tsx
+++ b/src/app/docbase/page.tsx
@@ -1,6 +1,6 @@
 'use client' // クライアントコンポーネントとしてマーク
 
-import SearchForm from '../../components/SearchForm' // パスを修正
+import SearchForm from '../../components/DocbaseSearchForm' // パスを修正
 import { Toaster } from 'react-hot-toast' // Toasterをインポート
 // import { SparklesCore } from "../../components/ui/sparkles"; // 架空のUIコンポーネントなのだ -> 一旦コメントアウト
 import Header from '../../components/Header' // 変更

--- a/src/app/slack/page.tsx
+++ b/src/app/slack/page.tsx
@@ -8,6 +8,8 @@ import { fetchSlackMessages, type SearchSuccessResponse } from '@/lib/slackClien
 import { convertToSlackMarkdown } from '../../lib/slackdown'
 import type { SlackMessage } from '../../types/slack'
 import { toast, Toaster } from 'react-hot-toast'
+import { useDownload } from '../../hooks/useDownload'
+import { MarkdownPreview } from '../../components/DocbaseMarkdownPreview'
 
 // タイムスタンプをフォーマットするヘルパー関数
 const formatTimestamp = (ts: string): string => {
@@ -81,6 +83,10 @@ export default function SlackPage() {
   const [startDate, setStartDate] = useState<string>('')
   const [endDate, setEndDate] = useState<string>('')
   const [customPerPage, setCustomPerPage] = useState<number>(20)
+  const [channel, setChannel] = useState<string>('')
+  const [author, setAuthor] = useState<string>('')
+  const [showAdvanced, setShowAdvanced] = useState<boolean>(false)
+  const { isDownloading, handleDownload } = useDownload()
 
   // ローカルストレージからトークンを読み込み・保存するuseEffect
   useEffect(() => {
@@ -99,13 +105,10 @@ export default function SlackPage() {
   // 検索クエリに期間・件数を反映するヘルパー
   const buildQuery = () => {
     let q = searchQuery.trim()
-    if (startDate && endDate) {
-      q += ` after:${startDate} before:${endDate}`
-    } else if (startDate) {
-      q += ` after:${startDate}`
-    } else if (endDate) {
-      q += ` before:${endDate}`
-    }
+    if (channel) q += ` in:${channel.startsWith('#') ? channel : `#${channel}`}`
+    if (author) q += ` from:${author.startsWith('@') ? author : `@${author}`}`
+    if (startDate) q += ` after:${startDate}`
+    if (endDate) q += ` before:${endDate}`
     return q
   }
 
@@ -202,198 +205,331 @@ export default function SlackPage() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between bg-gradient-to-b from-slate-50 to-sky-100 text-slate-800">
-      <Header title="Slack メッセージ検索 & Markdown出力" />
-      <div className="flex-grow container mx-auto px-4 py-8 w-full max-w-3xl">
-        <Toaster position="top-right" />
-        <h1 className="text-3xl font-bold mb-8 text-center text-gray-800">Slack メッセージ検索 & Markdown出力</h1>
-
-        <div className="mb-6 p-4 border border-blue-300 rounded-lg bg-blue-50 shadow-sm">
-          <p className="text-sm text-blue-700">
-            このツールはSlackの <strong className="font-semibold">search.messages</strong>{' '}
-            APIエンドポイントを使用します。
-            <br />
-            利用には、Slackアプリに <code className="bg-blue-100 text-blue-800 px-1.5 py-0.5 rounded">search:read</code>{' '}
-            のスコープ権限が必要です。
-            <br />
-            以前のバージョンから移行した場合は、アプリの権限を確認し、必要であれば再認証してください。
-          </p>
-        </div>
-
-        <form onSubmit={handleFormSubmit} className="space-y-6 bg-white p-6 rounded-lg shadow-md">
-          <div>
-            <label htmlFor="token" className="block text-sm font-medium text-gray-700 mb-1">
-              Slack API トークン (User Token: <code className="text-xs">xoxp-</code> から始まるもの):
-            </label>
-            <input
-              type="password"
-              id="token"
-              value={token}
-              onChange={(e) => setToken(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-              placeholder="xoxp-..."
-              required
-            />
-          </div>
-
-          <div>
-            <label htmlFor="searchQuery" className="block text-sm font-medium text-gray-700 mb-1">
-              検索クエリ (例: <code className="text-xs">重要なキーワード in:#general after:2024-01-01</code>):
-            </label>
-            <input
-              type="text"
-              id="searchQuery"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-              placeholder="Slackの検索演算子が利用可能"
-            />
-            <p className="mt-2 text-xs text-gray-500">
-              ヘルプ: Slackの検索演算子は
-              <a
-                href="https://slack.com/intl/ja-jp/help/articles/202528808-Slack-%E3%81%A7%E6%A4%9C%E7%B4%A2%E3%81%99%E3%82%8B"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-indigo-600 hover:text-indigo-800 underline"
-              >
-                こちら
-              </a>
-              を参照。
+    <main className="flex min-h-screen flex-col text-gray-800 selection:bg-blue-100 font-sans">
+      <Header title="NotebookLM Collector - Slack" />
+      <Toaster
+        position="top-center"
+        toastOptions={{
+          className: '!border !border-gray-200 !bg-white !text-gray-700 !shadow-lg !rounded-md',
+          success: {
+            iconTheme: {
+              primary: '#36C5F0', // Slackブルー
+              secondary: '#FFFFFF',
+            },
+          },
+          error: {
+            iconTheme: {
+              primary: '#EF4444',
+              secondary: '#FFFFFF',
+            },
+          },
+        }}
+      />
+      <div className="relative z-10 flex flex-col items-center w-full">
+        {/* ヒーローセクション */}
+        <section className="w-full text-center my-32">
+          <div className="max-w-screen-lg mx-auto px-4 sm:px-6 lg:px-8">
+            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6 text-gray-800 leading-tight">
+              Slackの会話を、
+              <br />
+              NotebookLMへ簡単連携
+            </h1>
+            <p className="text-lg md:text-xl lg:text-2xl text-gray-600 max-w-3xl mx-auto">
+              キーワードや期間でSlackメッセージを検索し、NotebookLM用のMarkdownファイルをすぐに生成できます。
             </p>
           </div>
-
-          <div className="flex flex-col md:flex-row md:space-x-4 space-y-2 md:space-y-0">
-            <div className="flex-1">
-              <label htmlFor="startDate" className="block text-xs font-medium text-gray-700 mb-1">
-                開始日 (after:)
-              </label>
-              <input
-                type="date"
-                id="startDate"
-                value={startDate}
-                onChange={(e) => setStartDate(e.target.value)}
-                className="block w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 text-xs"
-              />
-            </div>
-            <div className="flex-1">
-              <label htmlFor="endDate" className="block text-xs font-medium text-gray-700 mb-1">
-                終了日 (before:)
-              </label>
-              <input
-                type="date"
-                id="endDate"
-                value={endDate}
-                onChange={(e) => setEndDate(e.target.value)}
-                className="block w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 text-xs"
-              />
-            </div>
-            <div className="flex-1">
-              <label htmlFor="customPerPage" className="block text-xs font-medium text-gray-700 mb-1">
-                1ページ取得件数 (最大100)
-              </label>
-              <input
-                type="number"
-                id="customPerPage"
-                min={1}
-                max={100}
-                value={customPerPage}
-                onChange={(e) => setCustomPerPage(Number(e.target.value))}
-                className="block w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 text-xs"
-              />
-            </div>
-          </div>
-
-          <div className="flex items-center space-x-3">
-            <button
-              type="submit"
-              disabled={isLoading || !token || !searchQuery}
-              className="px-4 py-2 bg-indigo-600 text-white font-semibold rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 transition ease-in-out duration-150"
-            >
-              {isLoading ? '取得中...' : '検索・全件取得 (最大500件)'}
-            </button>
-          </div>
-        </form>
-
-        {error && (
-          <div className="mt-6 p-3 bg-red-100 border border-red-400 text-red-700 rounded-md shadow-sm">
-            <p className="font-medium">エラーが発生しました:</p>
-            <p className="text-sm">{error}</p>
-          </div>
-        )}
-
-        {messages.length > 0 && (
-          <div className="mt-8">
-            <h2 className="text-2xl font-semibold mb-4 text-gray-800">
-              検索結果 ({messages.length}件表示 / API上の総結果: {paginationInfo.totalResults}件)
-            </h2>
-            <div className="space-y-4">
-              {messages.map((msg) => (
-                <div
-                  key={msg.ts}
-                  className="p-4 border border-gray-200 rounded-lg shadow-sm bg-white hover:shadow-md transition-shadow"
-                >
-                  <div className="flex justify-between items-center mb-2">
-                    <span className="font-semibold text-indigo-700">
-                      {msg.username || msg.user || 'Unknown User'} (
-                      {msg.channel.name ? `#${msg.channel.name}` : msg.channel.id})
+        </section>
+        {/* 使い方説明セクション */}
+        <section className="w-full mt-12">
+          <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-background-light">
+            <h2 className="text-3xl md:text-4xl font-bold mb-20 text-center text-gray-800">利用はかんたん3ステップ</h2>
+            <div className="grid md:grid-cols-3 gap-x-8 gap-y-10 relative">
+              {[
+                {
+                  step: '1',
+                  title: '情報を入力',
+                  description: 'Slackトークン、検索キーワード、期間などを入力します。トークンは保存可能です。',
+                  icon: '⌨️',
+                },
+                {
+                  step: '2',
+                  title: '検索して生成',
+                  description:
+                    '「検索実行」ボタンでSlackからメッセージを取得し、NotebookLM用Markdownをプレビューします。',
+                  icon: '🔍',
+                },
+                {
+                  step: '3',
+                  title: 'ダウンロード',
+                  description: '生成されたMarkdownを「ダウンロード」ボタンで保存。すぐにAIに学習させられます。',
+                  icon: '💾',
+                },
+              ].map((item) => (
+                <div key={item.step} className="text-center md:text-left">
+                  <div className="flex items-center justify-center md:justify-start mb-4">
+                    <span className="flex items-center justify-center w-10 h-10 bg-blue-500 text-white text-xl font-bold rounded-full mr-4">
+                      {item.step}
                     </span>
-                    <a
-                      href={msg.permalink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-xs text-indigo-500 hover:underline"
-                    >
-                      {formatTimestamp(msg.ts)} (Slackで表示)
-                    </a>
+                    <span className="text-3xl">{item.icon}</span>
                   </div>
-                  <div className="whitespace-pre-wrap text-sm text-gray-700">{msg.text || '(本文なし)'}</div>
+                  <h3 className="text-lg font-semibold mb-2 text-gray-800">{item.title}</h3>
+                  <p className="text-gray-600 text-sm leading-relaxed">{item.description}</p>
                 </div>
               ))}
             </div>
           </div>
-        )}
-
-        {currentPreviewMarkdown && (
-          <div className="mt-8">
-            <h2 className="text-xl font-semibold mb-3 text-gray-800">Markdownプレビュー:</h2>
-            <div className="flex items-center mb-2 space-x-2">
-              <button
-                type="button"
-                onClick={() => {
-                  const now = new Date()
-                  const ymdhms = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}`
-                  const fileName = `notebooklm_slack_${searchQuery ? searchQuery.replace(/\s+/g, '_').slice(0, 20) : 'search'}_${ymdhms}.md`
-                  const blob = new Blob([currentPreviewMarkdown], { type: 'text/markdown' })
-                  const a = document.createElement('a')
-                  a.href = URL.createObjectURL(blob)
-                  a.download = fileName
-                  a.click()
-                  setTimeout(() => URL.revokeObjectURL(a.href), 1000)
-                  toast.success('Markdownファイルをダウンロードしました！')
-                }}
-                className="px-3 py-1.5 bg-green-600 text-white text-sm font-semibold rounded-md shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1 transition ease-in-out duration-150"
-              >
-                Markdownをダウンロード
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  navigator.clipboard.writeText(currentPreviewMarkdown)
-                  toast.success('Markdownをクリップボードにコピーしました！')
-                }}
-                className="px-3 py-1.5 bg-teal-500 text-white text-sm font-semibold rounded-md shadow-sm hover:bg-teal-600 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-1 transition ease-in-out duration-150"
-              >
-                Markdownをコピー
-              </button>
+        </section>
+        {/* セキュリティ説明セクション */}
+        <section className="w-full mt-12">
+          <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-background-light">
+            <div className="text-center">
+              <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-gray-800">🔒 セキュリティについて</h2>
+              <p className="text-gray-600 text-lg leading-relaxed max-w-3xl mx-auto">
+                入力されたSlack APIトークンや取得したメッセージ内容は、お使いのブラウザ内でのみ処理されます。
+                これらの情報が外部サーバーに送信されたり、保存されたりすることは一切ありませんので、安心してご利用いただけます。
+              </p>
             </div>
-            <textarea
-              readOnly
-              value={currentPreviewMarkdown}
-              className="w-full h-96 p-3 border border-gray-300 rounded-md bg-gray-50 font-mono text-xs shadow-inner"
-              placeholder="ここにMarkdownプレビューが表示されます"
-            />
           </div>
-        )}
+        </section>
+        {/* メイン機能セクション */}
+        <section id="main-tool-section" className="w-full my-12 bg-white">
+          <div className="max-w-screen-lg mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-10 md:py-12 shadow-md rounded-lg border border-gray-200">
+            <div className="px-0">
+              <h2 className="text-4xl font-bold mb-6 text-center text-gray-800">Slack メッセージ検索・収集</h2>
+              <div className="max-w-3xl mx-auto">
+                <form onSubmit={handleFormSubmit} className="space-y-6">
+                  <div className="space-y-4">
+                    <div>
+                      <label htmlFor="searchQuery" className="block text-base font-medium text-gray-700 mb-1">
+                        検索キーワード
+                      </label>
+                      <input
+                        id="searchQuery"
+                        type="text"
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        placeholder="Slackの検索演算子も利用可"
+                        className="block w-full px-4 py-3 border border-gray-400 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-400 focus:border-blue-400 disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                        disabled={isLoading || isDownloading}
+                        required
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="token" className="block text-base font-medium text-gray-700 mb-1">
+                        Slack API トークン
+                      </label>
+                      <input
+                        id="token"
+                        type="password"
+                        value={token}
+                        onChange={(e) => setToken(e.target.value)}
+                        placeholder="xoxp-..."
+                        className="block w-full px-4 py-3 border border-gray-400 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-400 focus:border-blue-400 disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                        disabled={isLoading || isDownloading}
+                        required
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-4 pt-2">
+                    <button
+                      type="button"
+                      onClick={() => setShowAdvanced(!showAdvanced)}
+                      className="text-sm text-blue-600 hover:text-blue-800 focus:outline-none"
+                    >
+                      {showAdvanced ? '詳細な条件を閉じる ▲' : 'もっと詳細な条件を追加する ▼'}
+                    </button>
+                    {showAdvanced && (
+                      <div className="space-y-4 p-4 border border-gray-300 rounded-md bg-gray-50">
+                        <div>
+                          <label htmlFor="channel" className="block text-sm font-medium text-gray-700 mb-1">
+                            チャンネル (例: #general)
+                          </label>
+                          <input
+                            id="channel"
+                            type="text"
+                            value={channel}
+                            onChange={(e) => setChannel(e.target.value)}
+                            placeholder="#general"
+                            className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-400 focus:border-blue-400 disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                            disabled={isLoading || isDownloading}
+                          />
+                        </div>
+                        <div>
+                          <label htmlFor="author" className="block text-sm font-medium text-gray-700 mb-1">
+                            投稿者 (例: @user)
+                          </label>
+                          <input
+                            id="author"
+                            type="text"
+                            value={author}
+                            onChange={(e) => setAuthor(e.target.value)}
+                            placeholder="@user"
+                            className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-400 focus:border-blue-400 disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                            disabled={isLoading || isDownloading}
+                          />
+                        </div>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                          <div>
+                            <label htmlFor="startDate" className="block text-sm font-medium text-gray-700 mb-1">
+                              投稿期間 (開始日)
+                            </label>
+                            <input
+                              id="startDate"
+                              type="date"
+                              value={startDate}
+                              onChange={(e) => setStartDate(e.target.value)}
+                              className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-400 focus:border-blue-400 disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                              disabled={isLoading || isDownloading}
+                            />
+                          </div>
+                          <div>
+                            <label htmlFor="endDate" className="block text-sm font-medium text-gray-700 mb-1">
+                              投稿期間 (終了日)
+                            </label>
+                            <input
+                              id="endDate"
+                              type="date"
+                              value={endDate}
+                              onChange={(e) => setEndDate(e.target.value)}
+                              className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-400 focus:border-blue-400 disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                              disabled={isLoading || isDownloading}
+                            />
+                          </div>
+                        </div>
+                        <div>
+                          <label htmlFor="customPerPage" className="block text-sm font-medium text-gray-700 mb-1">
+                            1ページ取得件数 (最大100)
+                          </label>
+                          <input
+                            id="customPerPage"
+                            type="number"
+                            min={1}
+                            max={100}
+                            value={customPerPage}
+                            onChange={(e) => setCustomPerPage(Number(e.target.value))}
+                            placeholder="20"
+                            className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-400 focus:border-blue-400 disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                            disabled={isLoading || isDownloading}
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex flex-col sm:flex-row space-y-3 sm:space-y-0 sm:space-x-3 pt-2">
+                    <button
+                      type="submit"
+                      className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-transparent shadow-sm text-sm font-medium rounded-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
+                      disabled={isLoading || isDownloading || !token || !searchQuery}
+                    >
+                      {isLoading ? (
+                        <>
+                          <svg
+                            className="animate-spin -ml-1 mr-2 h-5 w-5"
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                          >
+                            <title>検索処理ローディング</title>
+                            <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            />
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                            />
+                          </svg>
+                          検索中...
+                        </>
+                      ) : (
+                        '検索実行'
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDownload(currentPreviewMarkdown, searchQuery, !!currentPreviewMarkdown)}
+                      className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-blue-600 shadow-sm text-sm font-medium rounded-sm text-blue-600 bg-white hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-200 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
+                      disabled={isLoading || isDownloading || !currentPreviewMarkdown}
+                    >
+                      {isDownloading ? (
+                        <>
+                          <svg
+                            className="animate-spin -ml-1 mr-2 h-5 w-5"
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                          >
+                            <title>ダウンロード処理ローディング</title>
+                            <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            />
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                            />
+                          </svg>
+                          生成中...
+                        </>
+                      ) : (
+                        'Markdownダウンロード'
+                      )}
+                    </button>
+                  </div>
+                  {/* エラー表示 */}
+                  {error && (
+                    <div className="mt-5 p-3.5 text-sm text-gray-800 bg-red-50 border border-red-300 rounded-sm shadow-sm">
+                      <div className="flex items-center">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-5 w-5 mr-2 text-red-500"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        >
+                          <title>エラーアイコン</title>
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                          />
+                        </svg>
+                        <p className="font-medium">エラーが発生しました:</p>
+                      </div>
+                      <p className="ml-7 mt-0.5 text-red-600">{error}</p>
+                    </div>
+                  )}
+                  {/* プレビュー */}
+                  {currentPreviewMarkdown && !isLoading && !error && (
+                    <div className="mt-6 pt-5 border-t border-gray-200">
+                      <div className="flex justify-between items-center mb-3">
+                        <h3 className="text-lg font-semibold text-gray-800">Markdownプレビュー</h3>
+                        <p className="text-sm text-gray-500">取得件数: {messages.length}件</p>
+                      </div>
+                      <MarkdownPreview markdown={currentPreviewMarkdown} />
+                      {messages.length > 10 && (
+                        <p className="mt-2 text-sm text-gray-500">
+                          プレビューには最初の10件のみ表示されています。すべての内容を確認するには、ファイルをダウンロードしてください。
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </form>
+              </div>
+            </div>
+          </div>
+        </section>
       </div>
       <Footer />
     </main>

--- a/src/components/DocbaseMarkdownPreview.tsx
+++ b/src/components/DocbaseMarkdownPreview.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import type { FC, ReactNode } from 'react'
+import ReactMarkdown, { type ExtraProps as ReactMarkdownExtraProps } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+// react-markdownのカスタムコンポーネントのprops型を定義
+// BiomeのnoExplicitAnyを抑制するために、型をanyにしてコメントで説明を追加します
+
+interface MarkdownPreviewProps {
+  markdown: string
+}
+
+/**
+ * Markdownプレビューコンポーネント
+ * @param markdown 表示するMarkdown文字列
+ */
+export const MarkdownPreview: FC<MarkdownPreviewProps> = ({ markdown }) => {
+  if (!markdown) {
+    return (
+      <div className="p-6 bg-white rounded-lg shadow border border-gray-200 min-h-[200px] flex items-center justify-center">
+        <p className="text-gray-500">ここにMarkdownプレビューが表示されます。</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 rounded-md prose max-w-none prose-neutral prose-sm sm:prose-base lg:prose-lg xl:prose-xl">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+          h2: ({ node, children, ...props }: any) => (
+            <h2 className="text-3xl font-bold mt-8 mb-4 pb-2 border-b-2 border-primary" {...props}>
+              {children}
+            </h2>
+          ),
+          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+          blockquote: ({ node, children, ...props }: any) => (
+            <blockquote className="my-2 text-sm" {...props}>
+              {children}
+            </blockquote>
+          ),
+          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+          code: ({ node, inline, className, children, ...props }: any) => {
+            const match = /language-(\w+)/.exec(className || '')
+            return !inline && match ? (
+              <div className="my-4 bg-gray-800 rounded-md overflow-hidden shadow">
+                <div className="px-4 py-2 text-sm text-gray-300 bg-gray-700 ">{match[1]}</div>
+                <pre className="p-4 text-sm leading-relaxed overflow-x-auto text-gray-100">
+                  <code {...props} className={className}>
+                    {children}
+                  </code>
+                </pre>
+              </div>
+            ) : (
+              <code
+                {...props}
+                className={className || 'px-1 py-0.5 bg-gray-200 text-text rounded-sm text-sm font-mono'}
+              >
+                {children}
+              </code>
+            )
+          },
+          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+          a: ({ node, children, ...props }: any) => (
+            <a className="text-primary hover:underline hover:text-primary-dark" {...props}>
+              {children}
+            </a>
+          ),
+        }}
+      >
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/src/components/DocbaseSearchForm.tsx
+++ b/src/components/DocbaseSearchForm.tsx
@@ -1,0 +1,322 @@
+'use client'
+
+import React, { useState, type FormEvent, useEffect, useRef } from 'react'
+import { DocbaseDomainInput } from './DocbaseDomainInput'
+import { DocbaseTokenInput } from './DocbaseTokenInput'
+import { useSearch } from '../hooks/useSearch'
+import { useDownload } from '../hooks/useDownload'
+import useLocalStorage from '../hooks/useLocalStorage'
+import type { ApiError } from '../types/error'
+import { generateMarkdown } from '../utils/markdownGenerator'
+import { MarkdownPreview } from './DocbaseMarkdownPreview'
+
+const LOCAL_STORAGE_DOMAIN_KEY = 'docbaseDomain'
+const LOCAL_STORAGE_TOKEN_KEY = 'docbaseToken'
+
+/**
+ * 検索フォームコンポーネント
+ */
+const SearchForm = () => {
+  const [keyword, setKeyword] = useState('')
+  const [domain, setDomain] = useLocalStorage<string>(LOCAL_STORAGE_DOMAIN_KEY, '')
+  const [token, setToken] = useLocalStorage<string>(LOCAL_STORAGE_TOKEN_KEY, '')
+  const [markdownContent, setMarkdownContent] = useState('')
+  const [showAdvancedSearch, setShowAdvancedSearch] = useState(false)
+  const [tags, setTags] = useState('')
+  const [author, setAuthor] = useState('')
+  const [titleFilter, setTitleFilter] = useState('')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [group, setGroup] = useState('')
+
+  const { posts, isLoading, error, searchPosts, canRetry, retrySearch } = useSearch()
+  const { isDownloading, handleDownload } = useDownload()
+
+  const tokenInputRef = useRef<HTMLInputElement>(null)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setMarkdownContent('')
+    const advancedFilters = {
+      tags,
+      author,
+      titleFilter,
+      startDate,
+      endDate,
+      group,
+    }
+    await searchPosts(domain, token, keyword, advancedFilters)
+  }
+
+  useEffect(() => {
+    if (posts && posts.length > 0) {
+      const md = generateMarkdown(posts.slice(0, 10))
+      setMarkdownContent(md)
+    } else {
+      setMarkdownContent('')
+    }
+  }, [posts])
+
+  useEffect(() => {
+    if (error?.type === 'unauthorized') {
+      tokenInputRef.current?.focus()
+    }
+  }, [error])
+
+  const handleDownloadClick = () => {
+    const postsExist = posts && posts.length > 0
+    handleDownload(markdownContent, keyword, postsExist)
+  }
+
+  const renderErrorCause = (currentError: ApiError | null) => {
+    if (!currentError) return null
+
+    if (currentError.type === 'network' || currentError.type === 'unknown') {
+      if (currentError.cause) {
+        if (currentError.cause instanceof Error) {
+          return <p className="text-sm">詳細: {currentError.cause.message}</p>
+        }
+        return <p className="text-sm">詳細: {String(currentError.cause)}</p>
+      }
+    }
+    return null
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="keyword" className="block text-base font-medium text-docbase-text mb-1">
+              検索キーワード
+            </label>
+            <input
+              id="keyword"
+              type="text"
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              placeholder="キーワードを入力してください"
+              className="block w-full px-4 py-3 border border-gray-400 rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+              disabled={isLoading || isDownloading}
+              required
+            />
+          </div>
+          <DocbaseDomainInput domain={domain} onDomainChange={setDomain} disabled={isLoading || isDownloading} />
+          <DocbaseTokenInput token={token} onTokenChange={setToken} disabled={isLoading || isDownloading} />
+        </div>
+
+        {/* 詳細検索の開閉ボタンと入力フィールドを追加 */}
+        <div className="space-y-4 pt-2">
+          <button
+            type="button"
+            onClick={() => setShowAdvancedSearch(!showAdvancedSearch)}
+            className="text-sm text-docbase-primary hover:text-docbase-primary-dark focus:outline-none"
+          >
+            {showAdvancedSearch ? '詳細な条件を閉じる ▲' : 'もっと詳細な条件を追加する ▼'}
+          </button>
+
+          {showAdvancedSearch && (
+            <div className="space-y-4 p-4 border border-gray-300 rounded-md bg-gray-50">
+              <div>
+                <label htmlFor="tags" className="block text-sm font-medium text-docbase-text mb-1">
+                  タグ (カンマ区切り)
+                </label>
+                <input
+                  id="tags"
+                  type="text"
+                  value={tags}
+                  onChange={(e) => setTags(e.target.value)}
+                  placeholder="例: API, 設計"
+                  className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                  disabled={isLoading || isDownloading}
+                />
+              </div>
+              <div>
+                <label htmlFor="author" className="block text-sm font-medium text-docbase-text mb-1">
+                  投稿者 (ユーザーID)
+                </label>
+                <input
+                  id="author"
+                  type="text"
+                  value={author}
+                  onChange={(e) => setAuthor(e.target.value)}
+                  placeholder="例: user123"
+                  className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                  disabled={isLoading || isDownloading}
+                />
+              </div>
+              <div>
+                <label htmlFor="titleFilter" className="block text-sm font-medium text-docbase-text mb-1">
+                  タイトルに含むキーワード
+                </label>
+                <input
+                  id="titleFilter"
+                  type="text"
+                  value={titleFilter}
+                  onChange={(e) => setTitleFilter(e.target.value)}
+                  placeholder="例: 仕様書"
+                  className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                  disabled={isLoading || isDownloading}
+                />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label htmlFor="startDate" className="block text-sm font-medium text-docbase-text mb-1">
+                    投稿期間 (開始日)
+                  </label>
+                  <input
+                    id="startDate"
+                    type="date"
+                    value={startDate}
+                    onChange={(e) => setStartDate(e.target.value)}
+                    className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                    disabled={isLoading || isDownloading}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="endDate" className="block text-sm font-medium text-docbase-text mb-1">
+                    投稿期間 (終了日)
+                  </label>
+                  <input
+                    id="endDate"
+                    type="date"
+                    value={endDate}
+                    onChange={(e) => setEndDate(e.target.value)}
+                    className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                    disabled={isLoading || isDownloading}
+                  />
+                </div>
+              </div>
+              <div>
+                <label htmlFor="group" className="block text-sm font-medium text-docbase-text mb-1">
+                  グループ名
+                </label>
+                <input
+                  id="group"
+                  type="text"
+                  value={group}
+                  onChange={(e) => setGroup(e.target.value)}
+                  placeholder="例: 開発チーム"
+                  className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+                  disabled={isLoading || isDownloading}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col sm:flex-row space-y-3 sm:space-y-0 sm:space-x-3 pt-2">
+          <button
+            type="submit"
+            className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-transparent shadow-sm text-sm font-medium rounded-sm text-white bg-docbase-primary hover:bg-docbase-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
+            disabled={isLoading || isDownloading || !domain || !token || !keyword}
+          >
+            {isLoading ? (
+              <>
+                <svg
+                  className="animate-spin -ml-1 mr-2 h-5 w-5"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <title>検索処理ローディング</title>
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                検索中...
+              </>
+            ) : (
+              '検索実行'
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={handleDownloadClick}
+            className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-docbase-primary shadow-sm text-sm font-medium rounded-sm text-docbase-primary bg-white hover:bg-docbase-primary/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
+            disabled={isLoading || isDownloading || !markdownContent.trim()}
+          >
+            {isDownloading ? (
+              <>
+                <svg
+                  className="animate-spin -ml-1 mr-2 h-5 w-5"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <title>ダウンロード処理ローディング</title>
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                生成中...
+              </>
+            ) : (
+              'Markdownダウンロード'
+            )}
+          </button>
+        </div>
+
+        {canRetry && !isLoading && (
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={retrySearch}
+              className="w-full inline-flex justify-center py-2 px-4 border border-yellow-400 shadow-sm text-sm font-medium rounded-sm text-yellow-700 bg-yellow-50 hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500 transition-colors duration-150 ease-in-out"
+            >
+              再試行
+            </button>
+          </div>
+        )}
+
+        {error && (
+          <div className="mt-5 p-3.5 text-sm text-docbase-text bg-red-50 border border-red-300 rounded-sm shadow-sm">
+            <div className="flex items-center">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 mr-2 text-red-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <title>エラーアイコン</title>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+              <p className="font-medium">エラーが発生しました:</p>
+            </div>
+            <p className="ml-7 mt-0.5 text-red-600">{error.message}</p>
+            {renderErrorCause(error) && <div className="ml-7 mt-1 text-xs text-red-500">{renderErrorCause(error)}</div>}
+          </div>
+        )}
+
+        {markdownContent && !isLoading && !error && (
+          <div className="mt-6 pt-5 border-t border-gray-200">
+            <div className="flex justify-between items-center mb-3">
+              <h3 className="text-lg font-semibold text-docbase-text">Markdownプレビュー</h3>
+              {posts && posts.length > 0 && <p className="text-sm text-docbase-text-sub">取得件数: {posts.length}件</p>}
+            </div>
+            <MarkdownPreview markdown={markdownContent} />
+            {posts && posts.length > 10 && (
+              <p className="mt-2 text-sm text-docbase-text-sub">
+                プレビューには最初の10件のみ表示されています。すべての内容を確認するには、ファイルをダウンロードしてください。
+              </p>
+            )}
+          </div>
+        )}
+      </form>
+    </div>
+  )
+}
+
+export default SearchForm

--- a/src/components/SlackAuthorInput.tsx
+++ b/src/components/SlackAuthorInput.tsx
@@ -1,0 +1,33 @@
+import type { FC } from 'react'
+
+type SlackAuthorInputProps = {
+  author: string
+  onAuthorChange: (author: string) => void
+  error?: string
+  disabled?: boolean
+}
+
+export const SlackAuthorInput: FC<SlackAuthorInputProps> = ({ author, onAuthorChange, error, disabled }) => {
+  return (
+    <div className="mb-4">
+      <label htmlFor="slack-author" className="block text-base font-medium text-gray-700 mb-1">
+        投稿者 (例: @user)
+      </label>
+      <input
+        type="text"
+        id="slack-author"
+        value={author}
+        onChange={(e) => onAuthorChange(e.target.value)}
+        placeholder="@user"
+        disabled={disabled}
+        className={`block w-full px-4 py-3 border ${error ? 'border-red-500' : 'border-gray-400'} rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500' : 'focus:ring-blue-400 focus:border-blue-400'} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
+        aria-describedby={error ? 'slack-author-error' : undefined}
+      />
+      {error && (
+        <p id="slack-author-error" className="mt-1 text-xs text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/SlackChannelInput.tsx
+++ b/src/components/SlackChannelInput.tsx
@@ -1,0 +1,33 @@
+import type { FC } from 'react'
+
+type SlackChannelInputProps = {
+  channel: string
+  onChannelChange: (channel: string) => void
+  error?: string
+  disabled?: boolean
+}
+
+export const SlackChannelInput: FC<SlackChannelInputProps> = ({ channel, onChannelChange, error, disabled }) => {
+  return (
+    <div className="mb-4">
+      <label htmlFor="slack-channel" className="block text-base font-medium text-gray-700 mb-1">
+        チャンネル (例: #general)
+      </label>
+      <input
+        type="text"
+        id="slack-channel"
+        value={channel}
+        onChange={(e) => onChannelChange(e.target.value)}
+        placeholder="#general"
+        disabled={disabled}
+        className={`block w-full px-4 py-3 border ${error ? 'border-red-500' : 'border-gray-400'} rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500' : 'focus:ring-blue-400 focus:border-blue-400'} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
+        aria-describedby={error ? 'slack-channel-error' : undefined}
+      />
+      {error && (
+        <p id="slack-channel-error" className="mt-1 text-xs text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/SlackMarkdownPreview.tsx
+++ b/src/components/SlackMarkdownPreview.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import type { FC } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+interface SlackMarkdownPreviewProps {
+  markdown: string
+}
+
+/**
+ * Slack用Markdownプレビュー（Docbaseと同じデザイン・機能で統一）
+ */
+export const SlackMarkdownPreview: FC<SlackMarkdownPreviewProps> = ({ markdown }) => {
+  if (!markdown) {
+    return (
+      <div className="p-6 bg-white rounded-lg shadow border border-gray-200 min-h-[200px] flex items-center justify-center">
+        <p className="text-gray-500">ここにMarkdownプレビューが表示されます。</p>
+      </div>
+    )
+  }
+  return (
+    <div className="p-4 rounded-md prose max-w-none prose-neutral prose-sm sm:prose-base lg:prose-lg xl:prose-xl">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+          h2: ({ node, children, ...props }: any) => (
+            <h2 className="text-3xl font-bold mt-8 mb-4 pb-2 border-b-2 border-primary" {...props}>
+              {children}
+            </h2>
+          ),
+          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+          blockquote: ({ node, children, ...props }: any) => (
+            <blockquote className="my-2 text-sm" {...props}>
+              {children}
+            </blockquote>
+          ),
+          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+          code: ({ node, inline, className, children, ...props }: any) => {
+            const match = /language-(\w+)/.exec(className || '')
+            return !inline && match ? (
+              <div className="my-4 bg-gray-800 rounded-md overflow-hidden shadow">
+                <div className="px-4 py-2 text-sm text-gray-300 bg-gray-700 ">{match[1]}</div>
+                <pre className="p-4 text-sm leading-relaxed overflow-x-auto text-gray-100">
+                  <code {...props} className={className}>
+                    {children}
+                  </code>
+                </pre>
+              </div>
+            ) : (
+              <code
+                {...props}
+                className={className || 'px-1 py-0.5 bg-gray-200 text-text rounded-sm text-sm font-mono'}
+              >
+                {children}
+              </code>
+            )
+          },
+          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+          a: ({ node, children, ...props }: any) => (
+            <a className="text-primary hover:underline hover:text-primary-dark" {...props}>
+              {children}
+            </a>
+          ),
+        }}
+      >
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/src/components/SlackTokenInput.tsx
+++ b/src/components/SlackTokenInput.tsx
@@ -1,0 +1,46 @@
+import React, { type FC, forwardRef, useImperativeHandle, useRef } from 'react'
+
+type SlackTokenInputProps = {
+  token: string
+  onTokenChange: (token: string) => void
+  error?: string
+  disabled?: boolean
+}
+
+export type SlackTokenInputRef = {
+  focus: () => void
+}
+
+export const SlackTokenInput = forwardRef<SlackTokenInputRef, SlackTokenInputProps>(
+  ({ token, onTokenChange, error, disabled }, ref) => {
+    const inputRef = useRef<HTMLInputElement>(null)
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        inputRef.current?.focus()
+      },
+    }))
+    return (
+      <div className="mb-4">
+        <label htmlFor="slack-token" className="block text-base font-medium text-gray-700 mb-1">
+          Slack APIトークン
+        </label>
+        <input
+          type="password"
+          id="slack-token"
+          ref={inputRef}
+          value={token}
+          onChange={(e) => onTokenChange(e.target.value)}
+          placeholder="xoxp-..."
+          disabled={disabled}
+          className={`block w-full px-4 py-3 border ${error ? 'border-red-500' : 'border-gray-400'} rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500' : 'focus:ring-blue-400 focus:border-blue-400'} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
+          aria-describedby={error ? 'slack-token-error' : undefined}
+        />
+        {error && (
+          <p id="slack-token-error" className="mt-1 text-xs text-red-600">
+            {error}
+          </p>
+        )}
+      </div>
+    )
+  },
+)

--- a/src/lib/slackClient.ts
+++ b/src/lib/slackClient.ts
@@ -6,7 +6,6 @@ import type {
   NetworkApiError,
   UnknownApiError,
   UnauthorizedApiError,
-  NotFoundApiError,
   RateLimitApiError,
   ApiError,
   ValidationApiError,


### PR DESCRIPTION
## 概要 SlackのMarkdownプレビューをDocbaseと同じ構造・デザイン・remark-gfm・カスタムコンポーネントで統一しました。- max-w-3xlラッパーでフォーム幅も完全一致 - コンポーネント分割・再利用性向上 ## 変更内容 - SlackMarkdownPreviewをDocbaseMarkdownPreviewと同じ構造・デザイン・remark-gfm・カスタムコンポーネントで統一 - max-w-3xlラッパーでフォーム幅も完全一致 - Slack/Docbase両方のプレビュー・フォームUIを完全統一 - コンポーネント分割 ## テスト手順 1.   でMarkdownプレビューの見た目・挙動が一致すること 2. 幅・余白・ボタン・エラー表示なども完全一致すること Closes #27