### PR TITLE
feat(slack): カード形式UI・検索ハイライト・統計パネル実装によるSlackスレッドプレビュー大幅改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,434 @@
+# CLAUDE.md - プロジェクト開発ルール
+
+このドキュメントは、NotebookLM Collector プロジェクトにおけるコーディング規約とワークフローを定義したものです。
+
+## プロジェクト概要
+
+**リポジトリ**: https://github.com/sotaroNishioka/notebooklm-collector  
+**プロジェクト名**: Docbase/Slack 連携 NotebookLM 用ドキュメント生成アプリ  
+**バージョン**: v1.9
+
+### 主要機能
+
+- Docbase API からの記事検索・取得（最大 500 件）
+- Slack API からのメッセージ・スレッド検索・取得（最大 300 件）
+- 検索結果の Markdown 形式での出力
+- NotebookLM 向けドキュメント生成
+- ブラウザ完結型でセキュアな処理
+
+## TypeScript コーディング規約
+
+### 基本方針
+
+- 最初に型と、それを処理する関数のインターフェースを考える
+- コードのコメントとして、そのファイルがどういう仕様かを可能な限り明記する
+- 実装が内部状態を持たないとき、class による実装を避けて関数を優先する
+- 副作用を抽象するために、アダプタパターンで外部依存を抽象し、テストではインメモリなアダプタで処理する
+
+### 型の使用方針
+
+1. **具体的な型を使用**
+
+   - `any`の使用を避ける
+   - `unknown`を使用してから型を絞り込む
+   - Utility Types を活用する
+
+2. **型エイリアスの命名**
+
+   ```ts
+   // Good
+   type UserId = string;
+   type UserData = {
+     id: UserId;
+     createdAt: Date;
+   };
+
+   // Bad
+   type Data = any;
+   ```
+
+### エラー処理パターン
+
+1. **Result 型の使用**
+
+   ```ts
+   import { err, ok, Result } from "npm:neverthrow";
+
+   type ApiError =
+     | { type: "network"; message: string }
+     | { type: "notFound"; message: string }
+     | { type: "unauthorized"; message: string };
+
+   async function fetchUser(id: string): Promise<Result<User, ApiError>> {
+     try {
+       const response = await fetch(`/api/users/${id}`);
+       if (!response.ok) {
+         switch (response.status) {
+           case 404:
+             return err({ type: "notFound", message: "User not found" });
+           case 401:
+             return err({ type: "unauthorized", message: "Unauthorized" });
+           default:
+             return err({
+               type: "network",
+               message: `HTTP error: ${response.status}`,
+             });
+         }
+       }
+       return ok(await response.json());
+     } catch (error) {
+       return err({
+         type: "network",
+         message: error instanceof Error ? error.message : "Unknown error",
+       });
+     }
+   }
+   ```
+
+### 実装パターン
+
+1. **関数ベース（状態を持たない場合）**
+
+   ```ts
+   // インターフェース
+   interface Logger {
+     log(message: string): void;
+   }
+
+   // 実装
+   function createLogger(): Logger {
+     return {
+       log(message: string): void {
+         console.log(`[${new Date().toISOString()}] ${message}`);
+       },
+     };
+   }
+   ```
+
+2. **Adapter パターン（外部依存の抽象化）**
+
+   ```ts
+   // types/api.ts
+   export type ApiError =
+     | { type: "network"; message: string }
+     | { type: "notFound"; message: string }
+     | { type: "unauthorized"; message: string };
+
+   export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
+
+   // fetcher.ts
+   export type Fetcher = <T>(
+     path: string,
+     options?: RequestInit
+   ) => Promise<Result<T, ApiError>>;
+
+   export function createFetcher(
+     baseUrl: string,
+     defaultHeaders?: Record<string, string>
+   ): Fetcher {
+     return async <T>(path: string, options?: RequestInit) => {
+       try {
+         const res = await fetch(`${baseUrl}${path}`, {
+           ...options,
+           headers: {
+             ...(defaultHeaders || {}),
+             ...(options?.headers || {}),
+           },
+         });
+         if (!res.ok) {
+           switch (res.status) {
+             case 404:
+               return {
+                 ok: false,
+                 error: { type: "notFound", message: "Not found" },
+               };
+             case 401:
+               return {
+                 ok: false,
+                 error: { type: "unauthorized", message: "Unauthorized" },
+               };
+             default:
+               return {
+                 ok: false,
+                 error: {
+                   type: "network",
+                   message: `HTTP error: ${res.status}`,
+                 },
+               };
+           }
+         }
+         const data = (await res.json()) as T;
+         return { ok: true, value: data };
+       } catch (e) {
+         return {
+           ok: false,
+           error: {
+             type: "network",
+             message: e instanceof Error ? e.message : "Unknown error",
+           },
+         };
+       }
+     };
+   }
+   ```
+
+## プロジェクト固有の型定義
+
+### Docbase 関連型
+
+```ts
+type DocbasePostListItem = {
+  id: number;
+  title: string;
+  body: string;
+  created_at: string; // ISO-8601
+  url: string;
+};
+```
+
+### Slack 関連型
+
+```ts
+// Slackメッセージ1件分の型
+type SlackMessage = {
+  ts: string; // メッセージのタイムスタンプ（スレッドIDにもなる）
+  user: string; // ユーザーID
+  text: string; // 本文
+  thread_ts?: string; // スレッド親のts（親メッセージの場合は省略）
+  channel: { id: string; name?: string }; // チャンネル情報
+  permalink?: string; // メッセージへのパーマリンク
+};
+
+// Slackスレッド全体の型
+type SlackThread = {
+  channel: string; // チャンネルID
+  parent: SlackMessage; // 親メッセージ
+  replies: SlackMessage[]; // 返信メッセージ群
+};
+
+// Slackユーザー情報の型
+type SlackUser = {
+  id: string;
+  name: string;
+  real_name?: string;
+};
+```
+
+## Git 運用ルール
+
+### Issue テンプレート
+
+````markdown
+### 概要
+
+- [機能の概要を記載]
+
+### 受け入れ条件
+
+1. [条件 1]
+2. [条件 2]
+
+### 変更箇所候補
+
+- `src/lib/auth.ts`
+- `src/pages/login.tsx`
+
+### 実装例
+
+```ts
+await supabase.auth.signInWithOtp({ email });
+```
+````
+
+### PR テンプレート
+
+```markdown
+<!-- Pull Request #<Issue番号> feat: [タイトル] -->
+
+## 概要
+
+- Issue #<Issue 番号> の実装
+
+## 変更内容
+
+- 追加: `src/pages/login.tsx`
+- 更新: `src/lib/auth.ts`
+
+## テスト手順
+
+1. `npm run dev` を実行
+2. /login にアクセスしメールリンクでログイン
+
+## 関連 Issue
+
+- resolves #<Issue 番号>
+```
+
+### コミットメッセージ規約
+
+```
+<type>(<scope>): <短い要約>
+
+<body>         # 任意: 詳細説明
+
+<footer>       # 任意: Closes #<Issue番号>
+```
+
+- **type**: feat, fix, docs, style, refactor, perf, test, chore
+- **scope**: component, page, api, util など
+- **footer**: `Closes #<Issue番号>` を記載
+
+## 作業フロー
+
+### 1. Git コンテキストの確認
+
+```sh
+git status
+```
+
+### 2. 作業ブランチの作成
+
+```sh
+# mainブランチが最新であることを確認
+git checkout main
+git pull origin main
+
+# Issueに紐づいたブランチを作成
+# ブランチ名の形式: issue-{issue番号}-{簡潔な説明}
+git checkout -b issue-42-auth-result-type
+```
+
+### 3. 作業とコミット
+
+```sh
+# 変更をステージングとコミット
+git add .
+git commit -m "feat(auth): Result型を使った認証エラー処理の実装
+
+- neverthrowライブラリを導入
+- APIレスポンスをResult型でラップ
+- エラーケースを型安全に処理
+
+Closes #42"
+```
+
+### 4. リモートへのプッシュと PR の作成
+
+```sh
+# 作業ブランチをリモートにプッシュ
+git push -u origin issue-42-auth-result-type
+
+# GitHub CLIを使用してPRを作成
+gh pr create --title "feat(auth): Result型を使った認証エラー処理の実装" --body "## 概要
+Issue #42 の実装として、認証処理にResult型を導入しました。
+
+## 変更内容
+- neverthrowライブラリの導入
+- 認証エラーの型定義を強化
+- APIレスポンスの型安全な処理
+- テストケースの追加
+
+## テスト手順
+1. \`npm test\` でテストが通ることを確認
+2. ログイン失敗時のエラーハンドリングが適切に動作することを確認
+
+Closes #42"
+```
+
+### 5. レビューとマージ後のクリーンアップ
+
+```sh
+# mainブランチに戻る
+git checkout main
+
+# リモートの変更を取得
+git pull origin main
+
+# 作業ブランチを削除
+git branch -d issue-42-auth-result-type
+```
+
+## 技術スタック
+
+| レイヤ         | 技術                   |
+| -------------- | ---------------------- |
+| フレームワーク | Next.js 15 / React     |
+| スタイリング   | Tailwind CSS           |
+| データ取得     | fetch / TanStack Query |
+| ストレージ     | localStorage           |
+| Lint / Format  | Biome                  |
+| 型システム     | TypeScript             |
+
+## 重要な注意事項
+
+### 開発時の心構え
+
+- ユーザーは時短のためにコーディングを依頼している
+- 2 回以上連続でテストを失敗した時は、現在の状況を整理して一緒に解決方法を考える
+- コンテキストが不明瞭な時は、ユーザーに確認する
+- 実装には標準語の日本語でコメントを入れる
+- 必ず日本語で返答する
+
+### 避けるべき操作
+
+- 対話的な git コマンド（-i フラグ）の使用
+- リモートリポジトリへの直接プッシュ
+- git 設定の変更
+
+### セキュリティ考慮事項
+
+- **データ処理の範囲**: 入力された Docbase/Slack API トークンおよび取得された記事・メッセージ内容は、外部サーバーに送信されることなく、すべてユーザーのブラウザ内で処理が完結する
+- **情報漏洩リスクの低減**: データがブラウザ外に出ないため、機密情報が意図せず外部に漏洩するリスクを最小限に抑える
+- **トークンの保存**: API トークンは、利便性のためにブラウザの LocalStorage に保存されるが、これもユーザーのローカル環境に限定された保存
+
+## API 仕様
+
+### Docbase API 連携
+
+| 操作 | Endpoint                | ヘッダー         | クエリ                  |
+| ---- | ----------------------- | ---------------- | ----------------------- |
+| 検索 | `/teams/{domain}/posts` | `X-DocBaseToken` | `q`, `page`, `per_page` |
+
+#### Docbase 詳細検索条件
+
+| 条件     | Docbase API クエリ形式             | 例                                                |
+| -------- | ---------------------------------- | ------------------------------------------------- |
+| タグ     | `tag:タグ名`                       | `tag:API tag:設計` (複数指定可、カンマ区切り入力) |
+| 投稿者   | `author:ユーザーID`                | `author:user123`                                  |
+| タイトル | `title:キーワード`                 | `title:仕様書`                                    |
+| 投稿期間 | `created_at:YYYY-MM-DD~YYYY-MM-DD` | `created_at:2023-01-01~2023-12-31`                |
+| グループ | `group:グループ名`                 | `group:開発チーム`                                |
+
+### Slack API 連携
+
+| 操作         | Endpoint               | HTTPメソッド | ヘッダー                                        | パラメータ             |
+| ------------ | ---------------------- | ------------ | ----------------------------------------------- | ---------------------- |
+| メッセージ検索 | `/search.messages`     | POST         | `Content-Type: application/x-www-form-urlencoded` | `token`, `query`, `count`, `page` |
+| スレッド取得   | `/conversations.replies` | POST         | `Content-Type: application/x-www-form-urlencoded` | `token`, `channel`, `ts` |
+| パーマリンク取得 | `/chat.getPermalink`   | GET          | `Authorization: Bearer {token}`                | `channel`, `message_ts` |
+| ユーザー情報取得 | `/users.info`          | POST         | `Content-Type: application/x-www-form-urlencoded` | `token`, `user`       |
+
+#### Slack 詳細検索条件
+
+| 条件         | Slack API クエリ形式         | 例                                           |
+| ------------ | --------------------------- | -------------------------------------------- |
+| チャンネル指定 | `in:#チャンネル名`           | `in:#general`                                |
+| 投稿者指定    | `from:@ユーザー名`           | `from:@user123`                              |
+| 期間指定      | `after:YYYY-MM-DD`, `before:YYYY-MM-DD` | `after:2023-01-01 before:2023-12-31` |
+| 完全一致検索  | `"キーワード"`               | `"重要な議事録"`                             |
+
+### 機能比較
+
+| 機能           | Slack                    | Docbase                      |
+| -------------- | ------------------------ | ---------------------------- |
+| 検索方式       | スレッド単位でまとめて表示 | 記事単位で表示               |
+| 最大取得件数   | 300件（スレッド）         | 500件（記事）                |
+| 詳細検索条件   | チャンネル、投稿者、期間  | タグ、投稿者、タイトル、期間、グループ |
+| プレビュー     | 最初の10スレッドのみ      | 全記事                       |
+| 認証方式       | User Token (xoxp-)       | API Token                    |
+| ローカルストレージ | slackApiToken           | docbaseApiToken, docbaseDomain |
+
+---
+
+**最終更新**: 2025-05-28  
+**管理者**: ずんだもん（Claude Assistant）

--- a/src/app/docbase/page.tsx
+++ b/src/app/docbase/page.tsx
@@ -1,10 +1,10 @@
 'use client' // クライアントコンポーネントとしてマーク
 
-import SearchForm from '../../components/DocbaseSearchForm' // パスを修正
 import { Toaster } from 'react-hot-toast' // Toasterをインポート
+import SearchForm from '../../components/DocbaseSearchForm' // パスを修正
+import Footer from '../../components/Footer' // 変更
 // import { SparklesCore } from "../../components/ui/sparkles"; // 架空のUIコンポーネントなのだ -> 一旦コメントアウト
 import Header from '../../components/Header' // 変更
-import Footer from '../../components/Footer' // 変更
 
 export default function DocbasePage() {
   // コンポーネント名を DocbasePage に変更

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Noto_Sans_JP, Geist_Mono } from 'next/font/google'
+import { Geist_Mono, Noto_Sans_JP } from 'next/font/google'
 import './globals.css'
 // import Header from '@/components/Header'
 // import Footer from '@/components/Footer'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
 'use client' // クライアントコンポーネントとしてマーク
 
 import Link from 'next/link'
-import Header from '../components/Header'
 import Footer from '../components/Footer'
+import Header from '../components/Header'
 
 export default function HomePage() {
   return (

--- a/src/app/slack/page.tsx
+++ b/src/app/slack/page.tsx
@@ -1,73 +1,70 @@
-"use client";
+'use client'
 
-import { useState, useEffect } from "react";
-import type React from "react";
-import Header from "../../components/Header";
-import Footer from "../../components/Footer";
 import {
-  fetchSlackMessages,
   type SearchSuccessResponse,
+  fetchSlackMessages,
+  fetchSlackPermalink,
   fetchSlackThreadMessages,
   fetchSlackUserName,
-  fetchSlackPermalink,
-} from "@/lib/slackClient";
-import {
-  convertToSlackMarkdown,
-  convertToSlackThreadMarkdown,
-} from "../../lib/slackdown";
-import type { SlackMessage } from "../../types/slack";
-import { toast, Toaster } from "react-hot-toast";
-import { useDownload } from "../../hooks/useDownload";
-import { MarkdownPreview } from "../../components/DocbaseMarkdownPreview";
+} from '@/lib/slackClient'
+import { useEffect, useState } from 'react'
+import type React from 'react'
+import { Toaster, toast } from 'react-hot-toast'
+import Footer from '../../components/Footer'
+import Header from '../../components/Header'
+import { SlackMarkdownPreview } from '../../components/SlackMarkdownPreview'
+import { useDownload } from '../../hooks/useDownload'
+import { convertToSlackMarkdown, convertToSlackThreadMarkdown } from '../../lib/slackdown'
+import type { SlackMessage, SlackThread } from '../../types/slack'
 
 // タイムスタンプをフォーマットするヘルパー関数
 const formatTimestamp = (ts: string): string => {
-  const date = new Date(Number.parseFloat(ts) * 1000);
-  return date.toLocaleString("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
-};
+  const date = new Date(Number.parseFloat(ts) * 1000)
+  return date.toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
 
 // 簡単なmrkdwnをHTMLに変換する
 const formatMessageText = (text: string) => {
-  let formattedText = text;
+  let formattedText = text
 
   // HTMLエンティティをエスケープする（基本的なもののみ）
   formattedText = formattedText
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
 
   // URLをリンクに変換 (エスケープ後に実行)
   formattedText = formattedText.replace(
     /(https?:\/\/[^\s&<>"'`]+)/g, // URLの正規表現を少し安全に
     (url) =>
-      `<a href="${url}" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">${url}</a>`
-  );
+      `<a href="${url}" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">${url}</a>`,
+  )
 
   // 太字: *text* -> <strong>text</strong>
-  formattedText = formattedText.replace(/\*(.+?)\*/g, "<strong>$1</strong>");
+  formattedText = formattedText.replace(/\*(.+?)\*/g, '<strong>$1</strong>')
   // イタリック: _text_ -> <em>text</em>
-  formattedText = formattedText.replace(/_(.+?)_/g, "<em>$1</em>");
+  formattedText = formattedText.replace(/_(.+?)_/g, '<em>$1</em>')
   // 取り消し線: ~text~ -> <del>text</del>
-  formattedText = formattedText.replace(/~(.+?)~/g, "<del>$1</del>");
+  formattedText = formattedText.replace(/~(.+?)~/g, '<del>$1</del>')
   // コード: `text` -> <code>text</code>
-  formattedText = formattedText.replace(/`(.+?)`/g, "<code>$1</code>");
+  formattedText = formattedText.replace(/`(.+?)`/g, '<code>$1</code>')
   // プレーンテキストブロック: ```text``` -> <pre><code>text</code></pre>
   formattedText = formattedText.replace(
     /```([\s\S]+?)```/g,
     (match, p1) =>
       `<pre class="bg-gray-100 p-2 my-1 rounded text-sm whitespace-pre-wrap"><code>${
         p1.trim() /* .replace(/\n/g, '<br />') */
-      }</code></pre>`
-  );
+      }</code></pre>`,
+  )
 
   // 通常の改行を <br> に変換 (preブロック処理後)
   // preブロック内の改行はそのまま活かしたいので、この処理は pre の外側に適用されるようにする
@@ -75,164 +72,145 @@ const formatMessageText = (text: string) => {
   // 今回は、preブロック以外での改行はそのまま表示されることを期待し、明示的な <br> 変換は一旦見送る
 
   // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-  return <span dangerouslySetInnerHTML={{ __html: formattedText }} />;
-};
+  return <span dangerouslySetInnerHTML={{ __html: formattedText }} />
+}
 
 // thread_tsでユニーク化するユーティリティ
 function uniqByThreadTs<T extends { thread_ts: string }>(arr: T[]): T[] {
-  const seen = new Set<string>();
+  const seen = new Set<string>()
   return arr.filter((item) => {
-    if (seen.has(item.thread_ts)) return false;
-    seen.add(item.thread_ts);
-    return true;
-  });
+    if (seen.has(item.thread_ts)) return false
+    seen.add(item.thread_ts)
+    return true
+  })
 }
 
 export default function SlackPage() {
-  const [token, setToken] = useState<string>("");
-  const [searchQuery, setSearchQuery] = useState<string>("");
-  const [messages, setMessages] = useState<SlackMessage[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
-  const [paginationInfo, setPaginationInfo] = useState<
-    SearchSuccessResponse["pagination"]
-  >({
+  const [token, setToken] = useState<string>('')
+  const [searchQuery, setSearchQuery] = useState<string>('')
+  const [messages, setMessages] = useState<SlackMessage[]>([])
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+  const [paginationInfo, setPaginationInfo] = useState<SearchSuccessResponse['pagination']>({
     currentPage: 1,
     totalPages: 1,
     totalResults: 0,
     perPage: 20,
-  });
-  const [currentPreviewMarkdown, setCurrentPreviewMarkdown] =
-    useState<string>("");
-  const [startDate, setStartDate] = useState<string>("");
-  const [endDate, setEndDate] = useState<string>("");
-  const [channel, setChannel] = useState<string>("");
-  const [author, setAuthor] = useState<string>("");
-  const [showAdvanced, setShowAdvanced] = useState<boolean>(false);
-  const { isDownloading, handleDownload } = useDownload();
-  const [threadMarkdowns, setThreadMarkdowns] = useState<string[]>([]);
+  })
+  const [currentPreviewMarkdown, setCurrentPreviewMarkdown] = useState<string>('')
+  const [startDate, setStartDate] = useState<string>('')
+  const [endDate, setEndDate] = useState<string>('')
+  const [channel, setChannel] = useState<string>('')
+  const [author, setAuthor] = useState<string>('')
+  const [showAdvanced, setShowAdvanced] = useState<boolean>(false)
+  const { isDownloading, handleDownload } = useDownload()
+  const [threadMarkdowns, setThreadMarkdowns] = useState<string[]>([])
+  const [slackThreads, setSlackThreads] = useState<SlackThread[]>([])
+  const [userMaps, setUserMaps] = useState<Record<string, string>>({})
+  const [permalinkMaps, setPermalinkMaps] = useState<Record<string, string>>({})
 
   // ローカルストレージからトークンを読み込み・保存するuseEffect
   useEffect(() => {
-    const storedToken = localStorage.getItem("slackApiToken");
+    const storedToken = localStorage.getItem('slackApiToken')
     if (storedToken) {
-      setToken(storedToken);
+      setToken(storedToken)
     }
-  }, []);
+  }, [])
 
   useEffect(() => {
     if (token) {
-      localStorage.setItem("slackApiToken", token);
+      localStorage.setItem('slackApiToken', token)
     }
-  }, [token]);
+  }, [token])
 
   // 検索クエリに期間・件数を反映するヘルパー
   const buildQuery = () => {
-    let q = searchQuery.trim();
+    let q = searchQuery.trim()
     // 常に完全一致検索（ダブルクォートで囲む）
-    if (q && !(q.startsWith('"') && q.endsWith('"'))) q = `"${q}"`;
-    if (channel)
-      q += ` in:${channel.startsWith("#") ? channel : `#${channel}`}`;
-    if (author) q += ` from:${author.startsWith("@") ? author : `@${author}`}`;
-    if (startDate) q += ` after:${startDate}`;
-    if (endDate) q += ` before:${endDate}`;
-    return q;
-  };
+    if (q && !(q.startsWith('"') && q.endsWith('"'))) q = `"${q}"`
+    if (channel) q += ` in:${channel.startsWith('#') ? channel : `#${channel}`}`
+    if (author) q += ` from:${author.startsWith('@') ? author : `@${author}`}`
+    if (startDate) q += ` after:${startDate}`
+    if (endDate) q += ` before:${endDate}`
+    return q
+  }
 
   const handleFetchMessages = async () => {
     if (!token) {
-      toast.error("Slack API トークンを入力してください。");
-      return;
+      toast.error('Slack API トークンを入力してください。')
+      return
     }
     if (!searchQuery) {
-      toast.error("検索クエリを入力してください。");
-      return;
+      toast.error('検索クエリを入力してください。')
+      return
     }
 
-    setIsLoading(true);
-    setError(null);
-    setMessages([]);
-    setCurrentPreviewMarkdown("");
-    setThreadMarkdowns([]);
+    setIsLoading(true)
+    setError(null)
+    setMessages([])
+    setCurrentPreviewMarkdown('')
+    setThreadMarkdowns([])
+    setSlackThreads([])
+    setUserMaps({})
+    setPermalinkMaps({})
     setPaginationInfo((prev) => ({
       ...prev,
       currentPage: 1,
       totalPages: 1,
       totalResults: 0,
-    }));
+    }))
 
-    let currentPageInternal = 1;
-    const allFetchedMessages: SlackMessage[] = [];
-    const maxTotalMessagesToFetch = 300;
-    let totalMessagesFetchedSoFar = 0;
-    let currentApiTotalPages = 1; // APIから返される最新の総ページ数
-    let loopError = false;
+    let currentPageInternal = 1
+    const allFetchedMessages: SlackMessage[] = []
+    const maxTotalMessagesToFetch = 300
+    let totalMessagesFetchedSoFar = 0
+    let currentApiTotalPages = 1 // APIから返される最新の総ページ数
+    let loopError = false
 
-    const loadingToastId = toast.loading(
-      "Slackからメッセージを検索・取得準備中... (最大300件)"
-    );
+    const loadingToastId = toast.loading('Slackからメッセージを検索・取得準備中... (最大300件)')
 
     try {
       while (totalMessagesFetchedSoFar < maxTotalMessagesToFetch) {
         toast.loading(
           `取得中 (${totalMessagesFetchedSoFar}件 / 最大${maxTotalMessagesToFetch}件) - Page ${currentPageInternal}${
-            currentApiTotalPages > 1 ? `/${currentApiTotalPages}` : ""
+            currentApiTotalPages > 1 ? `/${currentApiTotalPages}` : ''
           }`,
-          { id: loadingToastId }
-        );
+          { id: loadingToastId },
+        )
 
         // APIから取得する件数は paginationInfo.perPage を使用
-        const result = await fetchSlackMessages(
-          token,
-          buildQuery(),
-          100,
-          currentPageInternal
-        );
+        const result = await fetchSlackMessages(token, buildQuery(), 100, currentPageInternal)
 
         if (result.isOk()) {
-          const responseData = result.value;
-          currentApiTotalPages = responseData.pagination.totalPages; // 最新の総ページ数を更新
-          setPaginationInfo(responseData.pagination); // APIからの最新のページネーション情報でstateを更新
+          const responseData = result.value
+          currentApiTotalPages = responseData.pagination.totalPages // 最新の総ページ数を更新
+          setPaginationInfo(responseData.pagination) // APIからの最新のページネーション情報でstateを更新
 
           if (responseData.messages && responseData.messages.length > 0) {
-            allFetchedMessages.push(...responseData.messages);
-            totalMessagesFetchedSoFar = allFetchedMessages.length;
-            setMessages([...allFetchedMessages]);
+            allFetchedMessages.push(...responseData.messages)
+            totalMessagesFetchedSoFar = allFetchedMessages.length
+            setMessages([...allFetchedMessages])
           } else {
-            break;
+            break
           }
 
-          if (
-            currentPageInternal >= currentApiTotalPages ||
-            totalMessagesFetchedSoFar >= maxTotalMessagesToFetch
-          ) {
-            break; // 全ページ取得完了、または最大件数に達した
+          if (currentPageInternal >= currentApiTotalPages || totalMessagesFetchedSoFar >= maxTotalMessagesToFetch) {
+            break // 全ページ取得完了、または最大件数に達した
           }
-          currentPageInternal++;
+          currentPageInternal++
         } else {
-          const apiError = result.error;
-          console.error("Slack API Error during auto-pagination:", apiError);
-          setError(
-            `エラー (Page ${currentPageInternal}, Type: ${apiError.type}): ${apiError.message}`
-          );
-          toast.error(
-            `ページ ${currentPageInternal} の取得中にエラー: ${apiError.message}`,
-            {
-              id: loadingToastId,
-              duration: 4000,
-            }
-          );
-          if (
-            apiError.type === "unauthorized" ||
-            apiError.type === "missing_scope"
-          ) {
-            toast.error(
-              "トークンが無効か、必要な権限 (search:read) がありません。",
-              { duration: 6000 }
-            );
+          const apiError = result.error
+          console.error('Slack API Error during auto-pagination:', apiError)
+          setError(`エラー (Page ${currentPageInternal}, Type: ${apiError.type}): ${apiError.message}`)
+          toast.error(`ページ ${currentPageInternal} の取得中にエラー: ${apiError.message}`, {
+            id: loadingToastId,
+            duration: 4000,
+          })
+          if (apiError.type === 'unauthorized' || apiError.type === 'missing_scope') {
+            toast.error('トークンが無効か、必要な権限 (search:read) がありません。', { duration: 6000 })
           }
-          loopError = true;
-          break; // エラーが発生したらループを抜ける
+          loopError = true
+          break // エラーが発生したらループを抜ける
         }
       }
       if (!loopError) {
@@ -242,83 +220,83 @@ export default function SlackPage() {
           allFetchedMessages.map((msg) => ({
             thread_ts: msg.thread_ts || msg.ts,
             channel: msg.channel.id,
-          }))
-        );
-        const threadMarkdowns: string[] = [];
+          })),
+        )
+        const threadMarkdowns: string[] = []
+        const threads: SlackThread[] = []
+        const globalUserMap: Record<string, string> = {}
+        const globalPermalinkMap: Record<string, string> = {}
+
         for (const { thread_ts, channel } of threadRoots) {
           // スレッド全体取得
-          const threadResult = await fetchSlackThreadMessages(
-            channel,
-            thread_ts,
-            token
-          );
-          if (!threadResult.isOk()) continue;
-          const thread = threadResult.value;
+          const threadResult = await fetchSlackThreadMessages(channel, thread_ts, token)
+          if (!threadResult.isOk()) continue
+          const thread = threadResult.value
 
           // 親・返信メッセージにpermalinkをセット
           // allFetchedMessagesから該当tsのpermalinkを探す
           const setPermalink = (msg: SlackMessage) => {
-            const found = allFetchedMessages.find((m) => m.ts === msg.ts);
-            return found?.permalink;
-          };
-          thread.parent.permalink = setPermalink(thread.parent);
+            const found = allFetchedMessages.find((m) => m.ts === msg.ts)
+            return found?.permalink
+          }
+          thread.parent.permalink = setPermalink(thread.parent)
           thread.replies = thread.replies.map((r) => ({
             ...r,
             permalink: setPermalink(r),
-          }));
+          }))
 
           // ユーザーID一覧
-          const userIds = [
-            thread.parent.user,
-            ...thread.replies.map((r) => r.user),
-          ];
-          const userMap: Record<string, string> = {};
+          const userIds = [thread.parent.user, ...thread.replies.map((r) => r.user)]
+          const userMap: Record<string, string> = {}
           for (const userId of userIds) {
-            if (userMap[userId]) continue;
-            const userResult = await fetchSlackUserName(userId, token);
-            userMap[userId] = userResult.isOk()
-              ? userResult.value.name
-              : userId;
+            if (globalUserMap[userId]) {
+              userMap[userId] = globalUserMap[userId]
+              continue
+            }
+            const userResult = await fetchSlackUserName(userId, token)
+            const userName = userResult.isOk() ? userResult.value.name : userId
+            userMap[userId] = userName
+            globalUserMap[userId] = userName
           }
-          // パーマリンク取得処理は不要
+
+          // パーマリンクマップを作成
+          const permalinkMap = Object.fromEntries([
+            [thread.parent.ts, thread.parent.permalink ?? ''],
+            ...thread.replies.map((r) => [r.ts, r.permalink ?? '']),
+          ])
+
+          // グローバルマップに追加
+          Object.assign(globalPermalinkMap, permalinkMap)
+
           // Markdown生成
-          const md = convertToSlackThreadMarkdown(
-            thread,
-            userMap,
-            // ts→permalinkマップを作る
-            Object.fromEntries([
-              [thread.parent.ts, thread.parent.permalink ?? ""],
-              ...thread.replies.map((r) => [r.ts, r.permalink ?? ""]),
-            ])
-          );
-          threadMarkdowns.push(md);
+          const md = convertToSlackThreadMarkdown(thread, userMap, permalinkMap)
+          threadMarkdowns.push(md)
+          threads.push(thread)
         }
-        setThreadMarkdowns(threadMarkdowns);
-        setCurrentPreviewMarkdown(
-          threadMarkdowns.slice(0, 10).join("\n\n---\n\n")
-        );
-        toast.success(
-          `合計 ${threadMarkdowns.length} スレッドを取得・Markdown化しました。`,
-          { id: loadingToastId }
-        );
+        setThreadMarkdowns(threadMarkdowns)
+        setSlackThreads(threads)
+        setUserMaps(globalUserMap)
+        setPermalinkMaps(globalPermalinkMap)
+        setCurrentPreviewMarkdown(threadMarkdowns.slice(0, 10).join('\n\n---\n\n'))
+        toast.success(`合計 ${threadMarkdowns.length} スレッドを取得・Markdown化しました。`, { id: loadingToastId })
       } else {
-        toast.dismiss(loadingToastId);
+        toast.dismiss(loadingToastId)
       }
     } catch (e) {
-      console.error("Unexpected error during message fetching loop:", e);
-      toast.error("メッセージの自動取得中に予期せぬエラーが発生しました。", {
+      console.error('Unexpected error during message fetching loop:', e)
+      toast.error('メッセージの自動取得中に予期せぬエラーが発生しました。', {
         id: loadingToastId,
-      });
-      setError("予期せぬエラーが発生しました。");
+      })
+      setError('予期せぬエラーが発生しました。')
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
-  };
+  }
 
   const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    handleFetchMessages();
-  };
+    event.preventDefault()
+    handleFetchMessages()
+  }
 
   return (
     <main className="flex min-h-screen flex-col text-gray-800 selection:bg-blue-100 font-sans">
@@ -326,18 +304,17 @@ export default function SlackPage() {
       <Toaster
         position="top-center"
         toastOptions={{
-          className:
-            "!border !border-gray-200 !bg-white !text-gray-700 !shadow-lg !rounded-md",
+          className: '!border !border-gray-200 !bg-white !text-gray-700 !shadow-lg !rounded-md',
           success: {
             iconTheme: {
-              primary: "#36C5F0", // Slackブルー
-              secondary: "#FFFFFF",
+              primary: '#36C5F0', // Slackブルー
+              secondary: '#FFFFFF',
             },
           },
           error: {
             iconTheme: {
-              primary: "#EF4444",
-              secondary: "#FFFFFF",
+              primary: '#EF4444',
+              secondary: '#FFFFFF',
             },
           },
         }}
@@ -359,31 +336,27 @@ export default function SlackPage() {
         {/* 使い方説明セクション */}
         <section className="w-full mt-12">
           <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-background-light">
-            <h2 className="text-3xl md:text-4xl font-bold mb-20 text-center text-gray-800">
-              利用はかんたん3ステップ
-            </h2>
+            <h2 className="text-3xl md:text-4xl font-bold mb-20 text-center text-gray-800">利用はかんたん3ステップ</h2>
             <div className="grid md:grid-cols-3 gap-x-8 gap-y-10 relative">
               {[
                 {
-                  step: "1",
-                  title: "情報を入力",
-                  description:
-                    "Slackトークン、検索キーワード、期間などを入力します。トークンは保存可能です。",
-                  icon: "⌨️",
+                  step: '1',
+                  title: '情報を入力',
+                  description: 'Slackトークン、検索キーワード、期間などを入力します。トークンは保存可能です。',
+                  icon: '⌨️',
                 },
                 {
-                  step: "2",
-                  title: "検索して生成",
+                  step: '2',
+                  title: '検索して生成',
                   description:
-                    "「検索実行」ボタンでSlackからメッセージを取得し、NotebookLM用Markdownをプレビューします。",
-                  icon: "🔍",
+                    '「検索実行」ボタンでSlackからメッセージを取得し、NotebookLM用Markdownをプレビューします。',
+                  icon: '🔍',
                 },
                 {
-                  step: "3",
-                  title: "ダウンロード",
-                  description:
-                    "生成されたMarkdownを「ダウンロード」ボタンで保存。すぐにAIに学習させられます。",
-                  icon: "💾",
+                  step: '3',
+                  title: 'ダウンロード',
+                  description: '生成されたMarkdownを「ダウンロード」ボタンで保存。すぐにAIに学習させられます。',
+                  icon: '💾',
                 },
               ].map((item) => (
                 <div key={item.step} className="text-center md:text-left">
@@ -393,12 +366,8 @@ export default function SlackPage() {
                     </span>
                     <span className="text-3xl">{item.icon}</span>
                   </div>
-                  <h3 className="text-lg font-semibold mb-2 text-gray-800">
-                    {item.title}
-                  </h3>
-                  <p className="text-gray-600 text-sm leading-relaxed">
-                    {item.description}
-                  </p>
+                  <h3 className="text-lg font-semibold mb-2 text-gray-800">{item.title}</h3>
+                  <p className="text-gray-600 text-sm leading-relaxed">{item.description}</p>
                 </div>
               ))}
             </div>
@@ -408,12 +377,9 @@ export default function SlackPage() {
         <section className="w-full mt-12">
           <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-background-light">
             <div className="text-center">
-              <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-gray-800">
-                🔒 セキュリティについて
-              </h2>
+              <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-gray-800">🔒 セキュリティについて</h2>
               <p className="text-gray-600 text-lg leading-relaxed max-w-3xl mx-auto">
-                入力されたSlack
-                APIトークンや取得したメッセージ内容は、お使いのブラウザ内でのみ処理されます。
+                入力されたSlack APIトークンや取得したメッセージ内容は、お使いのブラウザ内でのみ処理されます。
                 これらの情報が外部サーバーに送信されたり、保存されたりすることは一切ありませんので、安心してご利用いただけます。
               </p>
             </div>
@@ -423,17 +389,12 @@ export default function SlackPage() {
         <section id="main-tool-section" className="w-full my-12 bg-white">
           <div className="max-w-screen-lg mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-10 md:py-12 shadow-md rounded-lg border border-gray-200">
             <div className="px-0">
-              <h2 className="text-4xl font-bold mb-6 text-center text-gray-800">
-                Slack メッセージ検索・収集
-              </h2>
+              <h2 className="text-4xl font-bold mb-6 text-center text-gray-800">Slack メッセージ検索・収集</h2>
               <div className="max-w-3xl mx-auto">
                 <form onSubmit={handleFormSubmit} className="space-y-6">
                   <div className="space-y-4">
                     <div>
-                      <label
-                        htmlFor="searchQuery"
-                        className="block text-base font-medium text-gray-700 mb-1"
-                      >
+                      <label htmlFor="searchQuery" className="block text-base font-medium text-gray-700 mb-1">
                         検索キーワード
                       </label>
                       <input
@@ -448,10 +409,7 @@ export default function SlackPage() {
                       />
                     </div>
                     <div>
-                      <label
-                        htmlFor="token"
-                        className="block text-base font-medium text-gray-700 mb-1"
-                      >
+                      <label htmlFor="token" className="block text-base font-medium text-gray-700 mb-1">
                         Slack API トークン
                       </label>
                       <input
@@ -472,17 +430,12 @@ export default function SlackPage() {
                       onClick={() => setShowAdvanced(!showAdvanced)}
                       className="text-sm text-blue-600 hover:text-blue-800 focus:outline-none"
                     >
-                      {showAdvanced
-                        ? "詳細な条件を閉じる ▲"
-                        : "もっと詳細な条件を追加する ▼"}
+                      {showAdvanced ? '詳細な条件を閉じる ▲' : 'もっと詳細な条件を追加する ▼'}
                     </button>
                     {showAdvanced && (
                       <div className="space-y-4 p-4 border border-gray-300 rounded-md bg-gray-50">
                         <div>
-                          <label
-                            htmlFor="channel"
-                            className="block text-sm font-medium text-gray-700 mb-1"
-                          >
+                          <label htmlFor="channel" className="block text-sm font-medium text-gray-700 mb-1">
                             チャンネル (例: #general)
                           </label>
                           <input
@@ -496,10 +449,7 @@ export default function SlackPage() {
                           />
                         </div>
                         <div>
-                          <label
-                            htmlFor="author"
-                            className="block text-sm font-medium text-gray-700 mb-1"
-                          >
+                          <label htmlFor="author" className="block text-sm font-medium text-gray-700 mb-1">
                             投稿者 (例: @user)
                           </label>
                           <input
@@ -514,10 +464,7 @@ export default function SlackPage() {
                         </div>
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                           <div>
-                            <label
-                              htmlFor="startDate"
-                              className="block text-sm font-medium text-gray-700 mb-1"
-                            >
+                            <label htmlFor="startDate" className="block text-sm font-medium text-gray-700 mb-1">
                               投稿期間 (開始日)
                             </label>
                             <input
@@ -530,10 +477,7 @@ export default function SlackPage() {
                             />
                           </div>
                           <div>
-                            <label
-                              htmlFor="endDate"
-                              className="block text-sm font-medium text-gray-700 mb-1"
-                            >
+                            <label htmlFor="endDate" className="block text-sm font-medium text-gray-700 mb-1">
                               投稿期間 (終了日)
                             </label>
                             <input
@@ -553,9 +497,7 @@ export default function SlackPage() {
                     <button
                       type="submit"
                       className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-transparent shadow-sm text-sm font-medium rounded-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
-                      disabled={
-                        isLoading || isDownloading || !token || !searchQuery
-                      }
+                      disabled={isLoading || isDownloading || !token || !searchQuery}
                     >
                       {isLoading ? (
                         <>
@@ -583,22 +525,14 @@ export default function SlackPage() {
                           検索中...
                         </>
                       ) : (
-                        "検索実行"
+                        '検索実行'
                       )}
                     </button>
                     <button
                       type="button"
-                      onClick={() =>
-                        handleDownload(
-                          currentPreviewMarkdown,
-                          searchQuery,
-                          !!currentPreviewMarkdown
-                        )
-                      }
+                      onClick={() => handleDownload(currentPreviewMarkdown, searchQuery, !!currentPreviewMarkdown)}
                       className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-blue-600 shadow-sm text-sm font-medium rounded-sm text-blue-600 bg-white hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-200 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
-                      disabled={
-                        isLoading || isDownloading || !currentPreviewMarkdown
-                      }
+                      disabled={isLoading || isDownloading || !currentPreviewMarkdown}
                     >
                       {isDownloading ? (
                         <>
@@ -626,7 +560,7 @@ export default function SlackPage() {
                           生成中...
                         </>
                       ) : (
-                        "Markdownダウンロード"
+                        'Markdownダウンロード'
                       )}
                     </button>
                   </div>
@@ -655,44 +589,34 @@ export default function SlackPage() {
                     </div>
                   )}
                   {/* プレビュー */}
-                  {threadMarkdowns.length > 0 && !isLoading && !error && (
+                  {slackThreads.length > 0 && !isLoading && !error && (
                     <div className="mt-6 pt-5 border-t border-gray-200">
                       <div className="flex justify-between items-center mb-3">
                         <h3 className="text-lg font-semibold text-gray-800">
-                          スレッド単位のMarkdownプレビュー（親＋返信まとめて）
+                          スレッド単位のプレビュー（親＋返信まとめて）
                         </h3>
-                        <p className="text-sm text-gray-500">
-                          取得スレッド数: {threadMarkdowns.length}件
-                        </p>
+                        <p className="text-sm text-gray-500">取得スレッド数: {slackThreads.length}件</p>
                       </div>
-                      <MarkdownPreview markdown={currentPreviewMarkdown} />
-                      {threadMarkdowns.length > 10 && (
-                        <p className="mt-2 text-sm text-gray-500">
-                          プレビューには最初の10スレッドのみ表示されています。すべてのスレッド内容を確認・保存するには、下の「スレッド単位でMarkdownダウンロード」ボタンを使ってください。
-                        </p>
-                      )}
+                      <SlackMarkdownPreview
+                        threads={slackThreads}
+                        searchKeyword={searchQuery}
+                        userMap={userMaps}
+                        permalinkMap={permalinkMaps}
+                      />
                       <button
                         type="button"
                         onClick={() =>
-                          handleDownload(
-                            threadMarkdowns.join("\n\n---\n\n"),
-                            searchQuery,
-                            !!threadMarkdowns.length
-                          )
+                          handleDownload(threadMarkdowns.join('\n\n---\n\n'), searchQuery, !!threadMarkdowns.length)
                         }
                         className="mt-4 w-full inline-flex items-center justify-center py-2.5 px-4 border border-blue-600 shadow-sm text-sm font-medium rounded-sm text-blue-600 bg-white hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-200 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
-                        disabled={
-                          isLoading || isDownloading || !threadMarkdowns.length
-                        }
+                        disabled={isLoading || isDownloading || !threadMarkdowns.length}
                       >
-                        {isDownloading
-                          ? "生成中..."
-                          : "スレッド単位でMarkdownダウンロード"}
+                        {isDownloading ? '生成中...' : 'スレッド単位でMarkdownダウンロード'}
                       </button>
                     </div>
                   )}
                   {/* スレッドが0件のときの案内 */}
-                  {threadMarkdowns.length === 0 && !isLoading && !error && (
+                  {slackThreads.length === 0 && !isLoading && !error && (
                     <div className="mt-6 pt-5 border-t border-gray-200 text-gray-500 text-center">
                       検索条件に該当するスレッドは見つかりませんでした。
                     </div>
@@ -705,5 +629,5 @@ export default function SlackPage() {
       </div>
       <Footer />
     </main>
-  );
+  )
 }

--- a/src/components/DocbaseSearchForm.tsx
+++ b/src/components/DocbaseSearchForm.tsx
@@ -1,14 +1,14 @@
 'use client'
 
 import React, { useState, type FormEvent, useEffect, useRef } from 'react'
-import { DocbaseDomainInput } from './DocbaseDomainInput'
-import { DocbaseTokenInput } from './DocbaseTokenInput'
-import { useSearch } from '../hooks/useSearch'
 import { useDownload } from '../hooks/useDownload'
 import useLocalStorage from '../hooks/useLocalStorage'
+import { useSearch } from '../hooks/useSearch'
 import type { ApiError } from '../types/error'
 import { generateMarkdown } from '../utils/markdownGenerator'
+import { DocbaseDomainInput } from './DocbaseDomainInput'
 import { MarkdownPreview } from './DocbaseMarkdownPreview'
+import { DocbaseTokenInput } from './DocbaseTokenInput'
 
 const LOCAL_STORAGE_DOMAIN_KEY = 'docbaseDomain'
 const LOCAL_STORAGE_TOKEN_KEY = 'docbaseToken'

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -1,16 +1,14 @@
-"use client";
+'use client'
 
-import type { FC, ReactNode } from "react";
-import ReactMarkdown, {
-  type ExtraProps as ReactMarkdownExtraProps,
-} from "react-markdown";
-import remarkGfm from "remark-gfm";
+import type { FC, ReactNode } from 'react'
+import ReactMarkdown, { type ExtraProps as ReactMarkdownExtraProps } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 
 // react-markdownのカスタムコンポーネントのprops型を定義
 // BiomeのnoExplicitAnyを抑制するために、型をanyにしてコメントで説明を追加します
 
 interface MarkdownPreviewProps {
-  markdown: string;
+  markdown: string
 }
 
 /**
@@ -21,11 +19,9 @@ export const MarkdownPreview: FC<MarkdownPreviewProps> = ({ markdown }) => {
   if (!markdown) {
     return (
       <div className="p-6 bg-white rounded-lg shadow border border-gray-200 min-h-[200px] flex items-center justify-center">
-        <p className="text-gray-500">
-          ここにMarkdownプレビューが表示されます。
-        </p>
+        <p className="text-gray-500">ここにMarkdownプレビューが表示されます。</p>
       </div>
-    );
+    )
   }
 
   return (
@@ -35,10 +31,7 @@ export const MarkdownPreview: FC<MarkdownPreviewProps> = ({ markdown }) => {
         components={{
           // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
           h2: ({ node, children, ...props }: any) => (
-            <h2
-              className="text-3xl font-bold mt-8 mb-4 pb-2 border-b-2 border-primary"
-              {...props}
-            >
+            <h2 className="text-3xl font-bold mt-8 mb-4 pb-2 border-b-2 border-primary" {...props}>
               {children}
             </h2>
           ),
@@ -62,12 +55,10 @@ export const MarkdownPreview: FC<MarkdownPreviewProps> = ({ markdown }) => {
           ),
           // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
           code: ({ node, inline, className, children, ...props }: any) => {
-            const match = /language-(\w+)/.exec(className || "");
+            const match = /language-(\w+)/.exec(className || '')
             return !inline && match ? (
               <div className="my-4 bg-gray-800 rounded-md overflow-hidden shadow">
-                <div className="px-4 py-2 text-sm text-gray-300 bg-gray-700 ">
-                  {match[1]}
-                </div>
+                <div className="px-4 py-2 text-sm text-gray-300 bg-gray-700 ">{match[1]}</div>
                 <pre className="p-4 text-sm leading-relaxed overflow-x-auto text-gray-100">
                   <code {...props} className={className}>
                     {children}
@@ -77,21 +68,15 @@ export const MarkdownPreview: FC<MarkdownPreviewProps> = ({ markdown }) => {
             ) : (
               <code
                 {...props}
-                className={
-                  className ||
-                  "px-1 py-0.5 bg-gray-200 text-text rounded-sm text-sm font-mono"
-                }
+                className={className || 'px-1 py-0.5 bg-gray-200 text-text rounded-sm text-sm font-mono'}
               >
                 {children}
               </code>
-            );
+            )
           },
           // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
           a: ({ node, children, ...props }: any) => (
-            <a
-              className="text-primary hover:underline hover:text-primary-dark"
-              {...props}
-            >
+            <a className="text-primary hover:underline hover:text-primary-dark" {...props}>
               {children}
             </a>
           ),
@@ -100,5 +85,5 @@ export const MarkdownPreview: FC<MarkdownPreviewProps> = ({ markdown }) => {
         {markdown}
       </ReactMarkdown>
     </div>
-  );
-};
+  )
+}

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import React, { useState, type FormEvent, useEffect, useRef } from 'react'
-import { DocbaseDomainInput } from './DocbaseDomainInput'
-import { DocbaseTokenInput } from './DocbaseTokenInput'
-import { useSearch } from '../hooks/useSearch'
 import { useDownload } from '../hooks/useDownload'
 import useLocalStorage from '../hooks/useLocalStorage'
+import { useSearch } from '../hooks/useSearch'
 import type { ApiError } from '../types/error'
 import { generateMarkdown } from '../utils/markdownGenerator'
+import { DocbaseDomainInput } from './DocbaseDomainInput'
+import { DocbaseTokenInput } from './DocbaseTokenInput'
 import { MarkdownPreview } from './MarkdownPreview'
 
 const LOCAL_STORAGE_DOMAIN_KEY = 'docbaseDomain'

--- a/src/components/SlackMarkdownPreview.tsx
+++ b/src/components/SlackMarkdownPreview.tsx
@@ -1,102 +1,354 @@
-"use client";
+'use client'
 
-import type { FC } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import type { FC } from 'react'
+import { useMemo, useState } from 'react'
+import type { SlackThread } from '../types/slack'
 
 interface SlackMarkdownPreviewProps {
-  markdown: string;
+  threads: SlackThread[]
+  searchKeyword?: string
+  userMap: Record<string, string>
+  permalinkMap: Record<string, string>
+}
+
+interface ThreadCardProps {
+  thread: SlackThread
+  index: number
+  searchKeyword?: string
+  userMap: Record<string, string>
+  permalinkMap: Record<string, string>
+  onToggleExpansion: (threadId: string) => void
+  isExpanded: boolean
 }
 
 /**
- * Slack用Markdownプレビュー（Docbaseと同じデザイン・機能で統一）
+ * 検索キーワードをハイライト表示する関数
+ */
+const highlightKeyword = (text: string, keyword?: string): string => {
+  if (!keyword || !text) return text
+
+  const regex = new RegExp(`(${keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi')
+  return text.replace(regex, '<mark class="bg-yellow-200 px-1 rounded">$1</mark>')
+}
+
+/**
+ * タイムスタンプを相対時間に変換する関数
+ */
+const formatRelativeTime = (timestamp: string): string => {
+  const date = new Date(Number.parseFloat(timestamp) * 1000)
+  const now = new Date()
+  const diffInHours = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60))
+
+  if (diffInHours < 1) return '1時間以内'
+  if (diffInHours < 24) return `${diffInHours}時間前`
+
+  const diffInDays = Math.floor(diffInHours / 24)
+  if (diffInDays < 7) return `${diffInDays}日前`
+  if (diffInDays < 30) return `${Math.floor(diffInDays / 7)}週間前`
+
+  return date.toLocaleDateString('ja-JP')
+}
+
+/**
+ * スレッドカードコンポーネント
+ */
+const ThreadCard: FC<ThreadCardProps> = ({
+  thread,
+  index,
+  searchKeyword,
+  userMap,
+  permalinkMap,
+  onToggleExpansion,
+  isExpanded,
+}) => {
+  const parentUser = userMap[thread.parent.user] || thread.parent.user
+  const parentPermalink = permalinkMap[thread.parent.ts] || ''
+  const channelName = thread.channel || '不明なチャンネル'
+  const replyCount = thread.replies.length
+
+  // メッセージのプレビューテキスト（最初の200文字）
+  const messagePreview =
+    thread.parent.text.length > 200 ? `${thread.parent.text.substring(0, 200)}...` : thread.parent.text
+
+  return (
+    <div className="border rounded-lg p-4 bg-white shadow-sm hover:shadow-md transition-shadow mb-6">
+      {/* ヘッダー */}
+      <div className="flex justify-between items-start mb-3">
+        <div className="flex items-center space-x-2">
+          <span className="text-lg font-semibold text-gray-800">スレッド #{index + 1}</span>
+          <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">{replyCount}件の返信</span>
+          <span className="px-2 py-1 bg-green-100 text-green-800 rounded text-xs">#{channelName}</span>
+        </div>
+        <a
+          href={parentPermalink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 text-sm hover:underline"
+        >
+          📎 Slackで開く
+        </a>
+      </div>
+
+      {/* 親メッセージ情報 */}
+      <div className="mb-4">
+        <div className="flex items-center space-x-3 mb-2">
+          <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white text-sm font-bold">
+            {parentUser.charAt(0).toUpperCase()}
+          </div>
+          <div>
+            <span className="font-medium text-gray-900">{parentUser}</span>
+            <time className="text-sm text-gray-500 ml-2">{formatRelativeTime(thread.parent.ts)}</time>
+          </div>
+        </div>
+
+        {/* メッセージ内容 */}
+        <div className="text-gray-700 text-sm">
+          {isExpanded ? (
+            <div
+              className="whitespace-pre-wrap"
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: 検索キーワードハイライトのため必要
+              dangerouslySetInnerHTML={{
+                __html: highlightKeyword(thread.parent.text, searchKeyword),
+              }}
+            />
+          ) : (
+            <p
+              className="whitespace-pre-wrap"
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: 検索キーワードハイライトのため必要
+              dangerouslySetInnerHTML={{
+                __html: highlightKeyword(messagePreview, searchKeyword),
+              }}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* 返信一覧（展開時のみ）*/}
+      {isExpanded && replyCount > 0 && (
+        <div className="ml-6 border-l-2 border-gray-200 pl-4 space-y-3">
+          <h4 className="font-medium text-gray-800 mb-2">返信 ({replyCount}件)</h4>
+          {thread.replies.map((reply) => {
+            const replyUser = userMap[reply.user] || reply.user
+            const replyPermalink = permalinkMap[reply.ts] || ''
+
+            return (
+              <div key={reply.ts} className="bg-gray-50 rounded p-3">
+                <div className="flex items-center space-x-2 mb-2">
+                  <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center text-white text-xs font-bold">
+                    {replyUser.charAt(0).toUpperCase()}
+                  </div>
+                  <span className="font-medium text-gray-800 text-sm">{replyUser}</span>
+                  <time className="text-xs text-gray-500">{formatRelativeTime(reply.ts)}</time>
+                  {replyPermalink && (
+                    <a
+                      href={replyPermalink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 text-xs hover:underline"
+                    >
+                      🔗
+                    </a>
+                  )}
+                </div>
+                <div
+                  className="text-gray-700 text-sm whitespace-pre-wrap"
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: 検索キーワードハイライトのため必要
+                  dangerouslySetInnerHTML={{
+                    __html: highlightKeyword(reply.text, searchKeyword),
+                  }}
+                />
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* 展開/折りたたみボタン */}
+      <div className="mt-3 flex justify-between items-center">
+        <button type="button" onClick={() => onToggleExpansion(thread.parent.ts)} className="text-blue-600 text-sm hover:underline">
+          {isExpanded
+            ? thread.parent.text.length > 200 || replyCount > 0
+              ? '折りたたむ'
+              : ''
+            : thread.parent.text.length > 200
+              ? '続きを読む'
+              : replyCount > 0
+                ? `${replyCount}件の返信を表示`
+                : ''}
+        </button>
+        <span className="text-xs text-gray-400">{formatRelativeTime(thread.parent.ts)}</span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Slack用Markdownプレビュー（改善版）
  */
 export const SlackMarkdownPreview: FC<SlackMarkdownPreviewProps> = ({
-  markdown,
+  threads,
+  searchKeyword,
+  userMap,
+  permalinkMap,
 }) => {
-  if (!markdown) {
+  const [expandedThreads, setExpandedThreads] = useState<Set<string>>(new Set())
+  const [filterChannel, setFilterChannel] = useState<string>('')
+  const [sortBy, setSortBy] = useState<string>('date_desc')
+
+  // 展開状態の切り替え
+  const toggleExpansion = (threadId: string) => {
+    const newExpanded = new Set(expandedThreads)
+    if (newExpanded.has(threadId)) {
+      newExpanded.delete(threadId)
+    } else {
+      newExpanded.add(threadId)
+    }
+    setExpandedThreads(newExpanded)
+  }
+
+  // 統計情報の計算
+  const statistics = useMemo(() => {
+    const totalReplies = threads.reduce((sum, thread) => sum + thread.replies.length, 0)
+    const uniqueUsers = new Set(threads.flatMap((thread) => [thread.parent.user, ...thread.replies.map((r) => r.user)]))
+      .size
+    const uniqueChannels = new Set(threads.map((thread) => thread.channel)).size
+
+    const dates = threads.map((thread) => new Date(Number.parseFloat(thread.parent.ts) * 1000))
+    const oldestDate = dates.length > 0 ? Math.min(...dates.map((d) => d.getTime())) : 0
+    const newestDate = dates.length > 0 ? Math.max(...dates.map((d) => d.getTime())) : 0
+    const dateRange =
+      oldestDate && newestDate
+        ? `${new Date(oldestDate).toLocaleDateString('ja-JP')} - ${new Date(newestDate).toLocaleDateString('ja-JP')}`
+        : '不明'
+
+    return {
+      threadCount: threads.length,
+      totalReplies,
+      uniqueUsers,
+      uniqueChannels,
+      dateRange,
+    }
+  }, [threads])
+
+  // フィルタリング・ソート処理
+  const filteredAndSortedThreads = useMemo(() => {
+    let filtered = threads
+
+    // チャンネルフィルタ
+    if (filterChannel) {
+      filtered = filtered.filter((thread) => thread.channel === filterChannel)
+    }
+
+    // ソート
+    const sorted = [...filtered].sort((a, b) => {
+      switch (sortBy) {
+        case 'date_desc':
+          return Number.parseFloat(b.parent.ts) - Number.parseFloat(a.parent.ts)
+        case 'date_asc':
+          return Number.parseFloat(a.parent.ts) - Number.parseFloat(b.parent.ts)
+        case 'replies_desc':
+          return b.replies.length - a.replies.length
+        case 'replies_asc':
+          return a.replies.length - b.replies.length
+        default:
+          return 0
+      }
+    })
+
+    return sorted
+  }, [threads, filterChannel, sortBy])
+
+  // ユニークチャンネル一覧
+  const uniqueChannels = Array.from(new Set(threads.map((thread) => thread.channel)))
+
+  if (!threads || threads.length === 0) {
     return (
       <div className="p-6 bg-white rounded-lg shadow border border-gray-200 min-h-[200px] flex items-center justify-center">
-        <p className="text-gray-500">
-          ここにMarkdownプレビューが表示されます。
-        </p>
+        <p className="text-gray-500">検索条件に該当するスレッドは見つかりませんでした。</p>
       </div>
-    );
+    )
   }
+
   return (
-    <div className="p-4 rounded-md prose max-w-none prose-neutral prose-sm sm:prose-base lg:prose-lg xl:prose-xl">
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        components={{
-          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
-          h2: ({ node, children, ...props }: any) => (
-            <h2
-              className="text-3xl font-bold mt-8 mb-4 pb-2 border-b-2 border-primary"
-              {...props}
-            >
-              {children}
-            </h2>
-          ),
-          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
-          h3: ({ node, children, ...props }: any) => (
-            <h3 className="text-2xl font-bold mt-6 mb-3" {...props}>
-              {children}
-            </h3>
-          ),
-          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
-          h4: ({ node, children, ...props }: any) => (
-            <h4 className="text-xl font-bold mt-4 mb-2" {...props}>
-              {children}
-            </h4>
-          ),
-          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
-          blockquote: ({ node, children, ...props }: any) => (
-            <blockquote
-              className="my-3 pl-4 border-l-4 border-green-400 bg-green-50 text-gray-800 rounded-sm py-2"
-              {...props}
-            >
-              {children}
-            </blockquote>
-          ),
-          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
-          code: ({ node, inline, className, children, ...props }: any) => {
-            const match = /language-(\w+)/.exec(className || "");
-            return !inline && match ? (
-              <div className="my-4 bg-gray-800 rounded-md overflow-hidden shadow">
-                <div className="px-4 py-2 text-sm text-gray-300 bg-gray-700 ">
-                  {match[1]}
-                </div>
-                <pre className="p-4 text-sm leading-relaxed overflow-x-auto text-gray-100">
-                  <code {...props} className={className}>
-                    {children}
-                  </code>
-                </pre>
-              </div>
-            ) : (
-              <code
-                {...props}
-                className={
-                  className ||
-                  "px-1 py-0.5 bg-gray-200 text-text rounded-sm text-sm font-mono"
-                }
-              >
-                {children}
-              </code>
-            );
-          },
-          // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
-          a: ({ node, children, ...props }: any) => (
-            <a
-              className="text-primary hover:underline hover:text-primary-dark"
-              {...props}
-            >
-              {children}
-            </a>
-          ),
-        }}
-      >
-        {markdown}
-      </ReactMarkdown>
+    <div className="space-y-6">
+      {/* 統計情報パネル */}
+      <div className="bg-gray-50 rounded-lg p-4">
+        <h3 className="text-lg font-semibold mb-3">検索結果サマリー</h3>
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+          <div className="text-center">
+            <div className="text-2xl font-bold text-blue-600">{statistics.threadCount}</div>
+            <div className="text-sm text-gray-600">スレッド数</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-green-600">{statistics.totalReplies}</div>
+            <div className="text-sm text-gray-600">返信数</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-purple-600">{statistics.uniqueUsers}</div>
+            <div className="text-sm text-gray-600">参加者数</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-orange-600">{statistics.uniqueChannels}</div>
+            <div className="text-sm text-gray-600">チャンネル数</div>
+          </div>
+          <div className="text-center">
+            <div className="text-xs font-bold text-gray-600">{statistics.dateRange}</div>
+            <div className="text-sm text-gray-600">期間</div>
+          </div>
+        </div>
+      </div>
+
+      {/* フィルタリング・ソートコントロール */}
+      <div className="flex flex-wrap gap-3">
+        <select
+          value={filterChannel}
+          onChange={(e) => setFilterChannel(e.target.value)}
+          className="border rounded px-3 py-2 text-sm"
+        >
+          <option value="">全チャンネル</option>
+          {uniqueChannels.map((channel) => (
+            <option key={channel} value={channel}>
+              {channel}
+            </option>
+          ))}
+        </select>
+
+        <select value={sortBy} onChange={(e) => setSortBy(e.target.value)} className="border rounded px-3 py-2 text-sm">
+          <option value="date_desc">新しい順</option>
+          <option value="date_asc">古い順</option>
+          <option value="replies_desc">返信数（多い順）</option>
+          <option value="replies_asc">返信数（少ない順）</option>
+        </select>
+
+        {filteredAndSortedThreads.length !== threads.length && (
+          <span className="flex items-center text-sm text-gray-600">
+            {filteredAndSortedThreads.length} / {threads.length} スレッドを表示中
+          </span>
+        )}
+      </div>
+
+      {/* スレッド一覧 */}
+      <div className="space-y-4">
+        {filteredAndSortedThreads.map((thread, index) => (
+          <ThreadCard
+            key={thread.parent.ts}
+            thread={thread}
+            index={index}
+            searchKeyword={searchKeyword}
+            userMap={userMap}
+            permalinkMap={permalinkMap}
+            onToggleExpansion={toggleExpansion}
+            isExpanded={expandedThreads.has(thread.parent.ts)}
+          />
+        ))}
+      </div>
+
+      {filteredAndSortedThreads.length > 10 && (
+        <div className="text-center text-sm text-gray-600 mt-6">
+          プレビューには最初の{Math.min(10, filteredAndSortedThreads.length)}スレッドのみ表示されています。
+          すべてのスレッド内容を確認・保存するには、「Markdownダウンロード」ボタンを使ってください。
+        </div>
+      )}
     </div>
-  );
-};
+  )
+}

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -1,6 +1,6 @@
-import { useState, useCallback } from 'react'
-import { downloadMarkdownFile } from '../utils/fileDownloader'
+import { useCallback, useState } from 'react'
 import toast from 'react-hot-toast'
+import { downloadMarkdownFile } from '../utils/fileDownloader'
 
 interface UseDownloadResult {
   isDownloading: boolean

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 /**
  * localStorageと値を同期するためのカスタムフック

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,9 +1,9 @@
-import { useState, useCallback } from 'react'
+import type { Result } from 'neverthrow' // Resultを型としてインポート (typeキーワードを明示)
+import { useCallback, useState } from 'react'
+import toast from 'react-hot-toast' // react-hot-toastをインポート
 import { fetchDocbasePosts } from '../lib/docbaseClient'
 import type { DocbasePostListItem } from '../types/docbase'
 import type { ApiError } from '../types/error'
-import type { Result } from 'neverthrow' // Resultを型としてインポート (typeキーワードを明示)
-import toast from 'react-hot-toast' // react-hot-toastをインポート
 
 // 詳細検索条件の型定義
 export interface AdvancedFilters {

--- a/src/lib/docbaseClient.ts
+++ b/src/lib/docbaseClient.ts
@@ -1,14 +1,14 @@
-import { ok, err, type Result } from 'neverthrow'
-import type { DocbasePostsResponse, DocbasePostListItem } from '../types/docbase'
+import { type Result, err, ok } from 'neverthrow'
+import type { AdvancedFilters } from '../hooks/useSearch'
+import type { DocbasePostListItem, DocbasePostsResponse } from '../types/docbase'
 import type {
   ApiError,
   NetworkApiError,
-  UnknownApiError,
-  UnauthorizedApiError,
   NotFoundApiError,
   RateLimitApiError,
+  UnauthorizedApiError,
+  UnknownApiError,
 } from '../types/error'
-import type { AdvancedFilters } from '../hooks/useSearch'
 
 const DOCBASE_API_BASE_URL = 'https://api.docbase.io/teams'
 const MAX_RETRIES = 3

--- a/src/lib/slackClient.ts
+++ b/src/lib/slackClient.ts
@@ -1,30 +1,30 @@
-import type { Result } from "neverthrow";
-import { err, ok } from "neverthrow";
-import type { SlackMessage, SlackThread, SlackUser } from "../types/slack";
+import type { Result } from 'neverthrow'
+import { err, ok } from 'neverthrow'
 // ApiError と個別のエラー型を src/types/error.ts からインポート
 import type {
-  NetworkApiError,
-  UnknownApiError,
-  UnauthorizedApiError,
-  RateLimitApiError,
   ApiError,
-  ValidationApiError,
   MissingScopeApiError,
-  SlackSpecificApiError,
+  NetworkApiError,
   NotFoundApiError,
-} from "../types/error";
+  RateLimitApiError,
+  SlackSpecificApiError,
+  UnauthorizedApiError,
+  UnknownApiError,
+  ValidationApiError,
+} from '../types/error'
+import type { SlackMessage, SlackThread, SlackUser } from '../types/slack'
 
-const SLACK_API_BASE_URL = "https://slack.com/api";
+const SLACK_API_BASE_URL = 'https://slack.com/api'
 
 // 成功時のレスポンスの型 (新しい構造)
 export interface SearchSuccessResponse {
-  messages: SlackMessage[];
+  messages: SlackMessage[]
   pagination: {
-    currentPage: number;
-    totalPages: number;
-    totalResults: number;
-    perPage: number;
-  };
+    currentPage: number
+    totalPages: number
+    totalResults: number
+    perPage: number
+  }
 }
 
 /**
@@ -40,13 +40,13 @@ export const fetchSlackMessages = async (
   token: string,
   query: string,
   count = 20,
-  page = 1
+  page = 1,
 ): Promise<Result<SearchSuccessResponse, ApiError>> => {
   if (!token || !query) {
     return err({
-      type: "validation",
-      message: "トークンと検索クエリは必須です。",
-    } as ValidationApiError);
+      type: 'validation',
+      message: 'トークンと検索クエリは必須です。',
+    } as ValidationApiError)
   }
 
   const params = new URLSearchParams({
@@ -54,153 +54,125 @@ export const fetchSlackMessages = async (
     query,
     count: count.toString(),
     page: page.toString(),
-  });
+  })
 
   try {
     // POSTメソッドに変更し、Content-Type を application/x-www-form-urlencoded に設定
     const response = await fetch(`${SLACK_API_BASE_URL}/search.messages`, {
-      method: "POST",
+      method: 'POST',
       headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: params.toString(), // パラメータをボディに設定
-    });
+    })
 
     if (!response.ok) {
-      let errorPayload: { error?: string } = {};
+      let errorPayload: { error?: string } = {}
       try {
-        errorPayload = await response.json();
+        errorPayload = await response.json()
       } catch (e) {
         // JSONパースエラーの場合は、ステータスコードのみでエラーを返す
       }
-      const errorMessage =
-        errorPayload?.error || `APIリクエスト失敗: ${response.status}`;
+      const errorMessage = errorPayload?.error || `APIリクエスト失敗: ${response.status}`
       if (response.status === 401) {
         return err({
-          type: "unauthorized",
-          message: "Slack APIトークンが無効です。",
-        } as UnauthorizedApiError);
+          type: 'unauthorized',
+          message: 'Slack APIトークンが無効です。',
+        } as UnauthorizedApiError)
       }
       if (response.status === 429) {
         return err({
-          type: "rate_limit",
-          message: "APIレート制限に達しました。",
-        } as RateLimitApiError);
+          type: 'rate_limit',
+          message: 'APIレート制限に達しました。',
+        } as RateLimitApiError)
       }
-      return err({ type: "network", message: errorMessage } as NetworkApiError);
+      return err({ type: 'network', message: errorMessage } as NetworkApiError)
     }
 
-    const data: unknown = await response.json();
-    if (!data || typeof data !== "object") {
+    const data: unknown = await response.json()
+    if (!data || typeof data !== 'object') {
       return err({
-        type: "unknown",
-        message: "不明なエラーが発生しました。",
-      } as UnknownApiError);
+        type: 'unknown',
+        message: '不明なエラーが発生しました。',
+      } as UnknownApiError)
     }
-    const obj = data as Record<string, unknown>;
-    if (!("ok" in obj) || obj.ok !== true) {
-      const errorVal =
-        "error" in obj && typeof obj.error === "string" ? obj.error : undefined;
+    const obj = data as Record<string, unknown>
+    if (!('ok' in obj) || obj.ok !== true) {
+      const errorVal = 'error' in obj && typeof obj.error === 'string' ? obj.error : undefined
       if (
-        errorVal === "invalid_auth" ||
-        errorVal === "not_authed" ||
-        errorVal === "token_revoked" ||
-        errorVal === "account_inactive"
+        errorVal === 'invalid_auth' ||
+        errorVal === 'not_authed' ||
+        errorVal === 'token_revoked' ||
+        errorVal === 'account_inactive'
       ) {
         return err({
-          type: "unauthorized",
+          type: 'unauthorized',
           message: `Slack認証エラー: ${errorVal}`,
-        } as UnauthorizedApiError);
+        } as UnauthorizedApiError)
       }
-      if (
-        typeof errorVal === "string" &&
-        errorVal.startsWith("missing_scope")
-      ) {
+      if (typeof errorVal === 'string' && errorVal.startsWith('missing_scope')) {
         return err({
-          type: "missing_scope",
+          type: 'missing_scope',
           message: `必要なスコープがありません: ${errorVal}`,
-        } as MissingScopeApiError);
+        } as MissingScopeApiError)
       }
       return err({
-        type: "slack_api",
-        message: errorVal || "Slack APIエラーが発生しました。",
-      } as SlackSpecificApiError);
+        type: 'slack_api',
+        message: errorVal || 'Slack APIエラーが発生しました。',
+      } as SlackSpecificApiError)
     }
     // messagesプロパティの存在チェック
-    let messages: SlackMessage[] = [];
-    let paginationData: Record<string, unknown> | undefined = undefined;
-    if (
-      "messages" in obj &&
-      typeof obj.messages === "object" &&
-      obj.messages !== null
-    ) {
-      const msgObj = obj.messages as Record<string, unknown>;
-      if ("matches" in msgObj && Array.isArray(msgObj.matches)) {
+    let messages: SlackMessage[] = []
+    let paginationData: Record<string, unknown> | undefined = undefined
+    if ('messages' in obj && typeof obj.messages === 'object' && obj.messages !== null) {
+      const msgObj = obj.messages as Record<string, unknown>
+      if ('matches' in msgObj && Array.isArray(msgObj.matches)) {
         messages = msgObj.matches.map((m: unknown) => {
-          const mm = m as { [key: string]: unknown };
+          const mm = m as { [key: string]: unknown }
           return {
-            ts: typeof mm.ts === "string" ? mm.ts : "",
-            user: typeof mm.user === "string" ? mm.user : "",
-            text: typeof mm.text === "string" ? mm.text : "",
-            thread_ts:
-              typeof mm.thread_ts === "string" ? mm.thread_ts : undefined,
+            ts: typeof mm.ts === 'string' ? mm.ts : '',
+            user: typeof mm.user === 'string' ? mm.user : '',
+            text: typeof mm.text === 'string' ? mm.text : '',
+            thread_ts: typeof mm.thread_ts === 'string' ? mm.thread_ts : undefined,
             channel:
-              mm.channel &&
-              typeof mm.channel === "object" &&
-              mm.channel !== null &&
-              "id" in mm.channel
+              mm.channel && typeof mm.channel === 'object' && mm.channel !== null && 'id' in mm.channel
                 ? {
                     id: (mm.channel as { id: string }).id,
                     name: (mm.channel as { name?: string }).name,
                   }
-                : { id: "", name: undefined },
-            permalink:
-              typeof mm.permalink === "string" ? mm.permalink : undefined,
-          };
-        });
+                : { id: '', name: undefined },
+            permalink: typeof mm.permalink === 'string' ? mm.permalink : undefined,
+          }
+        })
       }
-      if (
-        "pagination" in msgObj &&
-        typeof msgObj.pagination === "object" &&
-        msgObj.pagination !== null
-      ) {
-        paginationData = msgObj.pagination as Record<string, unknown>;
+      if ('pagination' in msgObj && typeof msgObj.pagination === 'object' && msgObj.pagination !== null) {
+        paginationData = msgObj.pagination as Record<string, unknown>
       }
     }
     const responsePagination = {
-      currentPage:
-        typeof paginationData?.page === "number" ? paginationData.page : 1,
-      totalPages:
-        typeof paginationData?.page_count === "number"
-          ? paginationData.page_count
-          : 1,
-      totalResults:
-        typeof paginationData?.total_count === "number"
-          ? paginationData.total_count
-          : 0,
-      perPage:
-        typeof paginationData?.per_page === "number"
-          ? paginationData.per_page
-          : count,
-    };
-    return ok({ messages, pagination: responsePagination });
+      currentPage: typeof paginationData?.page === 'number' ? paginationData.page : 1,
+      totalPages: typeof paginationData?.page_count === 'number' ? paginationData.page_count : 1,
+      totalResults: typeof paginationData?.total_count === 'number' ? paginationData.total_count : 0,
+      perPage: typeof paginationData?.per_page === 'number' ? paginationData.per_page : count,
+    }
+    return ok({ messages, pagination: responsePagination })
   } catch (e) {
-    console.error("fetchSlackMessages Error:", e);
+    console.error('fetchSlackMessages Error:', e)
     if (e instanceof Error) {
-      if (e.message.toLowerCase().includes("failed to fetch")) {
+      if (e.message.toLowerCase().includes('failed to fetch')) {
         return err({
-          type: "network",
-          message: "ネットワーク接続に失敗しました。",
-        } as NetworkApiError);
+          type: 'network',
+          message: 'ネットワーク接続に失敗しました。',
+        } as NetworkApiError)
       }
-      return err({ type: "unknown", message: e.message } as UnknownApiError);
+      return err({ type: 'unknown', message: e.message } as UnknownApiError)
     }
     return err({
-      type: "unknown",
-      message: "不明なエラーが発生しました。",
-    } as UnknownApiError);
+      type: 'unknown',
+      message: '不明なエラーが発生しました。',
+    } as UnknownApiError)
   }
-};
+}
 
 /**
  * Slackのスレッド全体（親＋返信）を取得する関数
@@ -211,73 +183,66 @@ export const fetchSlackMessages = async (
 export async function fetchSlackThreadMessages(
   channel: string,
   threadTs: string,
-  token: string
+  token: string,
 ): Promise<Result<SlackThread, ApiError>> {
   try {
     // conversations.replies でスレッド全体を取得（POST, form-urlencoded, tokenもbodyに含める）
-    const url = `${SLACK_API_BASE_URL}/conversations.replies`;
+    const url = `${SLACK_API_BASE_URL}/conversations.replies`
     const params = new URLSearchParams({
       token,
       channel,
       ts: threadTs,
-    });
+    })
     const res = await fetch(url, {
-      method: "POST",
+      method: 'POST',
       headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: params.toString(),
-    });
-    const data = await res.json();
+    })
+    const data = await res.json()
     if (!data.ok) {
-      if (
-        data.error === "not_authed" ||
-        data.error === "invalid_auth" ||
-        data.error === "token_revoked"
-      ) {
+      if (data.error === 'not_authed' || data.error === 'invalid_auth' || data.error === 'token_revoked') {
         const error: UnauthorizedApiError = {
-          type: "unauthorized",
-          message: "Slack APIトークンが無効です。",
-        };
-        return err(error);
+          type: 'unauthorized',
+          message: 'Slack APIトークンが無効です。',
+        }
+        return err(error)
       }
-      if (
-        data.error === "channel_not_found" ||
-        data.error === "thread_not_found"
-      ) {
+      if (data.error === 'channel_not_found' || data.error === 'thread_not_found') {
         const error: NotFoundApiError = {
-          type: "notFound",
-          message: "チャンネルまたはスレッドが見つかりません。",
-        };
-        return err(error);
+          type: 'notFound',
+          message: 'チャンネルまたはスレッドが見つかりません。',
+        }
+        return err(error)
       }
       const error: NetworkApiError = {
-        type: "network",
+        type: 'network',
         message: `Slack APIエラー: ${data.error}`,
-      };
-      return err(error);
+      }
+      return err(error)
     }
     // 親メッセージ＋返信を分離
     const messages: SlackMessage[] = data.messages.map((m: unknown) => {
-      const msg = m as Partial<SlackMessage>;
+      const msg = m as Partial<SlackMessage>
       return {
-        ts: msg.ts ?? "",
-        user: msg.user ?? "",
-        text: msg.text ?? "",
+        ts: msg.ts ?? '',
+        user: msg.user ?? '',
+        text: msg.text ?? '',
         thread_ts: msg.thread_ts,
         channel: { id: channel },
         permalink: undefined,
-      };
-    });
-    const parent = messages[0];
-    const replies = messages.slice(1);
-    return ok({ channel, parent, replies });
+      }
+    })
+    const parent = messages[0]
+    const replies = messages.slice(1)
+    return ok({ channel, parent, replies })
   } catch (e) {
     const error: NetworkApiError = {
-      type: "network",
-      message: e instanceof Error ? e.message : "Slack APIリクエスト失敗",
-    };
-    return err(error);
+      type: 'network',
+      message: e instanceof Error ? e.message : 'Slack APIリクエスト失敗',
+    }
+    return err(error)
   }
 }
 
@@ -290,54 +255,47 @@ export async function fetchSlackThreadMessages(
 export async function fetchSlackPermalink(
   channel: string,
   messageTs: string,
-  token: string
+  token: string,
 ): Promise<Result<string, ApiError>> {
   try {
     const url = `${SLACK_API_BASE_URL}/chat.getPermalink?channel=${encodeURIComponent(
-      channel
-    )}&message_ts=${encodeURIComponent(messageTs)}`;
+      channel,
+    )}&message_ts=${encodeURIComponent(messageTs)}`
     const res = await fetch(url, {
       headers: {
         Authorization: `Bearer ${token}`,
-        "Content-Type": "application/x-www-form-urlencoded",
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
-    });
-    const data = await res.json();
+    })
+    const data = await res.json()
     if (!data.ok) {
-      if (
-        data.error === "not_authed" ||
-        data.error === "invalid_auth" ||
-        data.error === "token_revoked"
-      ) {
+      if (data.error === 'not_authed' || data.error === 'invalid_auth' || data.error === 'token_revoked') {
         const error: UnauthorizedApiError = {
-          type: "unauthorized",
-          message: "Slack APIトークンが無効です。",
-        };
-        return err(error);
+          type: 'unauthorized',
+          message: 'Slack APIトークンが無効です。',
+        }
+        return err(error)
       }
-      if (
-        data.error === "channel_not_found" ||
-        data.error === "message_not_found"
-      ) {
+      if (data.error === 'channel_not_found' || data.error === 'message_not_found') {
         const error: NotFoundApiError = {
-          type: "notFound",
-          message: "チャンネルまたはメッセージが見つかりません。",
-        };
-        return err(error);
+          type: 'notFound',
+          message: 'チャンネルまたはメッセージが見つかりません。',
+        }
+        return err(error)
       }
       const error: NetworkApiError = {
-        type: "network",
+        type: 'network',
         message: `Slack APIエラー: ${data.error}`,
-      };
-      return err(error);
+      }
+      return err(error)
     }
-    return ok(data.permalink as string);
+    return ok(data.permalink as string)
   } catch (e) {
     const error: NetworkApiError = {
-      type: "network",
-      message: e instanceof Error ? e.message : "Slack APIリクエスト失敗",
-    };
-    return err(error);
+      type: 'network',
+      message: e instanceof Error ? e.message : 'Slack APIリクエスト失敗',
+    }
+    return err(error)
   }
 }
 
@@ -346,60 +304,53 @@ export async function fetchSlackPermalink(
  * @param userId ユーザーID
  * @param token Slack APIトークン
  */
-export async function fetchSlackUserName(
-  userId: string,
-  token: string
-): Promise<Result<SlackUser, ApiError>> {
+export async function fetchSlackUserName(userId: string, token: string): Promise<Result<SlackUser, ApiError>> {
   try {
-    const url = `${SLACK_API_BASE_URL}/users.info`;
+    const url = `${SLACK_API_BASE_URL}/users.info`
     const params = new URLSearchParams({
       token,
       user: userId,
-    });
+    })
     const res = await fetch(url, {
-      method: "POST",
+      method: 'POST',
       headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: params.toString(),
-    });
-    const data = await res.json();
+    })
+    const data = await res.json()
     if (!data.ok) {
-      if (
-        data.error === "not_authed" ||
-        data.error === "invalid_auth" ||
-        data.error === "token_revoked"
-      ) {
+      if (data.error === 'not_authed' || data.error === 'invalid_auth' || data.error === 'token_revoked') {
         const error: UnauthorizedApiError = {
-          type: "unauthorized",
-          message: "Slack APIトークンが無効です。",
-        };
-        return err(error);
+          type: 'unauthorized',
+          message: 'Slack APIトークンが無効です。',
+        }
+        return err(error)
       }
-      if (data.error === "user_not_found") {
+      if (data.error === 'user_not_found') {
         const error: NotFoundApiError = {
-          type: "notFound",
-          message: "ユーザーが見つかりません。",
-        };
-        return err(error);
+          type: 'notFound',
+          message: 'ユーザーが見つかりません。',
+        }
+        return err(error)
       }
       const error: NetworkApiError = {
-        type: "network",
+        type: 'network',
         message: `Slack APIエラー: ${data.error}`,
-      };
-      return err(error);
+      }
+      return err(error)
     }
     const user: SlackUser = {
       id: data.user.id,
       name: data.user.name,
       real_name: data.user.real_name,
-    };
-    return ok(user);
+    }
+    return ok(user)
   } catch (e) {
     const error: NetworkApiError = {
-      type: "network",
-      message: e instanceof Error ? e.message : "Slack APIリクエスト失敗",
-    };
-    return err(error);
+      type: 'network',
+      message: e instanceof Error ? e.message : 'Slack APIリクエスト失敗',
+    }
+    return err(error)
   }
 }

--- a/src/lib/slackdown.ts
+++ b/src/lib/slackdown.ts
@@ -1,4 +1,4 @@
-import type { SlackMessage, SlackThread, SlackUser } from "../types/slack";
+import type { SlackMessage, SlackThread, SlackUser } from '../types/slack'
 
 /**
  * SlackメッセージオブジェクトをMarkdown文字列に変換します。
@@ -7,31 +7,31 @@ import type { SlackMessage, SlackThread, SlackUser } from "../types/slack";
  * @returns Markdown形式の文字列
  */
 export const convertToSlackMarkdown = (message: SlackMessage): string => {
-  const { ts, user, text } = message;
+  const { ts, user, text } = message
 
   // タイムスタンプをDateオブジェクトに変換
-  const date = new Date(Number.parseFloat(ts) * 1000);
+  const date = new Date(Number.parseFloat(ts) * 1000)
   // YYYY-MM-DD HH:mm:ss 形式の文字列にフォーマット
   const formattedTimestamp = date
-    .toLocaleString("ja-JP", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
+    .toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
     })
-    .replace(/\//g, "-"); // スラッシュをハイフンに置換
+    .replace(/\//g, '-') // スラッシュをハイフンに置換
 
-  const markdownText = text || ""; // textがundefinedの場合は空文字に
+  const markdownText = text || '' // textがundefinedの場合は空文字に
 
   return `---
 Timestamp: ${formattedTimestamp}
-User: ${user || "N/A"}
+User: ${user || 'N/A'}
 ---
 
-${markdownText}`;
-};
+${markdownText}`
+}
 
 /**
  * Slackスレッド全体をMarkdown形式に変換する関数
@@ -43,59 +43,59 @@ ${markdownText}`;
 export function convertToSlackThreadMarkdown(
   thread: SlackThread,
   userMap: Record<string, string>,
-  permalinkMap: Record<string, string>
+  permalinkMap: Record<string, string>,
 ): string {
   // ユーザー名取得ヘルパー
-  const getUserName = (userId: string) => userMap[userId] || userId;
+  const getUserName = (userId: string) => userMap[userId] || userId
   // パーマリンク取得ヘルパー
-  const getPermalink = (ts: string) => permalinkMap[ts] || "";
+  const getPermalink = (ts: string) => permalinkMap[ts] || ''
 
   // 親メッセージ
-  const parent = thread.parent;
-  const parentUser = getUserName(parent.user);
-  const parentPermalink = getPermalink(parent.ts);
+  const parent = thread.parent
+  const parentUser = getUserName(parent.user)
+  const parentPermalink = getPermalink(parent.ts)
   // タイムスタンプをYYYY/MM/DD HH:mm:ss形式で
-  const parentDate = new Date(Number.parseFloat(parent.ts) * 1000);
-  const parentTimestamp = parentDate.toLocaleString("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    timeZone: "Asia/Tokyo",
-  });
+  const parentDate = new Date(Number.parseFloat(parent.ts) * 1000)
+  const parentTimestamp = parentDate.toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZone: 'Asia/Tokyo',
+  })
 
-  let md = "---  \n";
-  md += "## スレッド  \n";
-  md += `**Permalink:** [スレッド代表パーマリンク](${parentPermalink})\n`;
+  let md = '---  \n'
+  md += '## スレッド  \n'
+  md += `**Permalink:** [スレッド代表パーマリンク](${parentPermalink})\n`
 
-  md += "### ▶ 親メッセージ  \n";
-  md += `- **ユーザー:** ${parentUser}  \n`;
-  md += `- **タイムスタンプ:** ${parentTimestamp}  \n`;
-  md += `> ${parent.text.replace(/\n/g, "\n> ")}\n\n`;
+  md += '### ▶ 親メッセージ  \n'
+  md += `- **ユーザー:** ${parentUser}  \n`
+  md += `- **タイムスタンプ:** ${parentTimestamp}  \n`
+  md += `> ${parent.text.replace(/\n/g, '\n> ')}\n\n`
 
-  md += "### 🔄 返信一覧  \n";
+  md += '### 🔄 返信一覧  \n'
   if (thread.replies.length === 0) {
-    md += "> _返信はまだありません_\n";
+    md += '> _返信はまだありません_\n'
   } else {
     for (const reply of thread.replies) {
-      const replyUser = getUserName(reply.user);
-      const replyDate = new Date(Number.parseFloat(reply.ts) * 1000);
-      const replyTimestamp = replyDate.toLocaleString("ja-JP", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        timeZone: "Asia/Tokyo",
-      });
-      md += `- **ユーザー:** ${replyUser}  \n`;
-      md += `- **タイムスタンプ:** ${replyTimestamp}  \n`;
-      md += `> ${reply.text.replace(/\n/g, "\n> ")}\n\n`;
+      const replyUser = getUserName(reply.user)
+      const replyDate = new Date(Number.parseFloat(reply.ts) * 1000)
+      const replyTimestamp = replyDate.toLocaleString('ja-JP', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        timeZone: 'Asia/Tokyo',
+      })
+      md += `- **ユーザー:** ${replyUser}  \n`
+      md += `- **タイムスタンプ:** ${replyTimestamp}  \n`
+      md += `> ${reply.text.replace(/\n/g, '\n> ')}\n\n`
     }
   }
-  md += "---\n";
-  return md;
+  md += '---\n'
+  return md
 }

--- a/src/types/slack.ts
+++ b/src/types/slack.ts
@@ -4,29 +4,29 @@
  * Slackメッセージ1件分の型
  */
 export type SlackMessage = {
-  ts: string; // メッセージのタイムスタンプ（スレッドIDにもなる）
-  user: string; // ユーザーID
-  text: string; // 本文
-  thread_ts?: string; // スレッド親のts（親メッセージの場合は省略）
-  channel: { id: string; name?: string }; // チャンネル情報（id, name）
-  permalink?: string; // メッセージへのパーマリンク
+  ts: string // メッセージのタイムスタンプ（スレッドIDにもなる）
+  user: string // ユーザーID
+  text: string // 本文
+  thread_ts?: string // スレッド親のts（親メッセージの場合は省略）
+  channel: { id: string; name?: string } // チャンネル情報（id, name）
+  permalink?: string // メッセージへのパーマリンク
   // 必要に応じて他のフィールドも追加
-};
+}
 
 /**
  * Slackスレッド全体の型
  */
 export type SlackThread = {
-  channel: string; // チャンネルID
-  parent: SlackMessage; // 親メッセージ
-  replies: SlackMessage[]; // 返信メッセージ群
-};
+  channel: string // チャンネルID
+  parent: SlackMessage // 親メッセージ
+  replies: SlackMessage[] // 返信メッセージ群
+}
 
 /**
  * Slackユーザー情報の型
  */
 export type SlackUser = {
-  id: string;
-  name: string;
-  real_name?: string;
-};
+  id: string
+  name: string
+  real_name?: string
+}


### PR DESCRIPTION
## 概要

Issue #40 の実装として、SlackスレッドプレビューのUI/UXを大幅に改善しました。

## 変更内容

### 主要機能追加
- **カード形式レイアウト**: 各スレッドを個別のカードで表示
- **検索キーワードハイライト**: 検索語句を視覚的に強調表示
- **ユーザー情報表示**: アバター付きユーザー名表示
- **統計情報パネル**: 総スレッド数・メッセージ数・期間の概要表示
- **展開/折りたたみ機能**: スレッド詳細の表示切り替え
- **フィルタリング機能**: チャンネル別絞り込み
- **ソート機能**: 日付順・返信数順の並び替え

### 技術的改善
- `SlackMarkdownPreview.tsx`の完全書き直し
- `ThreadCard`コンポーネントによる構造化
- 状態管理の最適化（threads, userMap, permalinkMap）
- TypeScript型安全性の向上

### コード品質向上
- Biome自動フォーマッティング適用
- インポート順序・コーディング規約統一

## テスト手順

1. `npm run dev` でローカル開発サーバーを起動
2. `/slack` ページにアクセス
3. Slack APIトークンを入力して検索実行
4. 新しいカード形式UIでスレッド表示を確認
5. 以下の機能をテスト:
   - [ ] 検索キーワードのハイライト表示
   - [ ] スレッドの展開/折りたたみ
   - [ ] 統計情報パネルの表示
   - [ ] チャンネル別フィルタリング
   - [ ] ソート機能（日付・返信数）
   - [ ] レスポンシブデザイン

## 関連Issue

Closes #40

🤖 Generated with [Claude Code](https://claude.ai/code)