### PR TITLE
fix(deploy): GitHub Pages専用デプロイ設定に変更してVercel依存を完全に削除

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,27 @@
-name: Deploy
+name: Deploy to GitHub Pages
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
+# GitHub Pages へのデプロイ権限を設定
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 並行実行を防ぐ（GitHub Pages デプロイの競合を避ける）
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: production
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout repository
@@ -29,16 +42,22 @@ jobs:
       - name: Run type check
         run: npm run type-check
 
-      - name: Build application
+      - name: Build application for GitHub Pages
         run: npm run build
+        env:
+          NEXT_PUBLIC_BASE_PATH: /notebooklm-collector
 
-      - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload build artifacts to GitHub Pages
+        uses: actions/upload-pages-artifact@v3
         with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-args: '--prod'
-          vercel-org-id: ${{ secrets.ORG_ID }}
-          vercel-project-id: ${{ secrets.PROJECT_ID }}
+          path: out
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
       - name: Comment on success
         if: success() && github.event_name == 'push'
@@ -49,5 +68,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
-              body: '🚀 デプロイが完了しました！'
+              body: '🚀 GitHub Pages へのデプロイが完了しました！\n📄 サイトURL: ${{ steps.deployment.outputs.page_url }}'
             })


### PR DESCRIPTION
## 概要

Issue #176の追加修正として、GitHub ActionsのデプロイワークフローをVercelからGitHub Pages用に完全に変更しました。

## 変更内容

### デプロイワークフローの変更
- `.github/workflows/deploy.yml`をGitHub Pages専用設定に書き換え
- Vercel関連の設定とsecrets依存を完全に削除
- GitHub Pages用の権限設定（`pages: write`, `id-token: write`）を追加
- 並行実行制御（concurrency）でデプロイ競合を防止

### 静的サイト生成対応
- `out/`フォルダの静的ファイルをGitHub Pagesにデプロイ
- `NEXT_PUBLIC_BASE_PATH=/notebooklm-collector`でサブパス対応
- `next.config.ts`の既存設定と連携

### デプロイフロー改善
- GitHub Pages専用のactions（`configure-pages`, `upload-pages-artifact`, `deploy-pages`）を使用
- デプロイ成功時にサイトURLをコメント表示

## 効果

- Vercelへの意図しないデプロイが完全に停止
- GitHub Pagesでの正常なデプロイが可能
- デプロイエラーの根本的な解決
- セキュリティ向上（不要なsecrets依存を削除）

## テスト手順

1. PR マージ後、mainブランチへのpushでGitHub Pagesデプロイが実行される
2. GitHub Pagesサイトが正常に更新される
3. Vercelへのデプロイが実行されない

## 関連 Issue

- resolves #176

🤖 Generated with [Claude Code](https://claude.ai/code)