### PR TITLE
fix: adapters/index.tsのTypeScriptエラーを修正 #58

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -20,11 +20,16 @@ export {
   type SlackSearchResponse,
 } from './slackAdapter'
 
+// 内部使用のためのインポート
+import { createDocbaseAdapter as _createDocbaseAdapter } from './docbaseAdapter'
+import { createSlackAdapter as _createSlackAdapter } from './slackAdapter'
+import { createFetchHttpClient as _createFetchHttpClient } from './fetchHttpClient'
+
 // デフォルトインスタンス作成用のヘルパー関数
 export function createDefaultDocbaseAdapter() {
-  return createDocbaseAdapter(createFetchHttpClient())
+  return _createDocbaseAdapter(_createFetchHttpClient())
 }
 
 export function createDefaultSlackAdapter() {
-  return createSlackAdapter(createFetchHttpClient())
+  return _createSlackAdapter(_createFetchHttpClient())
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- adapters/index.tsでTypeScriptの型チェックエラーを修正
- 内部使用のためのインポートを_プレフィックス付きで明示的に追加
- エクスポートと内部使用のインポートを分離して名前の衝突を回避

## Test plan
- [x] `npm run type-check` が成功すること
- [x] `npm run lint` が成功すること
- [ ] GitHub Actions のビルドが成功すること

Closes #58

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)