### PR TITLE
feat(markdown): LLM・NotebookLM向けMarkdown出力形式の最適化実装

### DIFF
--- a/src/components/DocbaseSearchForm.tsx
+++ b/src/components/DocbaseSearchForm.tsx
@@ -50,12 +50,12 @@ const SearchForm = () => {
 
   useEffect(() => {
     if (posts && posts.length > 0) {
-      const md = generateMarkdown(posts.slice(0, 10))
+      const md = generateMarkdown(posts.slice(0, 10), keyword)
       setMarkdownContent(md)
     } else {
       setMarkdownContent('')
     }
-  }, [posts])
+  }, [posts, keyword])
 
   useEffect(() => {
     if (error?.type === 'unauthorized') {
@@ -65,7 +65,13 @@ const SearchForm = () => {
 
   const handleDownloadClick = () => {
     const postsExist = posts && posts.length > 0
-    handleDownload(markdownContent, keyword, postsExist)
+    if (postsExist) {
+      // ダウンロード時は全件のMarkdownを生成
+      const fullMarkdown = generateMarkdown(posts, keyword)
+      handleDownload(fullMarkdown, keyword, postsExist, 'docbase')
+    } else {
+      handleDownload(markdownContent, keyword, postsExist, 'docbase')
+    }
   }
 
   const renderErrorCause = (currentError: ApiError | null) => {

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -4,7 +4,7 @@ import { downloadMarkdownFile } from '../utils/fileDownloader'
 
 interface UseDownloadResult {
   isDownloading: boolean
-  handleDownload: (markdownContent: string, keyword: string, postsExist: boolean) => Promise<void>
+  handleDownload: (markdownContent: string, keyword: string, postsExist: boolean, sourceType?: 'docbase' | 'slack') => Promise<void>
 }
 
 /**
@@ -13,11 +13,11 @@ interface UseDownloadResult {
 export const useDownload = (): UseDownloadResult => {
   const [isDownloading, setIsDownloading] = useState<boolean>(false)
 
-  const handleDownload = useCallback(async (markdownContent: string, keyword: string, postsExist: boolean) => {
+  const handleDownload = useCallback(async (markdownContent: string, keyword: string, postsExist: boolean, sourceType: 'docbase' | 'slack' = 'docbase') => {
     setIsDownloading(true)
     // ダウンロード対象がない場合は、fileDownloaderからのメッセージをtoastで表示
     if (!postsExist || !markdownContent.trim()) {
-      const result = downloadMarkdownFile(markdownContent, keyword, postsExist)
+      const result = downloadMarkdownFile(markdownContent, keyword, postsExist, sourceType)
       if (result.message) {
         toast.error(result.message)
       }
@@ -30,7 +30,7 @@ export const useDownload = (): UseDownloadResult => {
     try {
       // 非同期処理っぽく見せるために少し待つ（実際にはdownloadMarkdownFileは同期的）
       await new Promise((resolve) => setTimeout(resolve, 500))
-      const result = downloadMarkdownFile(markdownContent, keyword, postsExist)
+      const result = downloadMarkdownFile(markdownContent, keyword, postsExist, sourceType)
 
       if (result.success) {
         toast.success('Markdownファイルをダウンロードしました。', {

--- a/src/utils/markdownGenerator.ts
+++ b/src/utils/markdownGenerator.ts
@@ -1,31 +1,95 @@
 import type { DocbasePostListItem } from '../types/docbase'
 
 /**
- * Docbaseの投稿リストからMarkdown文字列を生成する関数
+ * Docbaseの投稿リストからLLM最適化Markdown文字列を生成する関数
+ * NotebookLM等のLLMによる構造理解を最適化した形式で出力
  * @param posts DocbasePostListItemの配列
- * @returns 生成されたMarkdown文字列
+ * @param searchKeyword 検索キーワード（メタデータとして記録）
+ * @returns LLM最適化Markdown文字列
  */
-export const generateMarkdown = (posts: DocbasePostListItem[]): string => {
+export const generateMarkdown = (posts: DocbasePostListItem[], searchKeyword?: string): string => {
   if (!posts || posts.length === 0) {
     return '' // 投稿がない場合は空文字列を返す
   }
 
-  return posts
-    .map((post) => {
-      // created_at を YYYY/MM/DD 形式にフォーマット (簡易的なもの)
-      let formattedDate = post.created_at
-      try {
-        const date = new Date(post.created_at)
-        formattedDate = `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(
-          2,
-          '0',
-        )}/${String(date.getDate()).padStart(2, '0')}`
-      } catch (e) {
-        console.error('Error formatting date:', post.created_at, e)
-        // フォーマットエラー時は元の文字列を使用
-      }
+  // 全体のメタデータ作成
+  const dates = posts.map(post => new Date(post.created_at))
+  const minDate = new Date(Math.min(...dates.map(d => d.getTime())))
+  const maxDate = new Date(Math.max(...dates.map(d => d.getTime())))
+  
+  // YAML Front Matter形式で全体メタデータ
+  let markdown = '---\n'
+  markdown += `source: "docbase"\n`
+  markdown += `total_articles: ${posts.length}\n`
+  if (searchKeyword) {
+    markdown += `search_keyword: "${searchKeyword}"\n`
+  }
+  markdown += `date_range: "${minDate.toISOString().split('T')[0]} - ${maxDate.toISOString().split('T')[0]}"\n`
+  markdown += `generated_at: "${new Date().toISOString()}"\n`
+  markdown += '---\n\n'
 
-      return [`## ${post.title}`, `> ${formattedDate}`, `> ${post.url}`, '```md', post.body, '```'].join('\n\n') // 各要素を2つの改行で結合
+  // LLM理解しやすいタイトル
+  const dateRange = minDate.toLocaleDateString('ja-JP') === maxDate.toLocaleDateString('ja-JP')
+    ? minDate.toLocaleDateString('ja-JP')
+    : `${minDate.toLocaleDateString('ja-JP')} - ${maxDate.toLocaleDateString('ja-JP')}`
+  
+  markdown += `# Docbase Articles Collection\n\n`
+  
+  markdown += '## Collection Overview\n'
+  markdown += `- **Total Articles**: ${posts.length}\n`
+  if (searchKeyword) {
+    markdown += `- **Search Keyword**: "${searchKeyword}"\n`
+  }
+  markdown += `- **Date Range**: ${dateRange}\n`
+  markdown += `- **Source**: Docbase Knowledge Base\n\n`
+
+  // 目次
+  markdown += '## Articles Index\n\n'
+  posts.forEach((post, index) => {
+    const date = new Date(post.created_at)
+    const formattedDate = date.toLocaleDateString('ja-JP')
+    markdown += `${index + 1}. [${post.title}](#article-${index + 1}) - ${formattedDate}\n`
+  })
+  markdown += '\n---\n\n'
+
+  // 各記事の詳細
+  markdown += '## Articles Content\n\n'
+  
+  return markdown + posts
+    .map((post, index) => {
+      // 日付フォーマット
+      const date = new Date(post.created_at)
+      const isoDate = date.toISOString()
+      const displayDate = date.toLocaleDateString('ja-JP', {
+        year: 'numeric',
+        month: 'long', 
+        day: 'numeric',
+        weekday: 'long'
+      })
+
+      // 記事のYAML Front Matter
+      let articleMd = `### Article ${index + 1}\n\n`
+      articleMd += '```yaml\n'
+      articleMd += `docbase_id: ${post.id}\n`
+      articleMd += `title: "${post.title}"\n`
+      articleMd += `created_at: "${isoDate}"\n`
+      articleMd += `url: "${post.url}"\n`
+      articleMd += '```\n\n'
+
+      // LLM理解しやすい構造
+      articleMd += `# ${post.title}\n\n`
+      
+      articleMd += '## Document Information\n'
+      articleMd += `- **Created**: ${displayDate}\n`
+      articleMd += `- **Source**: [Docbase Article](${post.url})\n`
+      articleMd += `- **Document ID**: ${post.id}\n\n`
+
+      articleMd += '## Content\n\n'
+      
+      // 本文をそのまま記載（二重エンコード回避）
+      articleMd += `${post.body}\n\n`
+
+      return articleMd
     })
-    .join('\n\n---\n\n') // 各投稿の間を水平線と2つの改行で区切る
+    .join('---\n\n') // 各記事の間を水平線で区切る
 }

--- a/src/utils/slackMarkdownGenerator.ts
+++ b/src/utils/slackMarkdownGenerator.ts
@@ -1,0 +1,92 @@
+import type { SlackThread } from '../types/slack'
+import { convertToSlackThreadMarkdown } from '../lib/slackdown'
+
+/**
+ * 複数のSlackスレッドをLLM最適化Markdown形式で統合
+ * @param threads Slackスレッドの配列
+ * @param userMap ユーザーID→ユーザー名のマップ
+ * @param permalinkMap ts→パーマリンクのマップ
+ * @param searchKeyword 検索キーワード（メタデータとして記録）
+ * @returns LLM最適化統合Markdown文字列
+ */
+export const generateSlackThreadsMarkdown = (
+  threads: SlackThread[],
+  userMap: Record<string, string>,
+  permalinkMap: Record<string, string>,
+  searchKeyword?: string
+): string => {
+  if (!threads || threads.length === 0) {
+    return ''
+  }
+
+  // 全体のメタデータ作成
+  const allMessages = threads.flatMap(thread => [thread.parent, ...thread.replies])
+  const dates = allMessages.map(msg => new Date(Number.parseFloat(msg.ts) * 1000))
+  const minDate = new Date(Math.min(...dates.map(d => d.getTime())))
+  const maxDate = new Date(Math.max(...dates.map(d => d.getTime())))
+  
+  // チャンネル・参加者情報
+  const channels = [...new Set(threads.map(thread => thread.channel))]
+  const allParticipants = [...new Set(allMessages.map(msg => userMap[msg.user] || msg.user))]
+  const totalMessages = allMessages.length
+
+  // YAML Front Matter形式で全体メタデータ
+  let markdown = '---\n'
+  markdown += `source: "slack"\n`
+  markdown += `total_threads: ${threads.length}\n`
+  markdown += `total_messages: ${totalMessages}\n`
+  if (searchKeyword) {
+    markdown += `search_keyword: "${searchKeyword}"\n`
+  }
+  markdown += `channels: [${channels.map(c => `"${c}"`).join(', ')}]\n`
+  markdown += `participants: [${allParticipants.slice(0, 10).map(p => `"${p}"`).join(', ')}]\n`
+  if (allParticipants.length > 10) {
+    markdown += `total_participants: ${allParticipants.length}\n`
+  }
+  markdown += `date_range: "${minDate.toISOString().split('T')[0]} - ${maxDate.toISOString().split('T')[0]}"\n`
+  markdown += `generated_at: "${new Date().toISOString()}"\n`
+  markdown += '---\n\n'
+
+  // LLM理解しやすいタイトル
+  const dateRange = minDate.toLocaleDateString('ja-JP') === maxDate.toLocaleDateString('ja-JP')
+    ? minDate.toLocaleDateString('ja-JP')
+    : `${minDate.toLocaleDateString('ja-JP')} - ${maxDate.toLocaleDateString('ja-JP')}`
+
+  markdown += `# Slack Threads Collection\n\n`
+  
+  markdown += '## Collection Overview\n'
+  markdown += `- **Total Threads**: ${threads.length}\n`
+  markdown += `- **Total Messages**: ${totalMessages}\n`
+  if (searchKeyword) {
+    markdown += `- **Search Keyword**: "${searchKeyword}"\n`
+  }
+  markdown += `- **Channels**: ${channels.join(', ')}\n`
+  markdown += `- **Date Range**: ${dateRange}\n`
+  markdown += `- **Participants**: ${allParticipants.length} unique users\n`
+  markdown += `- **Source**: Slack Workspace\n\n`
+
+  // スレッド目次
+  markdown += '## Threads Index\n\n'
+  threads.forEach((thread, index) => {
+    const date = new Date(Number.parseFloat(thread.parent.ts) * 1000)
+    const formattedDate = date.toLocaleDateString('ja-JP')
+    const userName = userMap[thread.parent.user] || thread.parent.user
+    const truncatedText = thread.parent.text.length > 50 
+      ? `${thread.parent.text.substring(0, 50)}...`
+      : thread.parent.text
+    markdown += `${index + 1}. [Thread ${index + 1}](#thread-${index + 1}) - ${userName} in ${thread.channel} (${formattedDate})\n`
+    markdown += `   "${truncatedText}"\n`
+  })
+  markdown += '\n---\n\n'
+
+  // 各スレッドの詳細
+  markdown += '## Threads Content\n\n'
+  
+  return markdown + threads
+    .map((thread, index) => {
+      let threadMd = `### Thread ${index + 1} {#thread-${index + 1}}\n\n`
+      threadMd += convertToSlackThreadMarkdown(thread, userMap, permalinkMap)
+      return threadMd
+    })
+    .join('\n\n') // スレッド間に空行
+}


### PR DESCRIPTION
## 概要

Issue #41 の実装として、LLM・NotebookLM向けのMarkdown出力形式を大幅に最適化しました。

## 変更内容

### Slack Markdown最適化
- **構造化ヘッダー**: 絵文字（▶、🔄）を削除し、階層的構造に変更
- **YAML Front Matter**: メタデータの構造化（thread_id、participants、reply_count等）
- **時系列順序**: Message Timeline形式で会話の流れを明確化
- **参照性向上**: パーマリンク、チャンネル、ユーザー情報の構造化

### Docbase Markdown最適化
- **メタデータ構造化**: YAML Front Matter採用（search_keyword、date_range等）
- **記事インデックス**: 目次機能でナビゲーション向上
- **二重エンコード解消**: 本文のMarkdown構造保持
- **検索性強化**: Document Information追加

### 技術的改善
- **slackMarkdownGenerator.ts**: 複数スレッド統合用新規ユーティリティ
- **LLM最適化ファイル命名**: `{source}_YYYY-MM-DD_{keyword}_{type}.md`
- **メタデータ分離**: YAML Front MatterとContent部分の明確化
- **構造化階層**: H1→H6の適切な使用でLLM理解促進

## ビフォー・アフター

### Before (Slack)
```markdown
---  
## スレッド  
**Permalink:** [スレッド代表パーマリンク](URL)
### ▶ 親メッセージ  
- **ユーザー:** user  
> メッセージ本文
### 🔄 返信一覧  
```

### After (Slack)
```markdown
---
thread_id: "1711077827.907099"
channel: "#general"
participants: ["user1", "user2"]
reply_count: 3
---

# Slack Thread: 2024-03-22

## Thread Context
- **Channel**: #general
- **Participants**: user1, user2

## Message Timeline

### Message 1 (Parent)
**Author**: user1
**Time**: 2024-03-22 12:24:06

メッセージ本文
```

## 関連Issue

Closes #41

## NotebookLM最適化効果

- **構造理解向上**: YAML Front Matterによるメタデータ構造化
- **処理性能向上**: 絵文字削除・階層構造最適化
- **検索性強化**: インデックス・クロスリファレンス改善
- **文字数最適化**: 500,000語制限を意識した効率的構造

🤖 Generated with [Claude Code](https://claude.ai/code)