### PR TITLE
fix(test): Playwrightテストコンフィグエラーを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,14 @@ jobs:
       - name: Run type check
         run: npm run type-check
 
-      - name: Run tests
+      - name: Run unit tests
         run: npm test
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Storybook tests
+        run: npm run test:e2e
 
       - name: Run build
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "notebooklm-collector",
       "version": "0.1.0",
       "dependencies": {
-        "@playwright/test": "^1.52.0",
         "neverthrow": "^8.2.0",
         "next": "15.3.2",
         "postcss": "^8.5.3",
@@ -21,6 +20,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.52.0",
         "@storybook/addon-a11y": "^8.6.14",
         "@storybook/addon-essentials": "^8.6.14",
         "@storybook/addon-viewport": "^8.6.14",
@@ -3616,6 +3616,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
       "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.52.0"
@@ -14200,6 +14201,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
       "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.52.0"
@@ -14218,6 +14220,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
       "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",
     "test:ui": "vitest --ui",
+    "test:e2e": "playwright test",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@playwright/test": "^1.52.0",
     "neverthrow": "^8.2.0",
     "next": "15.3.2",
     "postcss": "^8.5.3",
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.52.0",
     "@storybook/addon-a11y": "^8.6.14",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-viewport": "^8.6.14",

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,33 @@
+# Playwright E2E Tests
+
+このディレクトリには、Storybookのための Playwright E2E テストが含まれています。
+
+## テストの実行
+
+### 単体テスト（Vitest）
+```bash
+npm test
+```
+
+### E2Eテスト（Playwright）
+```bash
+npm run test:e2e
+```
+
+## テスト分離の理由
+
+このプロジェクトでは、以下の理由により単体テストとE2Eテストを分離しています：
+
+1. **異なるテストランナー**: Vitest（単体テスト）とPlaywright（E2Eテスト）は異なるテスト構文を使用
+2. **パフォーマンス**: E2Eテストは時間がかかるため、開発中は単体テストのみ実行可能
+3. **CI/CD最適化**: CIパイプラインで並列実行可能
+
+## ディレクトリ構造
+
+- `/src/__tests__/` - Vitestによる単体テスト
+- `/tests/` - PlaywrightによるE2Eテスト（Storybook）
+
+## 設定ファイル
+
+- `vitest.config.ts` - Vitest設定（`/tests/`を除外）
+- `playwright.config.ts` - Playwright設定（Storybookサーバー起動を含む）

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,16 @@ export default defineConfig({
     // テストセットアップファイル
     setupFiles: './src/__tests__/setup.ts',
     
+    // テスト対象から除外
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/cypress/**',
+      '**/.{idea,git,cache,output,temp}/**',
+      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
+      '**/tests/**',  // Playwrightテストディレクトリを除外
+    ],
+    
     // カバレッジ設定
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## 概要
Issue #83 のCI/CDエラーを修正しました。PlaywrightとVitestのテストランナー競合が原因で発生していたエラーを解消しています。

## 変更内容
- `@playwright/test`をdependenciesからdevDependenciesに移動
- `vitest.config.ts`で`/tests/`ディレクトリを除外設定追加
- `package.json`に`test:e2e`スクリプトを追加（Playwrightテスト専用）
- CI/CDワークフローを更新：
  - Playwrightブラウザのインストールステップを追加
  - E2Eテスト実行ステップを追加
- テスト分離についてのREADMEドキュメントを追加

## テスト
- [x] 単体テスト（Vitest）が正常に動作することを確認
- [x] 既存のテストが全て通過することを確認
- [x] CI/CDパイプラインでの実行を想定した設定

## チェックリスト
- [x] コーディング規約準拠
- [x] セキュリティ考慮（該当なし）
- [x] パフォーマンス最適化（テスト実行時間の改善）
- [x] エラーハンドリング実装（該当なし）

Closes #83

---
🤖 **Auto-generated by Implementer**
**Timestamp**: 2025-06-01 16:52:00 UTC