### PR TITLE
feat(ui): Slack画面にMarkdown生成ボタンとセキュリティ表記を追加

### DIFF
--- a/src/app/slack/page.tsx
+++ b/src/app/slack/page.tsx
@@ -92,6 +92,21 @@ export default function SlackPage() {
       <div className="relative z-10 flex flex-col items-center w-full">
         <SlackHeroSection />
 
+        <div className="flex justify-center bg-blue-500 w-full py-10">
+          <div className="flex flex-col items-center">
+            <button
+              type="button"
+              onClick={() => document.getElementById('main-tool-section')?.scrollIntoView({ behavior: 'smooth' })}
+              className="px-8 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-md shadow-md hover:shadow-lg transform hover:scale-105 transition-all duration-200 ease-in-out text-lg"
+            >
+              今すぐMarkdownを生成
+            </button>
+            <p className="text-white text-sm mt-2">
+              取得したSlackの情報はブラウザ内でのみ利用されます。サーバーには保存、送信されません。
+            </p>
+          </div>
+        </div>
+
         {/* メイン機能セクション */}
         <section id="main-tool-section" className="w-full my-12 bg-white">
           <div className="max-w-screen-lg mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-10 md:py-12 shadow-md rounded-lg border border-gray-200">


### PR DESCRIPTION
## 概要

Issue #174の要求に応じて、Slack画面にMarkdown生成ボタンとセキュリティ表記を追加し、DocbaseとSlack画面のUI一貫性を向上させました。

## 変更内容

### 追加された要素
- **「今すぐMarkdownを生成」ボタン**
  - 位置: SlackHeroSection下
  - スタイル: Docbase画面と統一された青いボタン（bg-blue-600 hover:bg-blue-700）
  - 機能: スムーズスクロールでメイン機能セクションに移動

- **セキュリティ表記**
  - テキスト: 「取得したSlackの情報はブラウザ内でのみ利用されます。サーバーには保存、送信されません。」
  - スタイル: 白文字、小さなフォントサイズ
  - 位置: ボタン下

## UI一貫性の向上

### Before（Slack画面）
- SlackHeroSection後に直接メイン機能セクション
- Markdown生成ボタンなし
- セキュリティ表記なし

### After（Slack画面）
- SlackHeroSection
- **Markdown生成ボタン + セキュリティ表記セクション**（新規追加）
- メイン機能セクション

### Docbase画面との整合性
- 同じボタンスタイルとレイアウト構造
- 媒体に応じたセキュリティ表記（「Docbase」→「Slack」）
- 一貫したユーザー体験の提供

## テスト結果

✅ **ビルド成功**: Next.js本番ビルド正常完了  
✅ **リント通過**: Biome lintエラーなし  
✅ **テスト通過**: 202/202テスト成功  
✅ **UI一貫性**: DocbaseとSlack画面の表記統一完了

## 受け入れ条件の達成状況

- ✅ Slack画面に「今すぐMarkdownを生成」ボタンを追加
- ✅ ボタン下にセキュリティ表記を追加
- ✅ UI一貫性の確保（Docbase画面との統一）

resolves #174

🤖 Generated with [Claude Code](https://claude.ai/code)