### PR TITLE
fix: GitHub Actionsデプロイワークフローのlintエラーを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,4 +205,4 @@ npm run type-check   # TypeScript型チェック
 ---
 
 **NotebookLM Collector v1.9**  
-🤖 Generated with [Claude Code](https://claude.ai/code)
+🤖 Generated with [Claude Code](https://claude.ai/code)<!-- Debug deploy workflow test -->

--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,7 @@
   "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
   "organizeImports": {
     "enabled": true,
-    "ignore": [".next/**", "node_modules/**", "public/**", ".github/**", "out/**", "coverage/**"]
+    "ignore": [".next/**", "node_modules/**", "public/**", ".github/**", "out/**", "coverage/**", ".claude/**"]
   },
   "linter": {
     "enabled": true,
@@ -16,6 +16,7 @@
       ".github/**",
       "out/**",
       "coverage/**",
+      ".claude/**",
       "next.config.ts",
       "postcss.config.mjs",
       "tailwind.config.ts",
@@ -35,6 +36,7 @@
       ".github/**",
       "out/**",
       "coverage/**",
+      ".claude/**",
       "postcss.config.mjs",
       "tailwind.config.ts",
       "tsconfig.json"


### PR DESCRIPTION
## 概要
GitHub Actionsのデプロイワークフローで発生していたlintエラーを修正しました。

## 問題の詳細
- PRのCIでは通るが、mainブランチマージ後のデプロイワークフローでlintエラーが発生
- 原因：デプロイワークフローで設定される`NEXT_PUBLIC_BASE_PATH`環境変数により、`.claude/settings.local.json`のフォーマットエラーが検出される

## 修正内容
- `biome.json`の無視リストに`.claude/**`を追加
- organizeImports、linter、formatterすべてで`.claude`ディレクトリを無視

## テスト結果
```bash
NEXT_PUBLIC_BASE_PATH=/notebooklm-collector npm run lint
# ✅ エラーなし
```

## 確認事項
- [x] ローカルでの環境変数付きlintテストが通過
- [x] デプロイワークフローと同じ条件でのテストが成功

これでmainブランチマージ後のデプロイ前テストエラーが解消されるはずです。