### PR TITLE
fix(lint): Biome lintエラーを全て修正

### DIFF
--- a/src/adapters/fetchHttpClient.ts
+++ b/src/adapters/fetchHttpClient.ts
@@ -36,7 +36,7 @@ export function createFetchHttpClient(
         try {
           // 指数バックオフによる待機（初回は待機なし）
           if (attempt > 0) {
-            const backoffMs = retryConfig.initialBackoffMs * Math.pow(2, attempt - 1)
+            const backoffMs = retryConfig.initialBackoffMs * 2 ** (attempt - 1)
             await sleep(backoffMs)
           }
 

--- a/src/app/slack/page.tsx
+++ b/src/app/slack/page.tsx
@@ -23,8 +23,8 @@ export default function SlackPage() {
   const { isDownloading, handleDownload } = useDownload()
   // TODO: Issue #39で統一エラーハンドリングフックに移行
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<any>(null)
-  const [slackThreads, setSlackThreads] = useState<any[]>([])
+  const [error, setError] = useState<Error | null>(null)
+  const [slackThreads, setSlackThreads] = useState<unknown[]>([])
   const [userMaps, setUserMaps] = useState<Record<string, string>>({})
   const [permalinkMaps, setPermalinkMaps] = useState<Record<string, string>>({})
   const [threadMarkdowns, setThreadMarkdowns] = useState<string[]>([])

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -51,6 +51,7 @@ export const MarkdownPreview: FC<MarkdownPreviewProps> = ({
           <h2 className="text-xl font-semibold text-gray-800">{title}</h2>
           {onDownload && (
             <button 
+              type="button"
               onClick={onDownload}
               className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
             >

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -123,7 +123,7 @@ export const useSearch = (options?: UseSearchOptions): UseSearchResult => {
       }
       await executeSearch(domain, token, keyword, advancedFilters) // advancedFilters を渡す
     },
-    [executeSearch, adapter],
+    [executeSearch],
   )
 
   const retrySearch = useCallback(() => {

--- a/src/hooks/useSlackSearchUnified.ts
+++ b/src/hooks/useSlackSearchUnified.ts
@@ -90,7 +90,7 @@ export function useSlackSearchUnified(options?: UseSlackSearchOptions): UseSlack
   /**
    * 検索クエリを構築
    */
-  const buildSearchQuery = (params: SlackSearchParams): string => {
+  const buildSearchQuery = useCallback((params: SlackSearchParams): string => {
     let query = params.searchQuery.trim()
 
     if (params.channel?.trim()) {
@@ -110,12 +110,12 @@ export function useSlackSearchUnified(options?: UseSlackSearchOptions): UseSlack
     }
 
     return query.trim()
-  }
+  }, [])
 
   /**
    * メッセージをスレッド単位でユニーク化
    */
-  const groupMessagesByThread = (messages: SlackMessage[]): SlackMessage[] => {
+  const groupMessagesByThread = useCallback((messages: SlackMessage[]): SlackMessage[] => {
     const threadMap = new Map<string, SlackMessage>()
     
     for (const message of messages) {
@@ -126,12 +126,12 @@ export function useSlackSearchUnified(options?: UseSlackSearchOptions): UseSlack
     }
     
     return Array.from(threadMap.values())
-  }
+  }, [])
 
   /**
    * スレッド詳細情報を取得
    */
-  const fetchThreadDetails = async (
+  const fetchThreadDetails = useCallback(async (
     uniqueMessages: SlackMessage[],
     token: string
   ): Promise<{
@@ -161,7 +161,9 @@ export function useSlackSearchUnified(options?: UseSlackSearchOptions): UseSlack
 
         // ユーザーIDを収集
         userIdSet.add(thread.parent.user)
-        thread.replies.forEach(reply => userIdSet.add(reply.user))
+        for (const reply of thread.replies) {
+          userIdSet.add(reply.user)
+        }
 
         // パーマリンク取得（親メッセージ）
         const parentPermalinkResult = await adapter.getPermalink({
@@ -197,7 +199,7 @@ export function useSlackSearchUnified(options?: UseSlackSearchOptions): UseSlack
     }
 
     return { threads, userMaps, permalinkMaps }
-  }
+  }, [adapter])
 
   /**
    * 検索実行
@@ -315,7 +317,7 @@ export function useSlackSearchUnified(options?: UseSlackSearchOptions): UseSlack
       // リトライ可能性判定
       setCanRetry(apiError.type === 'network' || apiError.type === 'rate_limit')
     }
-  }, [adapter])
+  }, [adapter, buildSearchQuery, groupMessagesByThread, fetchThreadDetails])
 
   /**
    * 再試行
@@ -378,7 +380,7 @@ function generateSingleThreadMarkdown(
 ): string {
   const parentUser = userMaps[thread.parent.user] || thread.parent.user
   const parentPermalink = permalinkMaps[thread.parent.ts] || '#'
-  const parentDate = new Date(parseFloat(thread.parent.ts) * 1000).toLocaleString('ja-JP')
+  const parentDate = new Date(Number.parseFloat(thread.parent.ts) * 1000).toLocaleString('ja-JP')
 
   let markdown = `## 🧵 スレッド: ${thread.parent.text.slice(0, 50)}...
 
@@ -393,7 +395,7 @@ function generateSingleThreadMarkdown(
     thread.replies.forEach((reply, index) => {
       const replyUser = userMaps[reply.user] || reply.user
       const replyPermalink = permalinkMaps[reply.ts] || '#'
-      const replyDate = new Date(parseFloat(reply.ts) * 1000).toLocaleString('ja-JP')
+      const replyDate = new Date(Number.parseFloat(reply.ts) * 1000).toLocaleString('ja-JP')
 
       markdown += `
 #### 💬 返信 ${index + 1}: ${replyUser} - ${replyDate}

--- a/src/lib/docbaseClient.ts
+++ b/src/lib/docbaseClient.ts
@@ -1,4 +1,4 @@
-import { type Result } from 'neverthrow'
+import type { Result } from 'neverthrow'
 import { createDocbaseAdapter, type DocbaseSearchParams } from '../adapters/docbaseAdapter'
 import { createFetchHttpClient } from '../adapters/fetchHttpClient'
 import type { AdvancedFilters } from '../hooks/useSearch'

--- a/src/utils/markdownGenerator.ts
+++ b/src/utils/markdownGenerator.ts
@@ -33,7 +33,7 @@ export const generateMarkdown = (posts: DocbasePostListItem[], searchKeyword?: s
     ? minDate.toLocaleDateString('ja-JP')
     : `${minDate.toLocaleDateString('ja-JP')} - ${maxDate.toLocaleDateString('ja-JP')}`
   
-  markdown += `# Docbase Articles Collection\n\n`
+  markdown += '# Docbase Articles Collection\n\n'
   
   markdown += '## Collection Overview\n'
   markdown += `- **Total Articles**: ${posts.length}\n`
@@ -41,7 +41,7 @@ export const generateMarkdown = (posts: DocbasePostListItem[], searchKeyword?: s
     markdown += `- **Search Keyword**: "${searchKeyword}"\n`
   }
   markdown += `- **Date Range**: ${dateRange}\n`
-  markdown += `- **Source**: Docbase Knowledge Base\n\n`
+  markdown += '- **Source**: Docbase Knowledge Base\n\n'
 
   // 目次
   markdown += '## Articles Index\n\n'

--- a/src/utils/slackMarkdownGenerator.ts
+++ b/src/utils/slackMarkdownGenerator.ts
@@ -52,7 +52,7 @@ export const generateSlackThreadsMarkdown = (
     ? minDate.toLocaleDateString('ja-JP')
     : `${minDate.toLocaleDateString('ja-JP')} - ${maxDate.toLocaleDateString('ja-JP')}`
 
-  markdown += `# Slack Threads Collection\n\n`
+  markdown += '# Slack Threads Collection\n\n'
   
   markdown += '## Collection Overview\n'
   markdown += `- **Total Threads**: ${threads.length}\n`
@@ -63,7 +63,7 @@ export const generateSlackThreadsMarkdown = (
   markdown += `- **Channels**: ${channels.join(', ')}\n`
   markdown += `- **Date Range**: ${dateRange}\n`
   markdown += `- **Participants**: ${allParticipants.length} unique users\n`
-  markdown += `- **Source**: Slack Workspace\n\n`
+  markdown += '- **Source**: Slack Workspace\n\n'
 
   // スレッド目次
   markdown += '## Threads Index\n\n'


### PR DESCRIPTION
$(cat <<'EOF'
## 概要

Issue #55 の実装として、GitHub ActionsでBiome lintチェックが失敗していた全てのエラーを修正しました。

## 変更内容

### 🔧 スタイル関連の修正
- `Math.pow` を `**` 演算子に変更（1件）
- 不要なテンプレートリテラルを通常の文字列に変更（4件）
- `parseFloat` を `Number.parseFloat` に変更（2件）
- 未使用のインポートを `import type` に変更（1件）

### 🎯 型関連の修正
- `any` 型を適切な型に変更：
  - `Error | null` への変更（1件）
  - `unknown[]` への変更（1件）

### ⚛️ React/DOM関連の修正
- ボタン要素に明示的な `type="button"` 属性を追加（1件）

### 🚀 パフォーマンス関連の修正
- `forEach` を `for...of` ループに変更（1件）

### 🪝 React Hooks関連の修正
- 不要な依存関係を削除（`adapter` を `useSearch` から削除）
- 不足している依存関係を追加（`useSlackSearchUnified` の `handleSearch`）
- 関数を `useCallback` でラップして依存関係エラーを解消：
  - `buildSearchQuery`
  - `groupMessagesByThread`
  - `fetchThreadDetails`

## テスト結果

- ✅ `npm run lint` が警告・エラーなしで成功
- ✅ 全てのlintエラーが解消されたことを確認

## 関連 Issue

- Closes #55

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)