### PR TITLE
feat(ci): テストワークフローを4つのジョブに並列化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,16 @@ on:
     branches: [main]
 
 jobs:
-  lint-and-typecheck:
+  lint-check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20.x]  # Node.js 20のみでテスト実行を統一
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -29,14 +25,59 @@ jobs:
       - name: Run lint check
         run: npm run lint
 
+  type-check-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Run type check
         run: npm run type-check
 
       - name: Run build
         run: npm run build
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Run unit tests
         run: npm test
+
+  e2e-tests-and-security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -34,7 +33,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -55,7 +53,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -73,7 +70,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## 概要
Issue #189 の実装として、GitHub ActionsのCIワークフローを並列化し、Node.jsバージョン指定を削除しました。

## 変更内容
### Before: 単一ジョブでの順次実行
- `lint-and-typecheck` ジョブで以下を順次実行:
  - Lintチェック → 型チェック → ビルド → ユニットテスト → E2Eテスト → セキュリティ監査

### After: 4つのジョブでの並列実行
1. **`lint-check`** - Lintチェック
2. **`type-check-and-build`** - 型チェック + ビルド
3. **`unit-tests`** - ユニットテスト  
4. **`e2e-tests-and-security`** - E2Eテスト + セキュリティ監査

### Node.jsバージョン指定の削除
- 全4つのジョブから `node-version: '20'` 指定を削除
- GitHub Actionsのデフォルトバージョンを使用するよう最適化
- 不要なバージョン指定記述を削除（Issue要求に対応）

## メリット
- **実行時間短縮**: 最も時間のかかるジョブの時間まで短縮（推定50-70%削減）
- **失敗の特定が容易**: どのチェックが失敗したか明確に把握可能
- **部分再実行**: 特定のジョブのみの再実行が可能
- **スケーラビリティ**: 新しいテストの追加が容易
- **設定簡素化**: 不要なNode.jsバージョン指定を削除

## テスト手順
1. PRマージ後、GitHub Actionsページで4つのジョブが並列実行されることを確認
2. 各ジョブが独立して成功/失敗することを確認
3. 全体の実行時間が従来より短縮されていることを確認
4. デフォルトのNode.jsバージョンで正常動作することを確認

## 関連 Issue
- resolves #189

🤖 Generated with [Claude Code](https://claude.ai/code)