### PR TITLE
feat(slack): Slack APIトークンのLocalStorage保存機能実装

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -21,10 +21,14 @@ export {
 } from './slackAdapter'
 
 // デフォルトインスタンス作成用のヘルパー関数
+import { createFetchHttpClient as fetchClient } from './fetchHttpClient'
+import { createDocbaseAdapter as docbaseAdapter } from './docbaseAdapter'
+import { createSlackAdapter as slackAdapter } from './slackAdapter'
+
 export function createDefaultDocbaseAdapter() {
-  return createDocbaseAdapter(createFetchHttpClient())
+  return docbaseAdapter(fetchClient())
 }
 
 export function createDefaultSlackAdapter() {
-  return createSlackAdapter(createFetchHttpClient())
+  return slackAdapter(fetchClient())
 }

--- a/src/app/slack/page.tsx
+++ b/src/app/slack/page.tsx
@@ -8,11 +8,12 @@ import Header from '../../components/Header'
 import { SlackHeroSection } from '../../components/SlackHeroSection'
 import { SlackSearchForm } from '../../components/SlackSearchForm'
 import { useDownload } from '../../hooks/useDownload'
+import useLocalStorage from '../../hooks/useLocalStorage'
 // import { useSlackSearch } from '../../hooks/useSlackSearch' // TODO: Issue #39で統一フックに移行
 import { generateSlackThreadsMarkdown } from '../../utils/slackMarkdownGenerator'
 
 export default function SlackPage() {
-  const [token, setToken] = useState<string>('')
+  const [token, setToken] = useLocalStorage<string>('slackApiToken', '')
   const [searchQuery, setSearchQuery] = useState<string>('')
   const [startDate, setStartDate] = useState<string>('')
   const [endDate, setEndDate] = useState<string>('')
@@ -34,20 +35,6 @@ export default function SlackPage() {
     // TODO: Issue #39で実装
     console.log('Search function will be implemented in Issue #39')
   }
-
-  // ローカルストレージからトークンを読み込み・保存するuseEffect
-  useEffect(() => {
-    const storedToken = localStorage.getItem('slackApiToken')
-    if (storedToken) {
-      setToken(storedToken)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (token) {
-      localStorage.setItem('slackApiToken', token)
-    }
-  }, [token])
 
   const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()


### PR DESCRIPTION
## 概要
Issue #50 の実装として、Slack APIトークンをLocalStorageに保存する機能を実装しました。

## 変更内容
- `src/app/slack/page.tsx`: useLocalStorageフックを使用した実装に変更
- `src/adapters/index.ts`: 循環参照エラーの修正

## 実装詳細
- 既存のuseEffectによる直接実装を`useLocalStorage`フックに置き換え
- Docbaseページと同じ実装パターンに統一
- ページリロード・再訪問時にトークンが自動復元される

## テスト手順
1. `npm run dev` で開発サーバーを起動
2. Slackページ（/slack）にアクセス
3. Slack APIトークンを入力
4. ページをリロードしてトークンが復元されることを確認
5. ブラウザのLocalStorageで`slackApiToken`キーが保存されていることを確認

## 影響範囲
- Slackページのトークン管理のみ
- 既存の検索機能・UI動作に変更なし

Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)