### PR TITLE
docs(readme): GitHub Pages デプロイメント状況バッジを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NotebookLM Collector
 
+[![Deploy to GitHub Pages](https://github.com/sotaroNishioka/notebooklm-collector/actions/workflows/deploy.yml/badge.svg)](https://github.com/sotaroNishioka/notebooklm-collector/actions/workflows/deploy.yml)
+
 DocbaseとSlackから情報を収集し、NotebookLM向けに最適化されたMarkdownファイルを生成するWebアプリケーションです。
 
 ## 🎯 概要


### PR DESCRIPTION
## 概要
READMEファイルにGitHub Pages デプロイメント状況を表示するバッジを追加しました。

## 変更内容
- GitHub Actions ワークフローのデプロイメント状況バッジを追加
- ユーザーがサイトの稼働状況を一目で確認できるように改善
- デプロイメントプロセスの透明性を向上

## 追加したバッジ
```markdown
[![Deploy to GitHub Pages](https://github.com/sotaroNishioka/notebooklm-collector/actions/workflows/deploy.yml/badge.svg)](https://github.com/sotaroNishioka/notebooklm-collector/actions/workflows/deploy.yml)
```

## 効果
- リポジトリ訪問者がデプロイメント状況を即座に把握可能
- 最新のデプロイメントが成功しているかを確認できる
- GitHub Pages サイトの信頼性を視覚的に示す

## テスト手順
1. READMEでバッジが正しく表示されることを確認
2. バッジをクリックしてGitHub Actionsページに正しく遷移することを確認
3. lint と type-check が正常に通ることを確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)