### PR TITLE
fix: 検索実行前に「検索条件に該当するスレッドは見つかりませんでした」が表示される問題を修正

### DIFF
--- a/src/app/slack/page.tsx
+++ b/src/app/slack/page.tsx
@@ -28,6 +28,7 @@ export default function SlackPage() {
   const {
     isLoading,
     progressStatus,
+    hasSearched,
     error,
     slackThreads,
     userMaps,
@@ -114,6 +115,7 @@ export default function SlackPage() {
                 isLoading={isLoading}
                 isDownloading={isDownloading}
                 progressStatus={progressStatus}
+                hasSearched={hasSearched}
                 error={error?.message || null}
                 slackThreads={slackThreads}
                 userMaps={userMaps}

--- a/src/components/SlackSearchForm.tsx
+++ b/src/components/SlackSearchForm.tsx
@@ -37,6 +37,7 @@ type SlackSearchFormProps = {
   isLoading: boolean
   isDownloading: boolean
   progressStatus: ProgressStatus
+  hasSearched: boolean
   error: string | null
   
   // 結果
@@ -68,6 +69,7 @@ export function SlackSearchForm({
   isLoading,
   isDownloading,
   progressStatus,
+  hasSearched,
   error,
   slackThreads,
   userMaps,
@@ -251,7 +253,7 @@ export function SlackSearchForm({
         )}
         
         {/* スレッドが0件のときの案内 */}
-        {slackThreads.length === 0 && !isLoading && !error && (
+        {slackThreads.length === 0 && !isLoading && !error && hasSearched && (
           <div className="mt-6 pt-5 border-t border-gray-200 text-gray-500 text-center">
             検索条件に該当するスレッドは見つかりませんでした。
           </div>

--- a/src/hooks/useSlackSearchUnified.ts
+++ b/src/hooks/useSlackSearchUnified.ts
@@ -51,6 +51,7 @@ interface UseSlackSearchState {
   }
   isLoading: boolean
   progressStatus: ProgressStatus
+  hasSearched: boolean
   error: ApiError | null
 }
 
@@ -96,6 +97,7 @@ export function useSlackSearchUnified(options?: UseSlackSearchOptions): UseSlack
       phase: 'idle',
       message: '',
     },
+    hasSearched: false,
     error: null,
   })
 
@@ -270,6 +272,7 @@ export function useSlackSearchUnified(options?: UseSlackSearchOptions): UseSlack
     setState(prev => ({ 
       ...prev, 
       isLoading: true, 
+      hasSearched: true,
       error: null,
       progressStatus: {
         phase: 'searching',


### PR DESCRIPTION
## 概要
Issue #67 の修正として、Slack検索ページで検索実行前に不適切なメッセージが表示される問題を解決しました。

## 問題
- ページ読み込み直後（検索実行前）から「検索条件に該当するスレッドは見つかりませんでした。」というメッセージが表示されていた
- ユーザーが何も操作していないのにエラーメッセージのような内容が見える状態だった

## 解決策

### 🔧 hasSearchedフラグの追加
- `useSlackSearchUnified`フックに検索実行状態を追跡する`hasSearched`フラグを追加
- 初期状態では`false`、検索実行時に`true`に設定

### 🎯 条件分岐ロジックの改善
**修正前:**
```typescript
{slackThreads.length === 0 && !isLoading && !error && (
  // メッセージ表示
)}
```

**修正後:**
```typescript
{slackThreads.length === 0 && !isLoading && !error && hasSearched && (
  // メッセージ表示
)}
```

## 動作確認

### ✅ 期待される動作
- **検索実行前**: 結果メッセージなし
- **検索実行後（結果なし）**: 「検索条件に該当するスレッドは見つかりませんでした。」
- **検索実行後（結果あり）**: 適切な結果表示

### 📝 変更ファイル
- `src/hooks/useSlackSearchUnified.ts` - hasSearchedフラグの追加
- `src/components/SlackSearchForm.tsx` - 条件分岐の改善
- `src/app/slack/page.tsx` - プロパティの追加

## テスト手順
1. Slackページにアクセス
2. ページ読み込み直後に不適切なメッセージが表示されないことを確認
3. 検索実行後に適切なメッセージが表示されることを確認

Closes #67

🤖 Generated with [Claude Code](https://claude.ai/code)