### PR TITLE
fix(ci): deploy.ymlでNode.js 20.xを明示的に指定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: 20.x
           cache: 'npm'
 
       - name: Install dependencies
@@ -39,10 +39,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: 20.x
           cache: 'npm'
 
       - name: Install dependencies
@@ -58,10 +58,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: 20.x
           cache: 'npm'
 
       - name: Restore cache


### PR DESCRIPTION
## 概要
deploy.ymlワークフローで.nvmrcファイルエラーが発生していたため、Node.js 20.xを明示的に指定するように修正しました。

## 変更内容
- すべてのジョブで`node-version-file: '.nvmrc'`を`node-version: 20.x`に変更
- CI.ymlと同じ実装方法に統一

## 背景
#207 をマージ後、GitHub Actionsで以下のエラーが発生：
```
Error: The specified node version file at: /home/runner/work/notebooklm-collector/notebooklm-collector/.nvmrc does not exist
```

## テスト計画
- [ ] GitHub Actionsのワークフローが正常に実行されることを確認
- [ ] lintジョブが成功することを確認
- [ ] type-checkジョブが成功することを確認
- [ ] buildジョブが成功することを確認
- [ ] deployジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)