### PR TITLE
fix: deploy.ymlの実行順序を修正してlintエラーを解決

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,92 +1,64 @@
-# Sample workflow for building and deploying a Next.js site to GitHub Pages
-#
-# To get started with Next.js see: https://nextjs.org/docs/getting-started
-#
-name: Deploy Next.js site to Pages
+name: Deploy
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches: [main]
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Detect package manager
-        id: detect-package-manager
-        run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine package manager"
-            exit 1
-          fi
-      - name: Setup Node.js
+
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
+          node-version: 20.x
+          cache: 'npm'
       - name: Restore cache
         uses: actions/cache@v4
         with:
           path: |
             .next/cache
-          # Generate a new cache whenever packages or source files change.
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+
       - name: Install dependencies
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+        run: npm ci
+
       - name: Run lint check
         run: npm run lint
+
       - name: Run type check
         run: npm run type-check
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          static_site_generator: next
+
       - name: Build with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        run: npm run build
         env:
           NEXT_PUBLIC_BASE_PATH: /notebooklm-collector
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
 
-  # Deployment job
   deploy:
     environment:
       name: github-pages

--- a/biome.json
+++ b/biome.json
@@ -38,6 +38,7 @@
       "out/**",
       "coverage/**",
       ".claude/**",
+      "next.config.js",
       "postcss.config.mjs",
       "tailwind.config.ts",
       "tsconfig.json"


### PR DESCRIPTION
## 概要

mainブランチマージ後のdeploy.yml処理中に発生していたlintエラーを解決しました。

## 変更内容

- **実行順序の修正**: `Setup Pages`ステップを`lint/type-check`の後に移動
- **Biome設定の修正**: `next.config.js`をformatterの無視リストに追加  
- **フォーマット統一**: deploy.ymlとci.ymlの書き方を統一

## 問題の詳細

deploy.ymlでは`actions/configure-pages@v5`がlintチェック前に`next.config.js`ファイルを生成していました。このファイルのフォーマットがBiome設定と一致せず、lintエラーが発生していました。

## 解決方法

1. ci.ymlと同じ実行順序に変更（lint → type-check → setup → build）
2. 生成されるJavaScriptファイルをBiome無視リストに追加
3. YAMLフォーマットの統一でメンテナンス性向上

## テスト手順

1. PRマージ後、mainブランチへのプッシュ時にGitHub Actionsが正常に完了することを確認
2. lintエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)