### PR TITLE
fix(deploy): GitHub Pagesワークフローのlint/type-checkコマンド修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,9 +74,9 @@ jobs:
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Run lint check
-        run: ${{ steps.detect-package-manager.outputs.runner }} npm run lint
+        run: npm run lint
       - name: Run type check
-        run: ${{ steps.detect-package-manager.outputs.runner }} npm run type-check
+        run: npm run type-check
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
         env:


### PR DESCRIPTION
## 概要
GitHub Pages デプロイメントワークフローで発生していたlintとtype-checkコマンドの実行エラーを修正しました。

## 変更内容
- `.github/workflows/deploy.yml`のlintとtype-checkコマンドを修正
- package manager runner変数の誤用を解決
- `npm run lint`と`npm run type-check`を直接実行するよう変更

## 問題の詳細
以前のワークフローでは以下のような誤った記述がありました：
```yaml
- name: Run lint check
  run: ${{ steps.detect-package-manager.outputs.runner }} npm run lint
```

この記述は`npx --no-install npm run lint`のような無効なコマンドを生成し、ビルドエラーの原因となっていました。

## 修正後
```yaml
- name: Run lint check
  run: npm run lint
- name: Run type check
  run: npm run type-check
```

## テスト手順
1. このPRをマージ後、mainブランチにプッシュされると自動的にGitHub Actionsが実行される
2. デプロイメントワークフローが正常に完了することを確認
3. GitHub Pagesサイトが正常にアクセス可能であることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)