### PR TITLE
fix: ホームページのSlack機能表記と実装状況の矛盾を修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,21 +15,33 @@ export default function HomePage() {
             さまざまな情報ソースからデータを収集し、NotebookLMで活用できるMarkdownを生成します。
           </p>
         </div>
-        <div className="grid md:grid-cols-2 gap-8 w-full max-w-4xl">
+        <div className="grid md:grid-cols-2 gap-8 w-full max-w-4xl mb-12">
           <Link
             href="/docbase"
             className="block p-8 bg-white rounded-lg shadow-lg hover:shadow-xl transition-shadow border border-gray-200"
           >
             <h2 className="text-3xl font-semibold mb-3 text-docbase-primary">Docbase連携</h2>
-            <p className="text-gray-700">Docbaseの記事を検索・収集し、Markdownを生成します。</p>
+            <p className="text-gray-700 mb-2">Docbaseの記事を検索・収集し、Markdownを生成します。</p>
+            <p className="text-sm text-gray-500">最大500件まで収集可能</p>
           </Link>
           <Link
             href="/slack"
             className="block p-8 bg-white rounded-lg shadow-lg hover:shadow-xl transition-shadow border border-gray-200"
           >
-            <h2 className="text-3xl font-semibold mb-3 text-indigo-600">Slack連携 (準備中)</h2>
-            <p className="text-gray-700">Slackのメッセージを収集し、Markdownを生成します。</p>
+            <h2 className="text-3xl font-semibold mb-3 text-indigo-600">Slack連携</h2>
+            <p className="text-gray-700 mb-2">Slackのスレッドを検索・収集し、NotebookLM用Markdownを生成します。</p>
+            <p className="text-sm text-gray-500">最大300件まで収集可能</p>
           </Link>
+        </div>
+        {/* セキュリティ説明セクション */}
+        <div className="w-full max-w-4xl">
+          <div className="px-6 py-8 rounded-xl border border-gray-200 bg-gray-50">
+            <h2 className="text-2xl font-bold mb-4 text-center text-gray-800">🔒 セキュリティについて</h2>
+            <p className="text-gray-600 text-center leading-relaxed">
+              入力されたAPIトークンや取得されたデータは、お使いのブラウザ内でのみ処理されます。<br />
+              外部サーバーへの送信や保存は一切行われませんので、安心してご利用いただけます。
+            </p>
+          </div>
         </div>
       </div>
       <Footer />


### PR DESCRIPTION
## 概要
Issue #48 の実装として、ホームページのSlack機能表記を実際の実装状況に合わせて修正しました。

## 変更内容
- ✅ Slack連携の「(準備中)」表記を削除
- ✅ Slack機能の説明文を実際の機能（スレッド検索・収集）に合わせて更新
- ✅ セキュリティ説明セクションを追加（ブラウザ内完結処理の説明）
- ✅ 各機能の制限（Docbase 500件、Slack 300件）を明記

## テスト手順
1. `npm run dev` でローカルサーバーを起動
2. http://localhost:3000 にアクセス
3. 以下を確認：
   - Slack連携に「(準備中)」の表記がないこと
   - Slack機能の説明が「スレッドを検索・収集」になっていること
   - セキュリティ説明セクションが表示されること
   - 各機能の収集件数制限が表示されること

Closes #48

🤖 Generated with [Claude Code](https://claude.ai/code)