### PR TITLE
feat(adapters): アダプタパターンによる外部依存抽象化の実装

### DIFF
--- a/src/__tests__/adapters/docbaseAdapter.test.ts
+++ b/src/__tests__/adapters/docbaseAdapter.test.ts
@@ -1,0 +1,168 @@
+// Docbaseアダプターのテスト
+// モックHTTPクライアントを使用してアダプターの動作を検証
+
+import { describe, expect, it } from '@jest/globals'
+import { createDocbaseAdapter } from '../../adapters/docbaseAdapter'
+import { createMockHttpClient, createSuccessResponse, createErrorResponse } from '../../adapters/mockHttpClient'
+import type { DocbasePostsResponse } from '../../types/docbase'
+import type { ApiError } from '../../types/error'
+
+describe('DocbaseAdapter', () => {
+  const mockDomain = 'test-team'
+  const mockToken = 'test-token'
+  const mockSearchParams = {
+    domain: mockDomain,
+    token: mockToken,
+    keyword: 'テストキーワード',
+  }
+
+  it('正常にDocbaseの投稿を検索できる', async () => {
+    const mockPosts: DocbasePostsResponse = {
+      posts: [
+        {
+          id: 1,
+          title: 'テスト投稿1',
+          body: 'テスト内容1',
+          created_at: '2023-01-01T00:00:00Z',
+          url: 'https://test.docbase.io/posts/1',
+        },
+        {
+          id: 2,
+          title: 'テスト投稿2',
+          body: 'テスト内容2',
+          created_at: '2023-01-02T00:00:00Z',
+          url: 'https://test.docbase.io/posts/2',
+        },
+      ],
+    }
+
+    const mockHttpClient = createMockHttpClient([
+      createSuccessResponse(
+        `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%E3%82%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%89%22&page=1&per_page=100`,
+        mockPosts,
+        'GET'
+      ),
+    ])
+
+    const adapter = createDocbaseAdapter(mockHttpClient)
+    const result = await adapter.searchPosts(mockSearchParams)
+
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(2)
+      expect(result.value[0].title).toBe('テスト投稿1')
+      expect(result.value[1].title).toBe('テスト投稿2')
+    }
+  })
+
+  it('空のキーワードの場合は空配列を返す', async () => {
+    const mockHttpClient = createMockHttpClient([])
+    const adapter = createDocbaseAdapter(mockHttpClient)
+
+    const result = await adapter.searchPosts({
+      ...mockSearchParams,
+      keyword: '',
+    })
+
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(0)
+    }
+  })
+
+  it('詳細検索条件を含む検索クエリを正しく構築する', async () => {
+    const mockPosts: DocbasePostsResponse = { posts: [] }
+    const expectedUrl = `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%22+tag%3AAPI+author%3Auser123&page=1&per_page=100`
+
+    const mockHttpClient = createMockHttpClient([
+      createSuccessResponse(expectedUrl, mockPosts, 'GET'),
+    ])
+
+    const adapter = createDocbaseAdapter(mockHttpClient)
+    const result = await adapter.searchPosts({
+      ...mockSearchParams,
+      keyword: 'テスト',
+      advancedFilters: {
+        tags: 'API',
+        author: 'user123',
+        titleFilter: '',
+        startDate: '',
+        endDate: '',
+        group: '',
+      },
+    })
+
+    expect(result.isOk()).toBe(true)
+  })
+
+  it('認証エラーを適切に処理する', async () => {
+    const unauthorizedError: ApiError = {
+      type: 'unauthorized',
+      message: 'Unauthorized - Please check your API token',
+    }
+
+    const mockHttpClient = createMockHttpClient([
+      createErrorResponse(
+        `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%E3%82%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%89%22&page=1&per_page=100`,
+        unauthorizedError,
+        'GET'
+      ),
+    ])
+
+    const adapter = createDocbaseAdapter(mockHttpClient)
+    const result = await adapter.searchPosts(mockSearchParams)
+
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.type).toBe('unauthorized')
+    }
+  })
+
+  it('複数ページのデータを統合する', async () => {
+    const page1Posts: DocbasePostsResponse = {
+      posts: Array.from({ length: 100 }, (_, i) => ({
+        id: i + 1,
+        title: `投稿${i + 1}`,
+        body: `内容${i + 1}`,
+        created_at: '2023-01-01T00:00:00Z',
+        url: `https://test.docbase.io/posts/${i + 1}`,
+      })),
+    }
+
+    const page2Posts: DocbasePostsResponse = {
+      posts: Array.from({ length: 50 }, (_, i) => ({
+        id: i + 101,
+        title: `投稿${i + 101}`,
+        body: `内容${i + 101}`,
+        created_at: '2023-01-01T00:00:00Z',
+        url: `https://test.docbase.io/posts/${i + 101}`,
+      })),
+    }
+
+    const mockHttpClient = createMockHttpClient([
+      createSuccessResponse(
+        `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%22&page=1&per_page=100`,
+        page1Posts,
+        'GET'
+      ),
+      createSuccessResponse(
+        `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%22&page=2&per_page=100`,
+        page2Posts,
+        'GET'
+      ),
+    ])
+
+    const adapter = createDocbaseAdapter(mockHttpClient)
+    const result = await adapter.searchPosts({
+      ...mockSearchParams,
+      keyword: 'テスト',
+    })
+
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(150) // 100 + 50
+      expect(result.value[0].title).toBe('投稿1')
+      expect(result.value[149].title).toBe('投稿150')
+    }
+  })
+})

--- a/src/adapters/docbaseAdapter.ts
+++ b/src/adapters/docbaseAdapter.ts
@@ -1,0 +1,166 @@
+// Docbase APIアダプター実装
+// HTTPクライアントアダプターを使用してDocbase APIにアクセスし、Result型で結果を返す
+
+import { err, ok, type Result } from 'neverthrow'
+import type { DocbasePostListItem, DocbasePostsResponse } from '../types/docbase'
+import type { ApiError } from '../types/error'
+import type { HttpClient } from './types'
+
+/**
+ * Docbase検索パラメータ
+ */
+export interface DocbaseSearchParams {
+  domain: string
+  token: string
+  keyword: string
+  advancedFilters?: {
+    tags?: string
+    author?: string
+    titleFilter?: string
+    startDate?: string
+    endDate?: string
+    group?: string
+  }
+}
+
+/**
+ * DocbaseアダプターAPI
+ */
+export interface DocbaseAdapter {
+  /**
+   * 投稿を検索してページネーション処理を行う
+   * @param params 検索パラメータ
+   * @returns Promise<Result<DocbasePostListItem[], ApiError>>
+   */
+  searchPosts(params: DocbaseSearchParams): Promise<Result<DocbasePostListItem[], ApiError>>
+}
+
+/**
+ * Docbaseアダプターの実装を作成
+ * @param httpClient HTTPクライアントアダプター
+ * @returns DocbaseAdapter の実装
+ */
+export function createDocbaseAdapter(httpClient: HttpClient): DocbaseAdapter {
+  const API_BASE_URL = 'https://api.docbase.io/teams'
+  const MAX_PAGES = 5
+  const POSTS_PER_PAGE = 100
+
+  return {
+    async searchPosts(params: DocbaseSearchParams): Promise<Result<DocbasePostListItem[], ApiError>> {
+      const { domain, token, keyword, advancedFilters } = params
+
+      // 検索クエリの構築
+      const query = buildSearchQuery(keyword, advancedFilters)
+      if (!query) {
+        return ok([]) // クエリが空の場合は空配列を返す
+      }
+
+      const allPosts: DocbasePostListItem[] = []
+      let currentPage = 1
+
+      // ページネーション処理
+      while (currentPage <= MAX_PAGES) {
+        const searchParams = new URLSearchParams({
+          q: query,
+          page: currentPage.toString(),
+          per_page: POSTS_PER_PAGE.toString(),
+        })
+
+        const url = `${API_BASE_URL}/${domain}/posts?${searchParams.toString()}`
+        
+        const result = await httpClient.fetch<DocbasePostsResponse>(url, {
+          headers: {
+            'X-DocBaseToken': token,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        if (result.isErr()) {
+          // HTTPクライアントからのエラーをそのまま返す
+          return err(result.error)
+        }
+
+        const data = result.value
+        if (data.posts && data.posts.length > 0) {
+          allPosts.push(...data.posts)
+          
+          // 取得した件数がper_page未満なら最終ページ
+          if (data.posts.length < POSTS_PER_PAGE) {
+            break
+          }
+        } else {
+          // 投稿が空なら終了
+          break
+        }
+
+        currentPage++
+      }
+
+      return ok(allPosts)
+    },
+  }
+}
+
+/**
+ * 検索クエリを構築する内部ヘルパー関数
+ */
+function buildSearchQuery(
+  keyword: string,
+  advancedFilters?: DocbaseSearchParams['advancedFilters']
+): string {
+  // キーワードと詳細検索条件の両方が空の場合は空文字を返す
+  if (
+    !keyword.trim() &&
+    (!advancedFilters ||
+      (!advancedFilters.tags?.trim() &&
+        !advancedFilters.author?.trim() &&
+        !advancedFilters.titleFilter?.trim() &&
+        !advancedFilters.startDate?.trim() &&
+        !advancedFilters.endDate?.trim() &&
+        !advancedFilters.group?.trim()))
+  ) {
+    return ''
+  }
+
+  let query = keyword.trim() ? `"${keyword.trim()}"` : ''
+
+  if (advancedFilters) {
+    const { tags, author, titleFilter, startDate, endDate, group } = advancedFilters
+
+    // タグ検索
+    if (tags?.trim()) {
+      for (const tag of tags
+        .split(',')
+        .map((t) => t.trim())
+        .filter((t) => t)) {
+        query += ` tag:${tag}`
+      }
+    }
+
+    // 投稿者検索
+    if (author?.trim()) {
+      query += ` author:${author.trim()}`
+    }
+
+    // タイトル検索
+    if (titleFilter?.trim()) {
+      query += ` title:${titleFilter.trim()}`
+    }
+
+    // 期間検索
+    if (startDate?.trim() && endDate?.trim()) {
+      query += ` created_at:${startDate.trim()}~${endDate.trim()}`
+    } else if (startDate?.trim()) {
+      query += ` created_at:${startDate.trim()}~*`
+    } else if (endDate?.trim()) {
+      query += ` created_at:*~${endDate.trim()}`
+    }
+
+    // グループ検索
+    if (group?.trim()) {
+      query += ` group:${group.trim()}`
+    }
+  }
+
+  return query.trim()
+}

--- a/src/adapters/fetchHttpClient.ts
+++ b/src/adapters/fetchHttpClient.ts
@@ -1,0 +1,130 @@
+// fetchベースのHTTPクライアントアダプター実装
+// 実際のAPIリクエストを処理し、Result型でレスポンスを返す
+
+import { err, ok, type Result } from 'neverthrow'
+import type { ApiError } from '../types/error'
+import type { HttpClient, RetryConfig } from './types'
+
+/**
+ * デフォルトのリトライ設定
+ */
+const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRetries: 3,
+  initialBackoffMs: 1000,
+  retryableErrors: ['network', 'rate_limit'],
+}
+
+/**
+ * 指定ミリ秒待機するユーティリティ関数
+ */
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * fetchベースのHTTPクライアントアダプターを作成
+ * @param retryConfig リトライ設定（オプション）
+ * @returns HttpClient インターフェースの実装
+ */
+export function createFetchHttpClient(
+  retryConfig: RetryConfig = DEFAULT_RETRY_CONFIG
+): HttpClient {
+  return {
+    async fetch<T>(url: string, options?: RequestInit): Promise<Result<T, ApiError>> {
+      let lastError: ApiError | null = null
+      
+      for (let attempt = 0; attempt <= retryConfig.maxRetries; attempt++) {
+        try {
+          // 指数バックオフによる待機（初回は待機なし）
+          if (attempt > 0) {
+            const backoffMs = retryConfig.initialBackoffMs * Math.pow(2, attempt - 1)
+            await sleep(backoffMs)
+          }
+
+          const response = await fetch(url, options)
+
+          // HTTPエラーレスポンスの処理
+          if (!response.ok) {
+            const apiError = mapHttpStatusToApiError(response.status, response.statusText)
+            
+            // リトライ対象のエラーかチェック
+            if (
+              attempt < retryConfig.maxRetries &&
+              retryConfig.retryableErrors.includes(apiError.type)
+            ) {
+              lastError = apiError
+              continue
+            }
+            
+            return err(apiError)
+          }
+
+          // 成功レスポンスの処理
+          const data = (await response.json()) as T
+          return ok(data)
+
+        } catch (error) {
+          const networkError: ApiError = {
+            type: 'network',
+            message: error instanceof Error ? error.message : 'Unknown network error',
+            cause: error,
+          }
+
+          // ネットワークエラーのリトライ
+          if (
+            attempt < retryConfig.maxRetries &&
+            retryConfig.retryableErrors.includes('network')
+          ) {
+            lastError = networkError
+            continue
+          }
+
+          return err(networkError)
+        }
+      }
+
+      // すべてのリトライが失敗した場合、最後のエラーを返す
+      return err(lastError || {
+        type: 'unknown',
+        message: 'Maximum retry attempts exceeded',
+      })
+    },
+  }
+}
+
+/**
+ * HTTPステータスコードをApiErrorにマッピング
+ */
+function mapHttpStatusToApiError(status: number, statusText: string): ApiError {
+  switch (status) {
+    case 401:
+      return {
+        type: 'unauthorized',
+        message: 'Unauthorized - Please check your API token',
+      }
+    case 403:
+      return {
+        type: 'missing_scope',
+        message: 'Forbidden - Missing required permissions',
+      }
+    case 404:
+      return {
+        type: 'notFound',
+        message: 'Resource not found',
+      }
+    case 429:
+      return {
+        type: 'rate_limit',
+        message: 'Rate limit exceeded - Please try again later',
+      }
+    case 400:
+      return {
+        type: 'validation',
+        message: 'Bad request - Please check your parameters',
+      }
+    default:
+      return {
+        type: 'network',
+        message: `HTTP error: ${status} ${statusText}`,
+      }
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,30 @@
+// アダプターパターン実装の統一エクスポート
+// すべてのアダプターとHTTPクライアントを一箇所から提供
+
+// 型定義
+export type { HttpClient, MockResponse, RetryConfig } from './types'
+
+// HTTPクライアントアダプター
+export { createFetchHttpClient } from './fetchHttpClient'
+export { createMockHttpClient, createSuccessResponse, createErrorResponse } from './mockHttpClient'
+
+// APIアダプター
+export { createDocbaseAdapter, type DocbaseAdapter, type DocbaseSearchParams } from './docbaseAdapter'
+export {
+  createSlackAdapter,
+  type SlackAdapter,
+  type SlackSearchParams,
+  type SlackThreadParams,
+  type SlackPermalinkParams,
+  type SlackUserParams,
+  type SlackSearchResponse,
+} from './slackAdapter'
+
+// デフォルトインスタンス作成用のヘルパー関数
+export function createDefaultDocbaseAdapter() {
+  return createDocbaseAdapter(createFetchHttpClient())
+}
+
+export function createDefaultSlackAdapter() {
+  return createSlackAdapter(createFetchHttpClient())
+}

--- a/src/adapters/mockHttpClient.ts
+++ b/src/adapters/mockHttpClient.ts
@@ -1,0 +1,102 @@
+// テスト用のモックHTTPクライアントアダプター実装
+// 実際のAPIリクエストを行わず、事前に設定されたレスポンスを返す
+
+import { err, ok, type Result } from 'neverthrow'
+import type { ApiError } from '../types/error'
+import type { HttpClient, MockResponse } from './types'
+
+/**
+ * テスト用のモックHTTPクライアントアダプターを作成
+ * @param responses モックレスポンスの配列
+ * @returns HttpClient インターフェースの実装
+ */
+export function createMockHttpClient(responses: MockResponse[]): HttpClient {
+  let requestCount = 0
+
+  return {
+    async fetch<T>(url: string, options?: RequestInit): Promise<Result<T, ApiError>> {
+      requestCount++
+
+      // URLとメソッドでマッチするレスポンスを検索
+      const method = options?.method?.toUpperCase() || 'GET'
+      const matchingResponse = responses.find(
+        (response) =>
+          response.url === url &&
+          (response.method?.toUpperCase() || 'GET') === method
+      )
+
+      // マッチするレスポンスが見つからない場合
+      if (!matchingResponse) {
+        return err({
+          type: 'notFound',
+          message: `No mock response configured for ${method} ${url}`,
+        })
+      }
+
+      // エラーレスポンスの場合
+      if (matchingResponse.error) {
+        return err(matchingResponse.error)
+      }
+
+      // 成功レスポンスの場合
+      if (matchingResponse.status >= 200 && matchingResponse.status < 300) {
+        return ok(matchingResponse.data as T)
+      }
+
+      // HTTPエラーレスポンスの場合
+      return err(mapStatusToApiError(matchingResponse.status))
+    },
+  }
+}
+
+/**
+ * HTTPステータスコードをApiErrorにマッピング（テスト用）
+ */
+function mapStatusToApiError(status: number): ApiError {
+  switch (status) {
+    case 401:
+      return { type: 'unauthorized', message: 'Mock unauthorized error' }
+    case 403:
+      return { type: 'missing_scope', message: 'Mock forbidden error' }
+    case 404:
+      return { type: 'notFound', message: 'Mock not found error' }
+    case 429:
+      return { type: 'rate_limit', message: 'Mock rate limit error' }
+    case 400:
+      return { type: 'validation', message: 'Mock validation error' }
+    default:
+      return { type: 'network', message: `Mock HTTP error: ${status}` }
+  }
+}
+
+/**
+ * テスト用のヘルパー関数: 成功レスポンスを簡単に作成
+ */
+export function createSuccessResponse(
+  url: string,
+  data: unknown,
+  method = 'GET'
+): MockResponse {
+  return {
+    url,
+    method,
+    status: 200,
+    data,
+  }
+}
+
+/**
+ * テスト用のヘルパー関数: エラーレスポンスを簡単に作成
+ */
+export function createErrorResponse(
+  url: string,
+  error: ApiError,
+  method = 'GET'
+): MockResponse {
+  return {
+    url,
+    method,
+    status: 500,
+    error,
+  }
+}

--- a/src/adapters/slackAdapter.ts
+++ b/src/adapters/slackAdapter.ts
@@ -1,0 +1,380 @@
+// Slack APIアダプター実装
+// HTTPクライアントアダプターを使用してSlack APIにアクセスし、Result型で結果を返す
+
+import { err, ok, type Result } from 'neverthrow'
+import type { SlackMessage, SlackThread, SlackUser } from '../types/slack'
+import type { ApiError } from '../types/error'
+import type { HttpClient } from './types'
+
+/**
+ * Slack検索パラメータ
+ */
+export interface SlackSearchParams {
+  token: string
+  query: string
+  count?: number
+  page?: number
+}
+
+/**
+ * Slackスレッド取得パラメータ
+ */
+export interface SlackThreadParams {
+  token: string
+  channel: string
+  threadTs: string
+}
+
+/**
+ * Slackパーマリンク取得パラメータ
+ */
+export interface SlackPermalinkParams {
+  token: string
+  channel: string
+  messageTs: string
+}
+
+/**
+ * Slackユーザー情報取得パラメータ
+ */
+export interface SlackUserParams {
+  token: string
+  userId: string
+}
+
+/**
+ * Slack検索成功レスポンス
+ */
+export interface SlackSearchResponse {
+  messages: SlackMessage[]
+  pagination: {
+    currentPage: number
+    totalPages: number
+    totalResults: number
+    perPage: number
+  }
+}
+
+/**
+ * SlackアダプターAPI
+ */
+export interface SlackAdapter {
+  /**
+   * メッセージを検索する
+   * @param params 検索パラメータ
+   * @returns Promise<Result<SlackSearchResponse, ApiError>>
+   */
+  searchMessages(params: SlackSearchParams): Promise<Result<SlackSearchResponse, ApiError>>
+
+  /**
+   * スレッド全体（親＋返信）を取得する
+   * @param params スレッド取得パラメータ
+   * @returns Promise<Result<SlackThread, ApiError>>
+   */
+  getThreadMessages(params: SlackThreadParams): Promise<Result<SlackThread, ApiError>>
+
+  /**
+   * メッセージのパーマリンクを取得する
+   * @param params パーマリンク取得パラメータ
+   * @returns Promise<Result<string, ApiError>>
+   */
+  getPermalink(params: SlackPermalinkParams): Promise<Result<string, ApiError>>
+
+  /**
+   * ユーザー情報を取得する
+   * @param params ユーザー情報取得パラメータ
+   * @returns Promise<Result<SlackUser, ApiError>>
+   */
+  getUserInfo(params: SlackUserParams): Promise<Result<SlackUser, ApiError>>
+}
+
+/**
+ * Slackアダプターの実装を作成
+ * @param httpClient HTTPクライアントアダプター
+ * @returns SlackAdapter の実装
+ */
+export function createSlackAdapter(httpClient: HttpClient): SlackAdapter {
+  const API_BASE_URL = 'https://slack.com/api'
+
+  return {
+    async searchMessages(params: SlackSearchParams): Promise<Result<SlackSearchResponse, ApiError>> {
+      const { token, query, count = 20, page = 1 } = params
+
+      if (!token || !query) {
+        return err({
+          type: 'validation',
+          message: 'トークンと検索クエリは必須です。',
+        })
+      }
+
+      const formParams = new URLSearchParams({
+        token,
+        query,
+        count: count.toString(),
+        page: page.toString(),
+      })
+
+      const result = await httpClient.fetch<SlackApiResponse>(`${API_BASE_URL}/search.messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: formParams.toString(),
+      })
+
+      if (result.isErr()) {
+        return err(result.error)
+      }
+
+      const data = result.value
+
+      // Slack API特有のエラーチェック
+      if (!data.ok) {
+        const errorCode = data.error || 'unknown_error'
+        return err(mapSlackErrorToApiError(errorCode))
+      }
+
+      // メッセージとページネーション情報の抽出
+      const messages = extractMessagesFromResponse(data)
+      const pagination = extractPaginationFromResponse(data, count)
+
+      return ok({ messages, pagination })
+    },
+
+    async getThreadMessages(params: SlackThreadParams): Promise<Result<SlackThread, ApiError>> {
+      const { token, channel, threadTs } = params
+
+      const formParams = new URLSearchParams({
+        token,
+        channel,
+        ts: threadTs,
+      })
+
+      const result = await httpClient.fetch<SlackApiResponse>(`${API_BASE_URL}/conversations.replies`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: formParams.toString(),
+      })
+
+      if (result.isErr()) {
+        return err(result.error)
+      }
+
+      const data = result.value
+
+      if (!data.ok) {
+        const errorCode = data.error || 'unknown_error'
+        return err(mapSlackErrorToApiError(errorCode))
+      }
+
+      // メッセージリストを抽出
+      const messages = extractThreadMessagesFromResponse(data, channel)
+      if (messages.length === 0) {
+        return err({
+          type: 'notFound',
+          message: 'スレッドメッセージが見つかりません。',
+        })
+      }
+
+      const parent = messages[0]
+      const replies = messages.slice(1)
+
+      return ok({ channel, parent, replies })
+    },
+
+    async getPermalink(params: SlackPermalinkParams): Promise<Result<string, ApiError>> {
+      const { token, channel, messageTs } = params
+
+      const url = `${API_BASE_URL}/chat.getPermalink?channel=${encodeURIComponent(
+        channel
+      )}&message_ts=${encodeURIComponent(messageTs)}`
+
+      const result = await httpClient.fetch<SlackApiResponse>(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      })
+
+      if (result.isErr()) {
+        return err(result.error)
+      }
+
+      const data = result.value
+
+      if (!data.ok) {
+        const errorCode = data.error || 'unknown_error'
+        return err(mapSlackErrorToApiError(errorCode))
+      }
+
+      return ok(data.permalink as string)
+    },
+
+    async getUserInfo(params: SlackUserParams): Promise<Result<SlackUser, ApiError>> {
+      const { token, userId } = params
+
+      const formParams = new URLSearchParams({
+        token,
+        user: userId,
+      })
+
+      const result = await httpClient.fetch<SlackApiResponse>(`${API_BASE_URL}/users.info`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: formParams.toString(),
+      })
+
+      if (result.isErr()) {
+        return err(result.error)
+      }
+
+      const data = result.value
+
+      if (!data.ok) {
+        const errorCode = data.error || 'unknown_error'
+        return err(mapSlackErrorToApiError(errorCode))
+      }
+
+      const user: SlackUser = {
+        id: data.user?.id || '',
+        name: data.user?.name || '',
+        real_name: data.user?.real_name,
+      }
+
+      return ok(user)
+    },
+  }
+}
+
+/**
+ * Slack APIレスポンスの基本型
+ */
+interface SlackApiResponse {
+  ok: boolean
+  error?: string
+  messages?: unknown
+  user?: {
+    id: string
+    name: string
+    real_name?: string
+  }
+  permalink?: string
+  [key: string]: unknown
+}
+
+/**
+ * Slack APIエラーコードをApiErrorにマッピング
+ */
+function mapSlackErrorToApiError(errorCode: string): ApiError {
+  switch (errorCode) {
+    case 'invalid_auth':
+    case 'not_authed':
+    case 'token_revoked':
+    case 'account_inactive':
+      return {
+        type: 'unauthorized',
+        message: `Slack認証エラー: ${errorCode}`,
+      }
+    case 'missing_scope':
+      return {
+        type: 'missing_scope',
+        message: `必要なスコープがありません: ${errorCode}`,
+      }
+    case 'channel_not_found':
+    case 'thread_not_found':
+    case 'message_not_found':
+    case 'user_not_found':
+      return {
+        type: 'notFound',
+        message: 'リソースが見つかりません。',
+      }
+    case 'rate_limited':
+      return {
+        type: 'rate_limit',
+        message: 'APIレート制限に達しました。',
+      }
+    default:
+      return {
+        type: 'slack_api',
+        message: `Slack APIエラー: ${errorCode}`,
+      }
+  }
+}
+
+/**
+ * 検索レスポンスからメッセージを抽出
+ */
+function extractMessagesFromResponse(data: SlackApiResponse): SlackMessage[] {
+  const messages: SlackMessage[] = []
+  
+  if (data.messages && typeof data.messages === 'object' && data.messages !== null) {
+    const msgObj = data.messages as Record<string, unknown>
+    if ('matches' in msgObj && Array.isArray(msgObj.matches)) {
+      return msgObj.matches.map((m: unknown) => {
+        const msg = m as Record<string, unknown>
+        return {
+          ts: typeof msg.ts === 'string' ? msg.ts : '',
+          user: typeof msg.user === 'string' ? msg.user : '',
+          text: typeof msg.text === 'string' ? msg.text : '',
+          thread_ts: typeof msg.thread_ts === 'string' ? msg.thread_ts : undefined,
+          channel:
+            msg.channel && typeof msg.channel === 'object' && msg.channel !== null && 'id' in msg.channel
+              ? {
+                  id: (msg.channel as { id: string }).id,
+                  name: (msg.channel as { name?: string }).name,
+                }
+              : { id: '', name: undefined },
+          permalink: typeof msg.permalink === 'string' ? msg.permalink : undefined,
+        }
+      })
+    }
+  }
+  
+  return messages
+}
+
+/**
+ * 検索レスポンスからページネーション情報を抽出
+ */
+function extractPaginationFromResponse(data: SlackApiResponse, count: number) {
+  let paginationData: Record<string, unknown> | undefined
+
+  if (data.messages && typeof data.messages === 'object' && data.messages !== null) {
+    const msgObj = data.messages as Record<string, unknown>
+    if ('pagination' in msgObj && typeof msgObj.pagination === 'object' && msgObj.pagination !== null) {
+      paginationData = msgObj.pagination as Record<string, unknown>
+    }
+  }
+
+  return {
+    currentPage: typeof paginationData?.page === 'number' ? paginationData.page : 1,
+    totalPages: typeof paginationData?.page_count === 'number' ? paginationData.page_count : 1,
+    totalResults: typeof paginationData?.total_count === 'number' ? paginationData.total_count : 0,
+    perPage: typeof paginationData?.per_page === 'number' ? paginationData.per_page : count,
+  }
+}
+
+/**
+ * スレッドレスポンスからメッセージを抽出
+ */
+function extractThreadMessagesFromResponse(data: SlackApiResponse, channel: string): SlackMessage[] {
+  if (!Array.isArray(data.messages)) {
+    return []
+  }
+
+  return data.messages.map((m: unknown) => {
+    const msg = m as Record<string, unknown>
+    return {
+      ts: typeof msg.ts === 'string' ? msg.ts : '',
+      user: typeof msg.user === 'string' ? msg.user : '',
+      text: typeof msg.text === 'string' ? msg.text : '',
+      thread_ts: typeof msg.thread_ts === 'string' ? msg.thread_ts : undefined,
+      channel: { id: channel },
+      permalink: undefined,
+    }
+  })
+}

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -1,0 +1,39 @@
+// アダプタパターンによる外部依存抽象化のための型定義
+// HTTPクライアントアダプター・APIアダプターの共通インターフェース
+
+import type { Result } from 'neverthrow'
+import type { ApiError } from '../types/error'
+
+/**
+ * HTTPクライアントアダプター
+ * fetch APIを抽象化し、テスト時にはモックで置き換え可能にする
+ */
+export interface HttpClient {
+  /**
+   * HTTPリクエストを実行し、Result型で結果を返す
+   * @param url リクエストURL
+   * @param options fetchのオプション
+   * @returns Promise<Result<T, ApiError>>
+   */
+  fetch<T>(url: string, options?: RequestInit): Promise<Result<T, ApiError>>
+}
+
+/**
+ * モックレスポンスの定義（テスト用）
+ */
+export interface MockResponse {
+  url: string
+  method?: string
+  status: number
+  data?: unknown
+  error?: ApiError
+}
+
+/**
+ * リトライ設定
+ */
+export interface RetryConfig {
+  maxRetries: number
+  initialBackoffMs: number
+  retryableErrors: ApiError['type'][]
+}

--- a/src/lib/docbaseClient.ts
+++ b/src/lib/docbaseClient.ts
@@ -1,27 +1,16 @@
-import { type Result, err, ok } from 'neverthrow'
+import { type Result } from 'neverthrow'
+import { createDocbaseAdapter, type DocbaseSearchParams } from '../adapters/docbaseAdapter'
+import { createFetchHttpClient } from '../adapters/fetchHttpClient'
 import type { AdvancedFilters } from '../hooks/useSearch'
-import type { DocbasePostListItem, DocbasePostsResponse } from '../types/docbase'
-import type {
-  ApiError,
-  NetworkApiError,
-  NotFoundApiError,
-  RateLimitApiError,
-  UnauthorizedApiError,
-  UnknownApiError,
-} from '../types/error'
+import type { DocbasePostListItem } from '../types/docbase'
+import type { ApiError } from '../types/error'
 
-const DOCBASE_API_BASE_URL = 'https://api.docbase.io/teams'
-const MAX_RETRIES = 3
-const INITIAL_BACKOFF_MS = 1000 // 1秒
+// デフォルトのDocbaseアダプターインスタンス
+const defaultAdapter = createDocbaseAdapter(createFetchHttpClient())
 
 /**
- * 指定されたミリ秒待機するPromiseを返すヘルパー関数
- * @param ms 待機するミリ秒
- */
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
-
-/**
- * Docbase APIから投稿リストを取得する関数（リトライ処理付き）
+ * Docbase APIから投稿リストを取得する関数（アダプターパターンを使用）
+ * 下位互換性のため、既存のインターフェースを維持
  *
  * @param domain Docbaseのチームドメイン
  * @param token Docbase APIトークン
@@ -34,170 +23,11 @@ export const fetchDocbasePosts = async (
   token: string,
   keyword: string,
   advancedFilters?: AdvancedFilters,
-  retries = MAX_RETRIES, // 残りのリトライ回数
-  backoff = INITIAL_BACKOFF_MS, // 現在のバックオフ時間
 ): Promise<Result<DocbasePostListItem[], ApiError>> => {
-  // キーワードと詳細検索条件の両方が空の場合は空の配列を返す
-  if (
-    !keyword.trim() &&
-    (!advancedFilters ||
-      (!advancedFilters.tags?.trim() &&
-        !advancedFilters.author?.trim() &&
-        !advancedFilters.titleFilter?.trim() &&
-        !advancedFilters.startDate?.trim() &&
-        !advancedFilters.endDate?.trim() &&
-        !advancedFilters.group?.trim()))
-  ) {
-    return ok([])
-  }
-
-  let query = keyword.trim() ? `"${keyword.trim()}"` : ''
-
-  if (advancedFilters) {
-    const { tags, author, titleFilter, startDate, endDate, group } = advancedFilters
-    if (tags?.trim()) {
-      for (const tag of tags
-        .split(',')
-        .map((t) => t.trim())
-        .filter((t) => t)) {
-        query += ` tag:${tag}`
-      }
-    }
-    if (author?.trim()) {
-      query += ` author:${author.trim()}`
-    }
-    if (titleFilter?.trim()) {
-      query += ` title:${titleFilter.trim()}`
-    }
-    if (startDate?.trim() && endDate?.trim()) {
-      query += ` created_at:${startDate.trim()}~${endDate.trim()}`
-    } else if (startDate?.trim()) {
-      query += ` created_at:${startDate.trim()}~*`
-    } else if (endDate?.trim()) {
-      query += ` created_at:*~${endDate.trim()}`
-    }
-    if (group?.trim()) {
-      query += ` group:${group.trim()}`
-    }
-  }
-  query = query.trim() // 前後の空白を削除
-
-  // クエリが空なら空の配列を返す
-  if (!query) {
-    return ok([])
-  }
-
-  const allPosts: DocbasePostListItem[] = []
-  let currentPage = 1
-  const postsPerPage = 100 // 1ページあたりの取得件数
-  const maxPages = 5 // 最大取得ページ数を3から5に変更
-
-  // リトライ処理をページネーションの外側に移動するため、
-  // この関数がリトライされるときは、特定のページからではなく、常に最初のページから再試行する。
-  // 個別のページ取得失敗時のリトライはここでは扱わず、全体としてのリトライに任せる。
-
-  while (currentPage <= maxPages) {
-    const searchParams = new URLSearchParams({
-      q: query,
-      page: currentPage.toString(),
-      per_page: postsPerPage.toString(),
-    })
-    const url = `${DOCBASE_API_BASE_URL}/${domain}/posts?${searchParams.toString()}`
-
-    try {
-      const response = await fetch(url, {
-        headers: {
-          'X-DocBaseToken': token,
-          'Content-Type': 'application/json',
-        },
-      })
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          const error: UnauthorizedApiError = {
-            type: 'unauthorized',
-            message: 'Docbase APIトークンが無効です。',
-          }
-          return err(error) // 認証エラーは即時エラー
-        }
-        if (response.status === 404) {
-          const error: NotFoundApiError = {
-            type: 'notFound',
-            message: 'Docbaseのチームが見つからないか、APIエンドポイントが誤っています。',
-          }
-          return err(error) // Not Foundも即時エラー
-        }
-        if (response.status === 429) {
-          // レートリミットの場合、この関数全体をリトライする
-          if (retries > 0) {
-            console.warn(
-              `Rate limit exceeded during page ${currentPage} fetch. Retrying entire fetch operation in ${backoff}ms... (${retries} retries left)`,
-            )
-            await sleep(backoff)
-            // fetchDocbasePosts を再度呼び出すが、retries と backoff を渡して再帰的にリトライ
-            // ループ処理は中断し、関数の最初から再試行する
-            return fetchDocbasePosts(domain, token, keyword, advancedFilters, retries - 1, backoff * 2)
-          }
-          const error: RateLimitApiError = {
-            type: 'rate_limit',
-            message: `Docbase APIのレートリミットに達しました (ページ ${currentPage} 取得時)。何度か再試行しましたが改善しませんでした。`,
-          }
-          return err(error)
-        }
-        // その他のネットワークエラー
-        const errorText = await response.text()
-        const error: NetworkApiError = {
-          type: 'network',
-          message: `Docbase APIリクエストエラー (ページ ${currentPage} 取得時): ${response.status} ${response.statusText}. ${errorText}`,
-        }
-        return err(error) // その他のエラーも即時エラー
-      }
-
-      const data = (await response.json()) as DocbasePostsResponse
-      if (data.posts && data.posts.length > 0) {
-        allPosts.push(...data.posts)
-        // 取得した件数がper_page未満なら、それが最終ページなのでループを抜ける
-        if (data.posts.length < postsPerPage) {
-          break
-        }
-      } else {
-        // 投稿が空なら、それ以上ページはないのでループを抜ける
-        break
-      }
-      currentPage++
-      // 短い待機時間を挟んでAPIへの負荷を軽減（任意）
-      // await sleep(200); // 例: 200ミリ秒待機
-    } catch (error) {
-      console.error(`Docbase API fetch error (page ${currentPage}):`, error)
-      // ネットワークエラーの場合もこの関数全体をリトライする
-      if (
-        retries > 0 &&
-        (error instanceof TypeError ||
-          (error instanceof Error && error.message.toLowerCase().includes('network error')))
-      ) {
-        console.warn(
-          `Network error occurred during page ${currentPage} fetch. Retrying entire fetch operation in ${backoff}ms... (${retries} retries left)`,
-        )
-        await sleep(backoff)
-        return fetchDocbasePosts(domain, token, keyword, advancedFilters, retries - 1, backoff * 2)
-      }
-
-      if (error instanceof Error) {
-        const apiError: NetworkApiError = {
-          type: 'network',
-          message: `ネットワークエラー (ページ ${currentPage} 取得時): ${error.message}`,
-          cause: error,
-        }
-        return err(apiError)
-      }
-      const unknownError: UnknownApiError = {
-        type: 'unknown',
-        message: `不明なエラーが発生しました (ページ ${currentPage} 取得時)。コンソールを確認してください。`,
-        cause: error,
-      }
-      return err(unknownError)
-    }
-  } // whileループの終わり
-
-  return ok(allPosts)
+  return defaultAdapter.searchPosts({
+    domain,
+    token,
+    keyword,
+    advancedFilters,
+  })
 }


### PR DESCRIPTION
## 概要

Issue #39 の実装として、アダプタパターンによる外部依存抽象化を行い、テスタビリティと保守性を大幅に向上させました。

## 変更内容

### 🏗️ アーキテクチャ改善
- **HTTPクライアントアダプター**: fetch API抽象化（リトライ・エラーハンドリング統一）
- **APIアダプター**: Docbase/Slack API呼び出しの抽象化
- **依存注入**: フック・クライアントでアダプター注入によるテスタビリティ向上

### 📁 新規ファイル
- `src/adapters/types.ts`: アダプター共通インターフェース定義
- `src/adapters/fetchHttpClient.ts`: 実際のHTTPリクエスト実装
- `src/adapters/mockHttpClient.ts`: テスト用モックHTTPクライアント
- `src/adapters/docbaseAdapter.ts`: Docbase API抽象化
- `src/adapters/slackAdapter.ts`: Slack API抽象化
- `src/adapters/index.ts`: 統一エクスポート
- `src/hooks/useSlackSearchUnified.ts`: 統一Slackフック（アダプターパターン）
- `src/__tests__/adapters/docbaseAdapter.test.ts`: アダプターテストケース

### 🔄 既存ファイル更新
- `src/hooks/useSearch.ts`: アダプター注入対応
- `src/lib/docbaseClient.ts`: アダプターパターン移行（下位互換性維持）

## 技術的改善点

### 1. 外部依存の抽象化
```typescript
// HTTPクライアントアダプター
interface HttpClient {
  fetch<T>(url: string, options?: RequestInit): Promise<Result<T, ApiError>>
}

// APIアダプター
interface DocbaseAdapter {
  searchPosts(params: DocbaseSearchParams): Promise<Result<DocbasePostListItem[], ApiError>>
}
```

### 2. 統一的なエラーハンドリング
- 指数バックオフによるリトライ処理
- Result型による型安全なエラーハンドリング
- ユーザーフレンドリーなエラーメッセージ変換

### 3. テスタビリティの向上
```typescript
// モックを使用したテスト
const mockHttpClient = createMockHttpClient([
  createSuccessResponse(url, mockData)
])
const adapter = createDocbaseAdapter(mockHttpClient)
```

### 4. 下位互換性の維持
- 既存の関数インターフェースを保持
- 段階的な移行が可能

## テスト手順

1. **単体テスト**: `npm test` でアダプターテストが通ることを確認
2. **統合テスト**: Docbase検索機能が正常に動作することを確認
3. **エラーハンドリング**: 認証エラー・ネットワークエラーが適切に処理されることを確認
4. **リトライ機能**: レートリミット・一時的エラーでリトライが動作することを確認

## 今後の展開

- Slack統一フック（useSlackSearchUnified）の実際の適用
- 既存Slackページコンポーネントのアダプターパターン移行
- より詳細なテストケース追加

🤖 Generated with [Claude Code](https://claude.ai/code)