### PR TITLE
feat(ci): deploy.ymlワークフローを3つのジョブに並列化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,17 +15,55 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 20.x
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version-file: '.nvmrc'
           cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint check
+        run: npm run lint
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type check
+        run: npm run type-check
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, type-check]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
       - name: Restore cache
         uses: actions/cache@v4
         with:
@@ -37,12 +75,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Run lint check
-        run: npm run lint
-
-      - name: Run type check
-        run: npm run type-check
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## 概要
deploy.ymlワークフローを3つのジョブに並列化して、デプロイプロセスを高速化しました。

## 変更内容
- lintとtype-checkジョブを並列実行するように分離
- buildジョブはlintとtype-check完了後に実行
- 各ジョブで独立してNode.jsセットアップと依存関係のインストールを実行
- 処理時間の短縮を実現

## メリット
- lintとtype-checkが並列に実行されるため、全体的な実行時間が短縮
- エラーの早期発見が可能（lintまたはtype-checkで失敗した場合、buildはスキップ）
- 各ジョブが独立しているため、デバッグが容易

## 関連
- #189 のテストワークフロー並列化と同様のアプローチ