### PR TITLE
fix: GitHub Actionsデプロイワークフローのlintエラーを根本解決

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -2,15 +2,7 @@
   "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
   "organizeImports": {
     "enabled": true,
-    "ignore": [
-      ".next/**",
-      "node_modules/**",
-      "public/**",
-      ".github/**",
-      "out/**",
-      "coverage/**",
-      ".claude/**"
-    ]
+    "ignore": [".next/**", "node_modules/**", "public/**", ".github/**", "out/**", "coverage/**", ".claude/**"]
   },
   "linter": {
     "enabled": true,

--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,15 @@
   "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
   "organizeImports": {
     "enabled": true,
-    "ignore": [".next/**", "node_modules/**", "public/**", ".github/**", "out/**", "coverage/**"]
+    "ignore": [
+      ".next/**",
+      "node_modules/**",
+      "public/**",
+      ".github/**",
+      "out/**",
+      "coverage/**",
+      ".claude/**"
+    ]
   },
   "linter": {
     "enabled": true,
@@ -16,7 +24,9 @@
       ".github/**",
       "out/**",
       "coverage/**",
+      ".claude/**",
       "next.config.ts",
+      "next.config.js",
       "postcss.config.mjs",
       "tailwind.config.ts",
       "tsconfig.json"
@@ -35,6 +45,7 @@
       ".github/**",
       "out/**",
       "coverage/**",
+      ".claude/**",
       "postcss.config.mjs",
       "tailwind.config.ts",
       "tsconfig.json"


### PR DESCRIPTION
## 概要
GitHub Actionsのデプロイワークフローで継続的に発生していたlintエラーを根本的に解決しました。

## 問題の詳細
- **症状**: PRのCIでは通るが、mainブランチマージ後のデプロイワークフローでlintエラーが発生
- **原因**: デプロイワークフローで設定される`NEXT_PUBLIC_BASE_PATH=/notebooklm-collector`環境変数により、`.claude/settings.local.json`のフォーマットエラーがBiomeで検出される
- **根本原因**: `.claude`ディレクトリがBiomeの無視リストに含まれていない

## 修正内容
- `biome.json`の無視リストに`.claude/**`を追加:
  - `organizeImports.ignore`
  - `linter.ignore` 
  - `formatter.ignore`
- `next.config.js`も無視対象に追加（将来的な対応）
- Biome設定ファイルのフォーマットを統一

## テスト結果
```bash
# ✅ 環境変数設定時のlintテスト
NEXT_PUBLIC_BASE_PATH=/notebooklm-collector npm run lint
# エラーなし

# ✅ 通常のlintテスト  
npm run lint
# エラーなし
```

## 影響範囲
- `.claude`ディレクトリはClaude Code専用の設定ファイルのため、無視しても問題なし
- デプロイワークフローでのlintエラーが解消され、安定したデプロイが可能

## 確認事項
- [x] ローカルでの環境変数付きlintテストが通過
- [x] デプロイワークフローと同じ条件でのテストが成功
- [x] 通常のlintテストも正常に動作

これで「PRでは通るがmainブランチマージ後のデプロイで失敗する」問題が根本的に解決されます。