### PR TITLE
fix(deploy): Vercelデプロイを削除してGitHub Pages専用設定に変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,13 +32,11 @@ jobs:
       - name: Build application
         run: npm run build
 
-      - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-args: '--prod'
-          vercel-org-id: ${{ secrets.ORG_ID }}
-          vercel-project-id: ${{ secrets.PROJECT_ID }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
 
       - name: Comment on success
         if: success() && github.event_name == 'push'
@@ -49,5 +47,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
-              body: '🚀 デプロイが完了しました！'
+              body: '🚀 GitHub Pagesへのデプロイが完了しました！'
             })


### PR DESCRIPTION
## 概要

Issue #176のコメント対応として、Vercel関連設定を削除してGitHub Pages専用のデプロイ設定に変更しました。

## 変更内容

- **deploy.yml**: Vercel ActionをGitHub Pages Actionに置き換え
  - `amondnet/vercel-action@v25` → `peaceiris/actions-gh-pages@v3`
  - デプロイ先を`./out`ディレクトリに変更
  - Vercel関連のsecrets（VERCEL_TOKEN、ORG_ID、PROJECT_ID）を削除
  - コミットコメントをGitHub Pages向けに更新

## 確認事項

✅ Vercel関連設定ファイル（vercel.json、.vercelignore）は存在しない  
✅ package.jsonにVercel関連スクリプトは存在しない  
✅ public/vercel.svgファイルは存在しない  
✅ next.config.tsはSSG向けに正しく設定済み（output: 'export'）  
✅ lint、type-check、buildが正常に動作  

## テスト手順

1. `npm run build` でビルドが成功することを確認
2. `./out`ディレクトリに静的ファイルが生成されることを確認
3. GitHub Pagesでのデプロイが正常に動作することを確認

## 関連 Issue

Closes #176

🤖 Generated with [Claude Code](https://claude.ai/code)