### PR TITLE
feat(docbase): プレビュー表示の最適化とグループフィールド削除

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,23 +1,28 @@
-import type { StorybookConfig } from '@storybook/nextjs'
+import type { StorybookConfig } from "@storybook/nextjs";
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
-  addons: ['@storybook/addon-essentials', '@storybook/addon-a11y', '@storybook/addon-viewport'],
+  stories: ["../src/**/*.stories.@(js|jsx|ts|tsx|mdx)"],
+  addons: [
+    "@storybook/addon-essentials",
+    "@storybook/addon-a11y",
+    "@storybook/addon-viewport",
+  ],
   framework: {
-    name: '@storybook/nextjs',
+    name: "@storybook/nextjs",
     options: {},
   },
   docs: {
-    autodocs: 'tag',
+    autodocs: "tag",
   },
   typescript: {
     check: false,
-    reactDocgen: 'react-docgen-typescript',
+    reactDocgen: "react-docgen-typescript",
     reactDocgenTypescriptOptions: {
       shouldExtractLiteralValuesFromEnum: true,
-      propFilter: (prop) => (prop.parent ? !/node_modules/.test(prop.parent.fileName) : true),
+      propFilter: (prop) =>
+        prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,
     },
   },
-}
+};
 
-export default config
+export default config;

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,42 +1,43 @@
-import { addons } from '@storybook/manager-api'
-import { create } from '@storybook/theming/create'
+import { addons } from "@storybook/manager-api";
+import { create } from "@storybook/theming/create";
 
 const theme = create({
-  base: 'light',
-  brandTitle: 'NotebookLM Collector',
-  brandUrl: 'https://github.com/sotaroNishioka/notebooklm-collector',
+  base: "light",
+  brandTitle: "NotebookLM Collector",
+  brandUrl: "https://github.com/sotaroNishioka/notebooklm-collector",
   brandImage: undefined,
-  brandTarget: '_self',
+  brandTarget: "_self",
 
-  colorPrimary: '#3b82f6',
-  colorSecondary: '#6366f1',
+  colorPrimary: "#3b82f6",
+  colorSecondary: "#6366f1",
 
   // UI
-  appBg: '#ffffff',
-  appContentBg: '#ffffff',
-  appBorderColor: '#e5e7eb',
+  appBg: "#ffffff",
+  appContentBg: "#ffffff",
+  appBorderColor: "#e5e7eb",
   appBorderRadius: 6,
 
   // Typography
   fontBase: '"Inter", "Helvetica Neue", Helvetica, Arial, sans-serif',
-  fontCode: 'Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+  fontCode:
+    'Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
 
   // Text colors
-  textColor: '#1f2937',
-  textInverseColor: '#ffffff',
+  textColor: "#1f2937",
+  textInverseColor: "#ffffff",
 
   // Toolbar default and active colors
-  barTextColor: '#6b7280',
-  barSelectedColor: '#3b82f6',
-  barBg: '#f9fafb',
+  barTextColor: "#6b7280",
+  barSelectedColor: "#3b82f6",
+  barBg: "#f9fafb",
 
   // Form colors
-  inputBg: '#ffffff',
-  inputBorder: '#d1d5db',
-  inputTextColor: '#1f2937',
+  inputBg: "#ffffff",
+  inputBorder: "#d1d5db",
+  inputTextColor: "#1f2937",
   inputBorderRadius: 4,
-})
+});
 
 addons.setConfig({
   theme,
-})
+});

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,9 +1,9 @@
-import type { Preview } from '@storybook/react'
-import '../src/app/globals.css'
+import type { Preview } from "@storybook/react";
+import "../src/app/globals.css";
 
 const preview: Preview = {
   parameters: {
-    actions: { argTypesRegex: '^on[A-Z].*' },
+    actions: { argTypesRegex: "^on[A-Z].*" },
     controls: {
       matchers: {
         color: /(background|color)$/i,
@@ -13,31 +13,31 @@ const preview: Preview = {
     viewport: {
       viewports: {
         mobile: {
-          name: 'Mobile',
+          name: "Mobile",
           styles: {
-            width: '375px',
-            height: '667px',
+            width: "375px",
+            height: "667px",
           },
         },
         tablet: {
-          name: 'Tablet',
+          name: "Tablet",
           styles: {
-            width: '768px',
-            height: '1024px',
+            width: "768px",
+            height: "1024px",
           },
         },
         desktop: {
-          name: 'Desktop',
+          name: "Desktop",
           styles: {
-            width: '1024px',
-            height: '768px',
+            width: "1024px",
+            height: "768px",
           },
         },
         large: {
-          name: 'Large Desktop',
+          name: "Large Desktop",
           styles: {
-            width: '1440px',
-            height: '900px',
+            width: "1440px",
+            height: "900px",
           },
         },
       },
@@ -45,23 +45,23 @@ const preview: Preview = {
     a11y: {
       config: {},
       options: {
-        checks: { 'color-contrast': { options: { noScroll: true } } },
+        checks: { "color-contrast": { options: { noScroll: true } } },
         restoreScroll: true,
       },
     },
   },
   globalTypes: {
     theme: {
-      description: 'Global theme for components',
-      defaultValue: 'light',
+      description: "Global theme for components",
+      defaultValue: "light",
       toolbar: {
-        title: 'Theme',
-        icon: 'circlehollow',
-        items: ['light', 'dark'],
+        title: "Theme",
+        icon: "circlehollow",
+        items: ["light", "dark"],
         dynamicTitle: true,
       },
     },
   },
-}
+};
 
-export default preview
+export default preview;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,7 +399,6 @@ git branch -d issue-42-auth-result-type
 | 投稿者   | `author:ユーザーID`                | `author:user123`                                  |
 | タイトル | `title:キーワード`                 | `title:仕様書`                                    |
 | 投稿期間 | `created_at:YYYY-MM-DD~YYYY-MM-DD` | `created_at:2023-01-01~2023-12-31`                |
-| グループ | `group:グループ名`                 | `group:開発チーム`                                |
 
 ### Slack API 連携
 
@@ -425,7 +424,7 @@ git branch -d issue-42-auth-result-type
 | -------------- | ------------------------ | ---------------------------- |
 | 検索方式       | スレッド単位でまとめて表示 | 記事単位で表示               |
 | 最大取得件数   | 300件（スレッド）         | 500件（記事）                |
-| 詳細検索条件   | チャンネル、投稿者、期間  | タグ、投稿者、タイトル、期間、グループ |
+| 詳細検索条件   | チャンネル、投稿者、期間  | タグ、投稿者、タイトル、期間 |
 | プレビュー     | 最初の10スレッドのみ      | 全記事                       |
 | 認証方式       | User Token (xoxp-)       | API Token                    |
 | ローカルストレージ | slackApiToken           | docbaseApiToken, docbaseDomain |

--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,15 @@
   "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
   "organizeImports": {
     "enabled": true,
-    "ignore": [".next/**", "node_modules/**", "public/**", ".github/**", "out/**", "coverage/**", ".claude/**"]
+    "ignore": [
+      ".next/**",
+      "node_modules/**",
+      "public/**",
+      ".github/**",
+      "out/**",
+      "coverage/**",
+      ".claude/**"
+    ]
   },
   "linter": {
     "enabled": true,
@@ -29,7 +37,7 @@
     "formatWithErrors": false,
     "indentStyle": "space",
     "indentWidth": 2,
-    "lineWidth": 120,
+    "lineWidth": 80,
     "ignore": [
       ".next/**",
       "node_modules/**",
@@ -46,10 +54,14 @@
   },
   "javascript": {
     "formatter": {
-      "quoteStyle": "single",
+      "quoteStyle": "double",
       "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded",
-      "semicolons": "asNeeded"
+      "semicolons": "always",
+      "trailingCommas": "es5",
+      "bracketSpacing": true,
+      "bracketSameLine": false,
+      "arrowParentheses": "always"
     }
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,25 +1,25 @@
-import type { NextConfig } from 'next'
+import type { NextConfig } from "next";
 
 // NEXT_PUBLIC_BASE_PATH は .env.production や GitHub Actions の env で設定される
 // GitHub Pages のリポジトリ名（サブパス）が入ることを想定 (例: "/my-app")
 // 値が取得できない場合は空文字とし、ローカル開発時はサブパスなしで動作するようにする
-const repoSubPath = process.env.NEXT_PUBLIC_BASE_PATH || ''
-const isProd = process.env.NODE_ENV === 'production'
+const repoSubPath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+const isProd = process.env.NODE_ENV === "production";
 
 const nextConfig: NextConfig = {
   // ① GitHub Pages 用に静的書き出し
-  output: 'export', // Next.js 13.3 以降での静的エクスポート指定
+  output: "export", // Next.js 13.3 以降での静的エクスポート指定
   trailingSlash: true, // URLの末尾にスラッシュを強制し、404エラーを防ぐ
 
   // ② サブパス設定（ビルド時に決定）
   // isProd の判定は、ローカル開発時 (npm run dev) にサブパスが適用されないようにするため
-  basePath: isProd ? repoSubPath : '',
-  assetPrefix: isProd ? `${repoSubPath}/` : '', // assetPrefix は末尾にスラッシュが必要な場合があるため注意
+  basePath: isProd ? repoSubPath : "",
+  assetPrefix: isProd ? `${repoSubPath}/` : "", // assetPrefix は末尾にスラッシュが必要な場合があるため注意
 
   // 画像最適化サーバーを使わない場合（静的エクスポート時は true を推奨）
   images: {
     unoptimized: true,
   },
-}
+};
 
-export default nextConfig
+export default nextConfig;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig, devices } from "@playwright/test";
 
 /**
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
-  testDir: './tests',
+  testDir: "./tests",
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -14,14 +14,14 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [['html'], ['github']] : 'html',
+  reporter: process.env.CI ? [["html"], ["github"]] : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:6006',
+    baseURL: "http://localhost:6006",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
 
     /* Action and navigation timeouts */
     actionTimeout: 10000,
@@ -31,12 +31,16 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'chromium',
+      name: "chromium",
       use: {
-        ...devices['Desktop Chrome'],
+        ...devices["Desktop Chrome"],
         // Storybookでの安定性向上のための設定
         launchOptions: {
-          args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+          args: [
+            "--no-sandbox",
+            "--disable-setuid-sandbox",
+            "--disable-dev-shm-usage",
+          ],
         },
       },
     },
@@ -44,11 +48,11 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run storybook -- --no-open --quiet',
-    url: 'http://localhost:6006',
+    command: "npm run storybook -- --no-open --quiet",
+    url: "http://localhost:6006",
     reuseExistingServer: !process.env.CI,
     timeout: 180 * 1000, // 3分に延長
-    stdout: 'pipe',
-    stderr: 'pipe',
+    stdout: "pipe",
+    stderr: "pipe",
   },
-})
+});

--- a/src/__tests__/adapters/docbaseAdapter.test.ts
+++ b/src/__tests__/adapters/docbaseAdapter.test.ts
@@ -1,37 +1,41 @@
 // Docbaseアダプターのテスト
 // モックHTTPクライアントを使用してアダプターの動作を検証
 
-import { describe, expect, it } from 'vitest'
-import { createErrorResponse, createMockHttpClient, createSuccessResponse } from '../../adapters/mockHttpClient'
-import { createDocbaseAdapter } from '../../features/docbase/adapters/docbaseAdapter'
-import type { DocbasePostsResponse } from '../../features/docbase/types/docbase'
-import type { ApiError } from '../../types/error'
+import { describe, expect, it } from "vitest";
+import {
+  createErrorResponse,
+  createMockHttpClient,
+  createSuccessResponse,
+} from "../../adapters/mockHttpClient";
+import { createDocbaseAdapter } from "../../features/docbase/adapters/docbaseAdapter";
+import type { DocbasePostsResponse } from "../../features/docbase/types/docbase";
+import type { ApiError } from "../../types/error";
 
-describe('DocbaseAdapter', () => {
-  const mockDomain = 'test-team'
-  const mockToken = 'test-token'
+describe("DocbaseAdapter", () => {
+  const mockDomain = "test-team";
+  const mockToken = "test-token";
   const mockSearchParams = {
     domain: mockDomain,
     token: mockToken,
-    keyword: 'テストキーワード',
-  }
+    keyword: "テストキーワード",
+  };
 
-  it('正常にDocbaseの投稿を検索できる', async () => {
+  it("正常にDocbaseの投稿を検索できる", async () => {
     const mockPosts: DocbasePostsResponse = {
       posts: [
         {
           id: 1,
-          title: 'テスト投稿1',
-          body: 'テスト内容1',
-          created_at: '2023-01-01T00:00:00Z',
-          url: 'https://test.docbase.io/posts/1',
+          title: "テスト投稿1",
+          body: "テスト内容1",
+          created_at: "2023-01-01T00:00:00Z",
+          url: "https://test.docbase.io/posts/1",
         },
         {
           id: 2,
-          title: 'テスト投稿2',
-          body: 'テスト内容2',
-          created_at: '2023-01-02T00:00:00Z',
-          url: 'https://test.docbase.io/posts/2',
+          title: "テスト投稿2",
+          body: "テスト内容2",
+          created_at: "2023-01-02T00:00:00Z",
+          url: "https://test.docbase.io/posts/2",
         },
       ],
       meta: {
@@ -39,43 +43,43 @@ describe('DocbaseAdapter', () => {
         next_page: null,
         total: 2,
       },
-    }
+    };
 
     const mockHttpClient = createMockHttpClient([
       createSuccessResponse(
         `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%E3%82%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%89%22&page=1&per_page=100`,
         mockPosts,
-        'GET',
+        "GET"
       ),
-    ])
+    ]);
 
-    const adapter = createDocbaseAdapter(mockHttpClient)
-    const result = await adapter.searchPosts(mockSearchParams)
+    const adapter = createDocbaseAdapter(mockHttpClient);
+    const result = await adapter.searchPosts(mockSearchParams);
 
-    expect(result.isOk()).toBe(true)
+    expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toHaveLength(2)
-      expect(result.value[0].title).toBe('テスト投稿1')
-      expect(result.value[1].title).toBe('テスト投稿2')
+      expect(result.value).toHaveLength(2);
+      expect(result.value[0].title).toBe("テスト投稿1");
+      expect(result.value[1].title).toBe("テスト投稿2");
     }
-  })
+  });
 
-  it('空のキーワードの場合は空配列を返す', async () => {
-    const mockHttpClient = createMockHttpClient([])
-    const adapter = createDocbaseAdapter(mockHttpClient)
+  it("空のキーワードの場合は空配列を返す", async () => {
+    const mockHttpClient = createMockHttpClient([]);
+    const adapter = createDocbaseAdapter(mockHttpClient);
 
     const result = await adapter.searchPosts({
       ...mockSearchParams,
-      keyword: '',
-    })
+      keyword: "",
+    });
 
-    expect(result.isOk()).toBe(true)
+    expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toHaveLength(0)
+      expect(result.value).toHaveLength(0);
     }
-  })
+  });
 
-  it('詳細検索条件を含む検索クエリを正しく構築する', async () => {
+  it("詳細検索条件を含む検索クエリを正しく構築する", async () => {
     const mockPosts: DocbasePostsResponse = {
       posts: [],
       meta: {
@@ -83,106 +87,108 @@ describe('DocbaseAdapter', () => {
         next_page: null,
         total: 0,
       },
-    }
-    const expectedUrl = `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%22+tag%3AAPI+author%3Auser123&page=1&per_page=100`
+    };
+    const expectedUrl = `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%22+tag%3AAPI+author%3Auser123&page=1&per_page=100`;
 
-    const mockHttpClient = createMockHttpClient([createSuccessResponse(expectedUrl, mockPosts, 'GET')])
+    const mockHttpClient = createMockHttpClient([
+      createSuccessResponse(expectedUrl, mockPosts, "GET"),
+    ]);
 
-    const adapter = createDocbaseAdapter(mockHttpClient)
+    const adapter = createDocbaseAdapter(mockHttpClient);
     const result = await adapter.searchPosts({
       ...mockSearchParams,
-      keyword: 'テスト',
+      keyword: "テスト",
       advancedFilters: {
-        tags: 'API',
-        author: 'user123',
-        titleFilter: '',
-        startDate: '',
-        endDate: '',
-        group: '',
+        tags: "API",
+        author: "user123",
+        titleFilter: "",
+        startDate: "",
+        endDate: "",
+        group: "",
       },
-    })
+    });
 
-    expect(result.isOk()).toBe(true)
-  })
+    expect(result.isOk()).toBe(true);
+  });
 
-  it('認証エラーを適切に処理する', async () => {
+  it("認証エラーを適切に処理する", async () => {
     const unauthorizedError: ApiError = {
-      type: 'unauthorized',
-      message: 'Unauthorized - Please check your API token',
-    }
+      type: "unauthorized",
+      message: "Unauthorized - Please check your API token",
+    };
 
     const mockHttpClient = createMockHttpClient([
       createErrorResponse(
         `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%E3%82%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%89%22&page=1&per_page=100`,
         unauthorizedError,
-        'GET',
+        "GET"
       ),
-    ])
+    ]);
 
-    const adapter = createDocbaseAdapter(mockHttpClient)
-    const result = await adapter.searchPosts(mockSearchParams)
+    const adapter = createDocbaseAdapter(mockHttpClient);
+    const result = await adapter.searchPosts(mockSearchParams);
 
-    expect(result.isErr()).toBe(true)
+    expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.type).toBe('unauthorized')
+      expect(result.error.type).toBe("unauthorized");
     }
-  })
+  });
 
-  it('複数ページのデータを統合する', async () => {
+  it("複数ページのデータを統合する", async () => {
     const page1Posts: DocbasePostsResponse = {
       posts: Array.from({ length: 100 }, (_, i) => ({
         id: i + 1,
         title: `投稿${i + 1}`,
         body: `内容${i + 1}`,
-        created_at: '2023-01-01T00:00:00Z',
+        created_at: "2023-01-01T00:00:00Z",
         url: `https://test.docbase.io/posts/${i + 1}`,
       })),
       meta: {
         previous_page: null,
-        next_page: '2',
+        next_page: "2",
         total: 150,
       },
-    }
+    };
 
     const page2Posts: DocbasePostsResponse = {
       posts: Array.from({ length: 50 }, (_, i) => ({
         id: i + 101,
         title: `投稿${i + 101}`,
         body: `内容${i + 101}`,
-        created_at: '2023-01-01T00:00:00Z',
+        created_at: "2023-01-01T00:00:00Z",
         url: `https://test.docbase.io/posts/${i + 101}`,
       })),
       meta: {
-        previous_page: '1',
+        previous_page: "1",
         next_page: null,
         total: 150,
       },
-    }
+    };
 
     const mockHttpClient = createMockHttpClient([
       createSuccessResponse(
         `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%22&page=1&per_page=100`,
         page1Posts,
-        'GET',
+        "GET"
       ),
       createSuccessResponse(
         `https://api.docbase.io/teams/${mockDomain}/posts?q=%22%E3%83%86%E3%82%B9%E3%83%88%22&page=2&per_page=100`,
         page2Posts,
-        'GET',
+        "GET"
       ),
-    ])
+    ]);
 
-    const adapter = createDocbaseAdapter(mockHttpClient)
+    const adapter = createDocbaseAdapter(mockHttpClient);
     const result = await adapter.searchPosts({
       ...mockSearchParams,
-      keyword: 'テスト',
-    })
+      keyword: "テスト",
+    });
 
-    expect(result.isOk()).toBe(true)
+    expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toHaveLength(150) // 100 + 50
-      expect(result.value[0].title).toBe('投稿1')
-      expect(result.value[149].title).toBe('投稿150')
+      expect(result.value).toHaveLength(150); // 100 + 50
+      expect(result.value[0].title).toBe("投稿1");
+      expect(result.value[149].title).toBe("投稿150");
     }
-  })
-})
+  });
+});

--- a/src/__tests__/adapters/docbaseAdapter.test.ts
+++ b/src/__tests__/adapters/docbaseAdapter.test.ts
@@ -165,7 +165,11 @@ describe("DocbaseAdapter", () => {
         body: `内容${i + 101}`,
         created_at: "2023-01-01T00:00:00Z",
         url: `https://test.docbase.io/posts/${i + 101}`,
-        user: { id: i + 101, name: `ユーザー${i + 101}`, profile_image_url: "" },
+        user: {
+          id: i + 101,
+          name: `ユーザー${i + 101}`,
+          profile_image_url: "",
+        },
         tags: [],
         scope: "everyone",
       })),

--- a/src/__tests__/adapters/docbaseAdapter.test.ts
+++ b/src/__tests__/adapters/docbaseAdapter.test.ts
@@ -29,6 +29,9 @@ describe("DocbaseAdapter", () => {
           body: "テスト内容1",
           created_at: "2023-01-01T00:00:00Z",
           url: "https://test.docbase.io/posts/1",
+          user: { id: 1, name: "テストユーザー1", profile_image_url: "" },
+          tags: [],
+          scope: "everyone",
         },
         {
           id: 2,
@@ -36,6 +39,9 @@ describe("DocbaseAdapter", () => {
           body: "テスト内容2",
           created_at: "2023-01-02T00:00:00Z",
           url: "https://test.docbase.io/posts/2",
+          user: { id: 2, name: "テストユーザー2", profile_image_url: "" },
+          tags: [],
+          scope: "everyone",
         },
       ],
       meta: {
@@ -104,7 +110,6 @@ describe("DocbaseAdapter", () => {
         titleFilter: "",
         startDate: "",
         endDate: "",
-        group: "",
       },
     });
 
@@ -142,6 +147,9 @@ describe("DocbaseAdapter", () => {
         body: `内容${i + 1}`,
         created_at: "2023-01-01T00:00:00Z",
         url: `https://test.docbase.io/posts/${i + 1}`,
+        user: { id: i + 1, name: `ユーザー${i + 1}`, profile_image_url: "" },
+        tags: [],
+        scope: "everyone",
       })),
       meta: {
         previous_page: null,
@@ -157,6 +165,9 @@ describe("DocbaseAdapter", () => {
         body: `内容${i + 101}`,
         created_at: "2023-01-01T00:00:00Z",
         url: `https://test.docbase.io/posts/${i + 101}`,
+        user: { id: i + 101, name: `ユーザー${i + 101}`, profile_image_url: "" },
+        tags: [],
+        scope: "everyone",
       })),
       meta: {
         previous_page: "1",

--- a/src/__tests__/adapters/slackAdapter.test.ts
+++ b/src/__tests__/adapters/slackAdapter.test.ts
@@ -1,35 +1,38 @@
-import { err, ok } from 'neverthrow'
-import { describe, expect, it, vi } from 'vitest'
-import { createMockHttpClient } from '../../adapters/mockHttpClient'
-import { type SlackAdapter, createSlackAdapter } from '../../features/slack/adapters/slackAdapter'
-import type { ApiError } from '../../types/error'
-import type { SlackMessage, SlackThread, SlackUser } from '../../types/slack'
+import { err, ok } from "neverthrow";
+import { describe, expect, it, vi } from "vitest";
+import { createMockHttpClient } from "../../adapters/mockHttpClient";
+import {
+  type SlackAdapter,
+  createSlackAdapter,
+} from "../../features/slack/adapters/slackAdapter";
+import type { ApiError } from "../../types/error";
+import type { SlackMessage, SlackThread, SlackUser } from "../../types/slack";
 
-describe('SlackAdapter', () => {
-  describe('searchMessages', () => {
-    it('メッセージ検索が成功する場合', async () => {
+describe("SlackAdapter", () => {
+  describe("searchMessages", () => {
+    it("メッセージ検索が成功する場合", async () => {
       // モックレスポンスの準備
       const mockMessages: SlackMessage[] = [
         {
-          ts: '1234567890.123456',
-          user: 'U123456',
-          text: 'テストメッセージ',
+          ts: "1234567890.123456",
+          user: "U123456",
+          text: "テストメッセージ",
           thread_ts: undefined,
-          channel: { id: 'C123456', name: 'general' },
-          permalink: 'https://slack.com/archives/C123456/p1234567890123456',
+          channel: { id: "C123456", name: "general" },
+          permalink: "https://slack.com/archives/C123456/p1234567890123456",
         },
-      ]
+      ];
 
       const mockResponse = {
         ok: true,
         messages: {
           matches: [
             {
-              ts: '1234567890.123456',
-              user: 'U123456',
-              text: 'テストメッセージ',
-              channel: { id: 'C123456', name: 'general' },
-              permalink: 'https://slack.com/archives/C123456/p1234567890123456',
+              ts: "1234567890.123456",
+              user: "U123456",
+              text: "テストメッセージ",
+              channel: { id: "C123456", name: "general" },
+              permalink: "https://slack.com/archives/C123456/p1234567890123456",
             },
           ],
           pagination: {
@@ -39,452 +42,455 @@ describe('SlackAdapter', () => {
             per_page: 20,
           },
         },
-      }
+      };
 
       // モックHTTPクライアントのセットアップ
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/search.messages',
-          method: 'POST',
+          url: "https://slack.com/api/search.messages",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
       // アダプターの作成とテスト実行
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.searchMessages({
-        token: 'xoxp-test-token',
-        query: 'test query',
+        token: "xoxp-test-token",
+        query: "test query",
         count: 20,
         page: 1,
-      })
+      });
 
       // 結果の検証
-      expect(result.isOk()).toBe(true)
+      expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.messages).toEqual(mockMessages)
+        expect(result.value.messages).toEqual(mockMessages);
         expect(result.value.pagination).toEqual({
           currentPage: 1,
           totalPages: 1,
           totalResults: 1,
           perPage: 20,
-        })
+        });
       }
-    })
+    });
 
-    it('トークンが無効な場合はエラーを返す', async () => {
+    it("トークンが無効な場合はエラーを返す", async () => {
       // エラーレスポンスの準備
       const mockResponse = {
         ok: false,
-        error: 'invalid_auth',
-      }
+        error: "invalid_auth",
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/search.messages',
-          method: 'POST',
+          url: "https://slack.com/api/search.messages",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.searchMessages({
-        token: 'invalid-token',
-        query: 'test query',
-      })
+        token: "invalid-token",
+        query: "test query",
+      });
 
       // エラーの検証
-      expect(result.isErr()).toBe(true)
+      expect(result.isErr()).toBe(true);
       if (result.isErr()) {
-        expect(result.error.type).toBe('unauthorized')
-        expect(result.error.message).toContain('Slack認証エラー')
+        expect(result.error.type).toBe("unauthorized");
+        expect(result.error.message).toContain("Slack認証エラー");
       }
-    })
+    });
 
-    it('パラメータが不足している場合はバリデーションエラーを返す', async () => {
-      const mockHttpClient = createMockHttpClient([])
-      const adapter = createSlackAdapter(mockHttpClient)
+    it("パラメータが不足している場合はバリデーションエラーを返す", async () => {
+      const mockHttpClient = createMockHttpClient([]);
+      const adapter = createSlackAdapter(mockHttpClient);
 
       // トークンが空の場合
       const result1 = await adapter.searchMessages({
-        token: '',
-        query: 'test query',
-      })
+        token: "",
+        query: "test query",
+      });
 
-      expect(result1.isErr()).toBe(true)
+      expect(result1.isErr()).toBe(true);
       if (result1.isErr()) {
-        expect(result1.error.type).toBe('validation')
+        expect(result1.error.type).toBe("validation");
       }
 
       // クエリが空の場合
       const result2 = await adapter.searchMessages({
-        token: 'xoxp-test-token',
-        query: '',
-      })
+        token: "xoxp-test-token",
+        query: "",
+      });
 
-      expect(result2.isErr()).toBe(true)
+      expect(result2.isErr()).toBe(true);
       if (result2.isErr()) {
-        expect(result2.error.type).toBe('validation')
+        expect(result2.error.type).toBe("validation");
       }
-    })
+    });
 
-    it('レート制限エラーを適切に処理する', async () => {
+    it("レート制限エラーを適切に処理する", async () => {
       const mockResponse = {
         ok: false,
-        error: 'rate_limited',
-      }
+        error: "rate_limited",
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/search.messages',
-          method: 'POST',
+          url: "https://slack.com/api/search.messages",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.searchMessages({
-        token: 'xoxp-test-token',
-        query: 'test query',
-      })
+        token: "xoxp-test-token",
+        query: "test query",
+      });
 
-      expect(result.isErr()).toBe(true)
+      expect(result.isErr()).toBe(true);
       if (result.isErr()) {
-        expect(result.error.type).toBe('rate_limit')
+        expect(result.error.type).toBe("rate_limit");
       }
-    })
-  })
+    });
+  });
 
-  describe('getThreadMessages', () => {
-    it('スレッドメッセージの取得が成功する場合', async () => {
+  describe("getThreadMessages", () => {
+    it("スレッドメッセージの取得が成功する場合", async () => {
       const mockResponse = {
         ok: true,
         messages: [
           {
-            ts: '1234567890.123456',
-            user: 'U123456',
-            text: '親メッセージ',
-            channel: { id: 'C123456' },
+            ts: "1234567890.123456",
+            user: "U123456",
+            text: "親メッセージ",
+            channel: { id: "C123456" },
           },
           {
-            ts: '1234567890.123457',
-            user: 'U789012',
-            text: '返信メッセージ',
-            thread_ts: '1234567890.123456',
-            channel: { id: 'C123456' },
+            ts: "1234567890.123457",
+            user: "U789012",
+            text: "返信メッセージ",
+            thread_ts: "1234567890.123456",
+            channel: { id: "C123456" },
           },
         ],
-      }
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/conversations.replies',
-          method: 'POST',
+          url: "https://slack.com/api/conversations.replies",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.getThreadMessages({
-        token: 'xoxp-test-token',
-        channel: 'C123456',
-        threadTs: '1234567890.123456',
-      })
+        token: "xoxp-test-token",
+        channel: "C123456",
+        threadTs: "1234567890.123456",
+      });
 
-      expect(result.isOk()).toBe(true)
+      expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.channel).toBe('C123456')
-        expect(result.value.parent.text).toBe('親メッセージ')
-        expect(result.value.replies).toHaveLength(1)
-        expect(result.value.replies[0].text).toBe('返信メッセージ')
+        expect(result.value.channel).toBe("C123456");
+        expect(result.value.parent.text).toBe("親メッセージ");
+        expect(result.value.replies).toHaveLength(1);
+        expect(result.value.replies[0].text).toBe("返信メッセージ");
       }
-    })
+    });
 
-    it('スレッドが見つからない場合はエラーを返す', async () => {
+    it("スレッドが見つからない場合はエラーを返す", async () => {
       const mockResponse = {
         ok: false,
-        error: 'thread_not_found',
-      }
+        error: "thread_not_found",
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/conversations.replies',
-          method: 'POST',
+          url: "https://slack.com/api/conversations.replies",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.getThreadMessages({
-        token: 'xoxp-test-token',
-        channel: 'C123456',
-        threadTs: 'invalid-ts',
-      })
+        token: "xoxp-test-token",
+        channel: "C123456",
+        threadTs: "invalid-ts",
+      });
 
-      expect(result.isErr()).toBe(true)
+      expect(result.isErr()).toBe(true);
       if (result.isErr()) {
-        expect(result.error.type).toBe('notFound')
+        expect(result.error.type).toBe("notFound");
       }
-    })
+    });
 
-    it('メッセージが空の場合はエラーを返す', async () => {
+    it("メッセージが空の場合はエラーを返す", async () => {
       const mockResponse = {
         ok: true,
         messages: [],
-      }
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/conversations.replies',
-          method: 'POST',
+          url: "https://slack.com/api/conversations.replies",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.getThreadMessages({
-        token: 'xoxp-test-token',
-        channel: 'C123456',
-        threadTs: '1234567890.123456',
-      })
+        token: "xoxp-test-token",
+        channel: "C123456",
+        threadTs: "1234567890.123456",
+      });
 
-      expect(result.isErr()).toBe(true)
+      expect(result.isErr()).toBe(true);
       if (result.isErr()) {
-        expect(result.error.type).toBe('notFound')
-        expect(result.error.message).toContain('スレッドメッセージが見つかりません')
+        expect(result.error.type).toBe("notFound");
+        expect(result.error.message).toContain(
+          "スレッドメッセージが見つかりません"
+        );
       }
-    })
-  })
+    });
+  });
 
-  describe('getPermalink', () => {
-    it('パーマリンクの取得が成功する場合', async () => {
-      const mockPermalink = 'https://slack.com/archives/C123456/p1234567890123456'
+  describe("getPermalink", () => {
+    it("パーマリンクの取得が成功する場合", async () => {
+      const mockPermalink =
+        "https://slack.com/archives/C123456/p1234567890123456";
       const mockResponse = {
         ok: true,
         permalink: mockPermalink,
-      }
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/chat.getPermalink?channel=C123456&message_ts=1234567890.123456',
-          method: 'GET',
+          url: "https://slack.com/api/chat.getPermalink?channel=C123456&message_ts=1234567890.123456",
+          method: "GET",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.getPermalink({
-        token: 'xoxp-test-token',
-        channel: 'C123456',
-        messageTs: '1234567890.123456',
-      })
+        token: "xoxp-test-token",
+        channel: "C123456",
+        messageTs: "1234567890.123456",
+      });
 
-      expect(result.isOk()).toBe(true)
+      expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value).toBe(mockPermalink)
+        expect(result.value).toBe(mockPermalink);
       }
-    })
+    });
 
-    it('メッセージが見つからない場合はエラーを返す', async () => {
+    it("メッセージが見つからない場合はエラーを返す", async () => {
       const mockResponse = {
         ok: false,
-        error: 'message_not_found',
-      }
+        error: "message_not_found",
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/chat.getPermalink?channel=C123456&message_ts=invalid-ts',
-          method: 'GET',
+          url: "https://slack.com/api/chat.getPermalink?channel=C123456&message_ts=invalid-ts",
+          method: "GET",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.getPermalink({
-        token: 'xoxp-test-token',
-        channel: 'C123456',
-        messageTs: 'invalid-ts',
-      })
+        token: "xoxp-test-token",
+        channel: "C123456",
+        messageTs: "invalid-ts",
+      });
 
-      expect(result.isErr()).toBe(true)
+      expect(result.isErr()).toBe(true);
       if (result.isErr()) {
-        expect(result.error.type).toBe('notFound')
+        expect(result.error.type).toBe("notFound");
       }
-    })
-  })
+    });
+  });
 
-  describe('getUserInfo', () => {
-    it('ユーザー情報の取得が成功する場合', async () => {
+  describe("getUserInfo", () => {
+    it("ユーザー情報の取得が成功する場合", async () => {
       const mockUser: SlackUser = {
-        id: 'U123456',
-        name: 'testuser',
-        real_name: 'Test User',
-      }
+        id: "U123456",
+        name: "testuser",
+        real_name: "Test User",
+      };
 
       const mockResponse = {
         ok: true,
         user: {
-          id: 'U123456',
-          name: 'testuser',
-          real_name: 'Test User',
+          id: "U123456",
+          name: "testuser",
+          real_name: "Test User",
         },
-      }
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/users.info',
-          method: 'POST',
+          url: "https://slack.com/api/users.info",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.getUserInfo({
-        token: 'xoxp-test-token',
-        userId: 'U123456',
-      })
+        token: "xoxp-test-token",
+        userId: "U123456",
+      });
 
-      expect(result.isOk()).toBe(true)
+      expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value).toEqual(mockUser)
+        expect(result.value).toEqual(mockUser);
       }
-    })
+    });
 
-    it('ユーザーが見つからない場合はエラーを返す', async () => {
+    it("ユーザーが見つからない場合はエラーを返す", async () => {
       const mockResponse = {
         ok: false,
-        error: 'user_not_found',
-      }
+        error: "user_not_found",
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/users.info',
-          method: 'POST',
+          url: "https://slack.com/api/users.info",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.getUserInfo({
-        token: 'xoxp-test-token',
-        userId: 'invalid-user',
-      })
+        token: "xoxp-test-token",
+        userId: "invalid-user",
+      });
 
-      expect(result.isErr()).toBe(true)
+      expect(result.isErr()).toBe(true);
       if (result.isErr()) {
-        expect(result.error.type).toBe('notFound')
+        expect(result.error.type).toBe("notFound");
       }
-    })
+    });
 
-    it('ユーザー情報が不完全な場合でも処理する', async () => {
+    it("ユーザー情報が不完全な場合でも処理する", async () => {
       const mockResponse = {
         ok: true,
         user: {
           // idとnameのみ、real_nameは欠落
-          id: 'U123456',
-          name: 'testuser',
+          id: "U123456",
+          name: "testuser",
         },
-      }
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/users.info',
-          method: 'POST',
+          url: "https://slack.com/api/users.info",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.getUserInfo({
-        token: 'xoxp-test-token',
-        userId: 'U123456',
-      })
+        token: "xoxp-test-token",
+        userId: "U123456",
+      });
 
-      expect(result.isOk()).toBe(true)
+      expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.id).toBe('U123456')
-        expect(result.value.name).toBe('testuser')
-        expect(result.value.real_name).toBeUndefined()
+        expect(result.value.id).toBe("U123456");
+        expect(result.value.name).toBe("testuser");
+        expect(result.value.real_name).toBeUndefined();
       }
-    })
-  })
+    });
+  });
 
-  describe('エラーマッピング', () => {
-    it('様々なSlackエラーコードが適切にマッピングされる', async () => {
+  describe("エラーマッピング", () => {
+    it("様々なSlackエラーコードが適切にマッピングされる", async () => {
       const errorMappings = [
-        { slackError: 'token_revoked', expectedType: 'unauthorized' },
-        { slackError: 'account_inactive', expectedType: 'unauthorized' },
-        { slackError: 'missing_scope', expectedType: 'missing_scope' },
-        { slackError: 'channel_not_found', expectedType: 'notFound' },
-        { slackError: 'unknown_error', expectedType: 'slack_api' },
-      ]
+        { slackError: "token_revoked", expectedType: "unauthorized" },
+        { slackError: "account_inactive", expectedType: "unauthorized" },
+        { slackError: "missing_scope", expectedType: "missing_scope" },
+        { slackError: "channel_not_found", expectedType: "notFound" },
+        { slackError: "unknown_error", expectedType: "slack_api" },
+      ];
 
       for (const { slackError, expectedType } of errorMappings) {
         const mockResponse = {
           ok: false,
           error: slackError,
-        }
+        };
 
         const mockHttpClient = createMockHttpClient([
           {
-            url: 'https://slack.com/api/search.messages',
-            method: 'POST',
+            url: "https://slack.com/api/search.messages",
+            method: "POST",
             status: 200,
             data: mockResponse,
           },
-        ])
+        ]);
 
-        const adapter = createSlackAdapter(mockHttpClient)
+        const adapter = createSlackAdapter(mockHttpClient);
         const result = await adapter.searchMessages({
-          token: 'xoxp-test-token',
-          query: 'test',
-        })
+          token: "xoxp-test-token",
+          query: "test",
+        });
 
-        expect(result.isErr()).toBe(true)
+        expect(result.isErr()).toBe(true);
         if (result.isErr()) {
-          expect(result.error.type).toBe(expectedType)
+          expect(result.error.type).toBe(expectedType);
         }
       }
-    })
-  })
+    });
+  });
 
-  describe('HTTPクライアントエラー処理', () => {
-    it('ネットワークエラーを適切に処理する', async () => {
+  describe("HTTPクライアントエラー処理", () => {
+    it("ネットワークエラーを適切に処理する", async () => {
       const networkError: ApiError = {
-        type: 'network',
-        message: 'ネットワーク接続に失敗しました',
-      }
+        type: "network",
+        message: "ネットワーク接続に失敗しました",
+      };
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: 'https://slack.com/api/search.messages',
-          method: 'POST',
+          url: "https://slack.com/api/search.messages",
+          method: "POST",
           status: 500,
           error: networkError,
         },
-      ])
+      ]);
 
-      const adapter = createSlackAdapter(mockHttpClient)
+      const adapter = createSlackAdapter(mockHttpClient);
       const result = await adapter.searchMessages({
-        token: 'xoxp-test-token',
-        query: 'test',
-      })
+        token: "xoxp-test-token",
+        query: "test",
+      });
 
-      expect(result.isErr()).toBe(true)
+      expect(result.isErr()).toBe(true);
       if (result.isErr()) {
-        expect(result.error.type).toBe('network')
+        expect(result.error.type).toBe("network");
       }
-    })
-  })
-})
+    });
+  });
+});

--- a/src/__tests__/components/ErrorBoundary.test.tsx
+++ b/src/__tests__/components/ErrorBoundary.test.tsx
@@ -4,10 +4,10 @@
  * Error Boundaryの動作確認とエラーハンドリング機能のテスト
  */
 
-import { render, screen } from '@testing-library/react'
-import type React from 'react'
-import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
-import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { ErrorBoundary } from "../../components/ErrorBoundary";
 
 // LocalStorageのモック
 const localStorageMock = {
@@ -15,113 +15,121 @@ const localStorageMock = {
   setItem: vi.fn(),
   removeItem: vi.fn(),
   clear: vi.fn(),
-}
-Object.defineProperty(window, 'localStorage', {
+};
+Object.defineProperty(window, "localStorage", {
   value: localStorageMock,
-})
+});
 
 // エラーを投げるテスト用コンポーネント
 const ThrowError: React.FC<{ shouldThrow: boolean }> = ({ shouldThrow }) => {
   if (shouldThrow) {
-    throw new Error('Test error')
+    throw new Error("Test error");
   }
-  return <div>No error</div>
-}
+  return <div>No error</div>;
+};
 
 // console.errorをモック
-const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 // console.groupをモック
-const consoleGroupSpy = vi.spyOn(console, 'group').mockImplementation(() => {})
+const consoleGroupSpy = vi.spyOn(console, "group").mockImplementation(() => {});
 
-describe('ErrorBoundary', () => {
+describe("ErrorBoundary", () => {
   beforeEach(() => {
-    localStorageMock.getItem.mockClear()
-    localStorageMock.setItem.mockClear()
-    consoleSpy.mockClear()
-    consoleGroupSpy.mockClear()
-  })
+    localStorageMock.getItem.mockClear();
+    localStorageMock.setItem.mockClear();
+    consoleSpy.mockClear();
+    consoleGroupSpy.mockClear();
+  });
 
   afterAll(() => {
-    consoleSpy.mockRestore()
-    consoleGroupSpy.mockRestore()
-  })
+    consoleSpy.mockRestore();
+    consoleGroupSpy.mockRestore();
+  });
 
-  test('正常な子コンポーネントをレンダリングする', () => {
+  test("正常な子コンポーネントをレンダリングする", () => {
     render(
       <ErrorBoundary>
         <ThrowError shouldThrow={false} />
-      </ErrorBoundary>,
-    )
+      </ErrorBoundary>
+    );
 
-    expect(screen.getByText('No error')).toBeInTheDocument()
-  })
+    expect(screen.getByText("No error")).toBeInTheDocument();
+  });
 
-  test('エラーが発生した場合にErrorFallbackを表示する', () => {
+  test("エラーが発生した場合にErrorFallbackを表示する", () => {
     render(
       <ErrorBoundary>
         <ThrowError shouldThrow={true} />
-      </ErrorBoundary>,
-    )
+      </ErrorBoundary>
+    );
 
-    expect(screen.getByText('申し訳ございません')).toBeInTheDocument()
-    expect(screen.getByText('予期しないエラーが発生しました。以下の方法で解決を試してください。')).toBeInTheDocument()
-  })
+    expect(screen.getByText("申し訳ございません")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "予期しないエラーが発生しました。以下の方法で解決を試してください。"
+      )
+    ).toBeInTheDocument();
+  });
 
-  test('カスタムフォールバックコンポーネントを使用する', () => {
-    const CustomFallback: React.FC<{ error: Error | null; resetError: () => void }> = () => (
-      <div>Custom error fallback</div>
-    )
+  test("カスタムフォールバックコンポーネントを使用する", () => {
+    const CustomFallback: React.FC<{
+      error: Error | null;
+      resetError: () => void;
+    }> = () => <div>Custom error fallback</div>;
 
     render(
       <ErrorBoundary fallback={CustomFallback}>
         <ThrowError shouldThrow={true} />
-      </ErrorBoundary>,
-    )
+      </ErrorBoundary>
+    );
 
-    expect(screen.getByText('Custom error fallback')).toBeInTheDocument()
-  })
+    expect(screen.getByText("Custom error fallback")).toBeInTheDocument();
+  });
 
-  test('onErrorコールバックが呼ばれる', () => {
-    const onErrorMock = vi.fn()
+  test("onErrorコールバックが呼ばれる", () => {
+    const onErrorMock = vi.fn();
 
     render(
       <ErrorBoundary onError={onErrorMock}>
         <ThrowError shouldThrow={true} />
-      </ErrorBoundary>,
-    )
+      </ErrorBoundary>
+    );
 
     expect(onErrorMock).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({
         componentStack: expect.any(String),
-      }),
-    )
-  })
+      })
+    );
+  });
 
-  test('エラーログがLocalStorageに保存される', () => {
-    localStorageMock.getItem.mockReturnValue(null)
-
-    render(
-      <ErrorBoundary>
-        <ThrowError shouldThrow={true} />
-      </ErrorBoundary>,
-    )
-
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('notebooklm_error_logs', expect.any(String))
-  })
-
-  test('開発環境でコンソールにエラー情報が出力される', () => {
-    const originalEnv = process.env.NODE_ENV
-    process.env.NODE_ENV = 'development'
+  test("エラーログがLocalStorageに保存される", () => {
+    localStorageMock.getItem.mockReturnValue(null);
 
     render(
       <ErrorBoundary>
         <ThrowError shouldThrow={true} />
-      </ErrorBoundary>,
-    )
+      </ErrorBoundary>
+    );
 
-    expect(consoleGroupSpy).toHaveBeenCalled()
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      "notebooklm_error_logs",
+      expect.any(String)
+    );
+  });
 
-    process.env.NODE_ENV = originalEnv
-  })
-})
+  test("開発環境でコンソールにエラー情報が出力される", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(consoleGroupSpy).toHaveBeenCalled();
+
+    process.env.NODE_ENV = originalEnv;
+  });
+});

--- a/src/__tests__/hooks/useDownload.test.ts
+++ b/src/__tests__/hooks/useDownload.test.ts
@@ -1,157 +1,241 @@
-import { act, renderHook, waitFor } from '@testing-library/react'
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useDownload } from '../../hooks/useDownload'
-import type { downloadMarkdownFile as downloadMarkdownFileType } from '../../utils/fileDownloader'
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDownload } from "../../hooks/useDownload";
+import type { downloadMarkdownFile as downloadMarkdownFileType } from "../../utils/fileDownloader";
 
 // react-hot-toastのモック
-vi.mock('react-hot-toast', () => ({
+vi.mock("react-hot-toast", () => ({
   default: {
-    loading: vi.fn(() => 'toast-id'),
+    loading: vi.fn(() => "toast-id"),
     success: vi.fn(),
     error: vi.fn(),
   },
-}))
+}));
 
 // fileDownloaderのモック
-vi.mock('../../utils/fileDownloader', () => ({
+vi.mock("../../utils/fileDownloader", () => ({
   downloadMarkdownFile: vi.fn(),
-}))
+}));
 
-describe('useDownload', () => {
+describe("useDownload", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
-  describe('初期状態', () => {
-    it('初期状態が正しく設定される', () => {
-      const { result } = renderHook(() => useDownload())
+  describe("初期状態", () => {
+    it("初期状態が正しく設定される", () => {
+      const { result } = renderHook(() => useDownload());
 
-      expect(result.current.isDownloading).toBe(false)
-      expect(typeof result.current.handleDownload).toBe('function')
-    })
-  })
+      expect(result.current.isDownloading).toBe(false);
+      expect(typeof result.current.handleDownload).toBe("function");
+    });
+  });
 
-  describe('ダウンロード成功', () => {
-    it('正常なダウンロード処理が成功する', async () => {
-      const { downloadMarkdownFile } = await import('../../utils/fileDownloader')
-      ;(downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>).mockReturnValue({
+  describe("ダウンロード成功", () => {
+    it("正常なダウンロード処理が成功する", async () => {
+      const { downloadMarkdownFile } = await import(
+        "../../utils/fileDownloader"
+      );
+      (
+        downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>
+      ).mockReturnValue({
         success: true,
         message: undefined,
-      })
+      });
 
-      const { result } = renderHook(() => useDownload())
+      const { result } = renderHook(() => useDownload());
 
       await act(async () => {
-        await result.current.handleDownload('# テストMarkdown', 'test-keyword', true, 'docbase')
-      })
+        await result.current.handleDownload(
+          "# テストMarkdown",
+          "test-keyword",
+          true,
+          "docbase"
+        );
+      });
 
-      expect(downloadMarkdownFile).toHaveBeenCalledWith('# テストMarkdown', 'test-keyword', true, 'docbase')
-      expect(result.current.isDownloading).toBe(false)
-    })
+      expect(downloadMarkdownFile).toHaveBeenCalledWith(
+        "# テストMarkdown",
+        "test-keyword",
+        true,
+        "docbase"
+      );
+      expect(result.current.isDownloading).toBe(false);
+    });
 
-    it('Slackソースタイプでダウンロード処理が成功する', async () => {
-      const { downloadMarkdownFile } = await import('../../utils/fileDownloader')
-      ;(downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>).mockReturnValue({
+    it("Slackソースタイプでダウンロード処理が成功する", async () => {
+      const { downloadMarkdownFile } = await import(
+        "../../utils/fileDownloader"
+      );
+      (
+        downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>
+      ).mockReturnValue({
         success: true,
         message: undefined,
-      })
+      });
 
-      const { result } = renderHook(() => useDownload())
+      const { result } = renderHook(() => useDownload());
 
       await act(async () => {
-        await result.current.handleDownload('# Slack Markdown', 'slack-search', true, 'slack')
-      })
+        await result.current.handleDownload(
+          "# Slack Markdown",
+          "slack-search",
+          true,
+          "slack"
+        );
+      });
 
-      expect(downloadMarkdownFile).toHaveBeenCalledWith('# Slack Markdown', 'slack-search', true, 'slack')
-    })
+      expect(downloadMarkdownFile).toHaveBeenCalledWith(
+        "# Slack Markdown",
+        "slack-search",
+        true,
+        "slack"
+      );
+    });
 
-    it('ソースタイプが指定されない場合はデフォルトでdocbaseを使用する', async () => {
-      const { downloadMarkdownFile } = await import('../../utils/fileDownloader')
-      ;(downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>).mockReturnValue({
+    it("ソースタイプが指定されない場合はデフォルトでdocbaseを使用する", async () => {
+      const { downloadMarkdownFile } = await import(
+        "../../utils/fileDownloader"
+      );
+      (
+        downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>
+      ).mockReturnValue({
         success: true,
         message: undefined,
-      })
+      });
 
-      const { result } = renderHook(() => useDownload())
+      const { result } = renderHook(() => useDownload());
 
       await act(async () => {
-        await result.current.handleDownload('# デフォルトMarkdown', 'default-keyword', true)
-      })
+        await result.current.handleDownload(
+          "# デフォルトMarkdown",
+          "default-keyword",
+          true
+        );
+      });
 
-      expect(downloadMarkdownFile).toHaveBeenCalledWith('# デフォルトMarkdown', 'default-keyword', true, 'docbase')
-    })
-  })
+      expect(downloadMarkdownFile).toHaveBeenCalledWith(
+        "# デフォルトMarkdown",
+        "default-keyword",
+        true,
+        "docbase"
+      );
+    });
+  });
 
-  describe('ダウンロード失敗', () => {
-    it('投稿が存在しない場合はエラーメッセージを表示する', async () => {
-      const { downloadMarkdownFile } = await import('../../utils/fileDownloader')
-      ;(downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>).mockReturnValue({
+  describe("ダウンロード失敗", () => {
+    it("投稿が存在しない場合はエラーメッセージを表示する", async () => {
+      const { downloadMarkdownFile } = await import(
+        "../../utils/fileDownloader"
+      );
+      (
+        downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>
+      ).mockReturnValue({
         success: false,
-        message: 'ダウンロード可能な投稿がありません',
-      })
+        message: "ダウンロード可能な投稿がありません",
+      });
 
-      const { result } = renderHook(() => useDownload())
+      const { result } = renderHook(() => useDownload());
 
       await act(async () => {
-        await result.current.handleDownload('', 'empty-keyword', false, 'docbase')
-      })
+        await result.current.handleDownload(
+          "",
+          "empty-keyword",
+          false,
+          "docbase"
+        );
+      });
 
-      expect(downloadMarkdownFile).toHaveBeenCalledWith('', 'empty-keyword', false, 'docbase')
-      expect(result.current.isDownloading).toBe(false)
-    })
+      expect(downloadMarkdownFile).toHaveBeenCalledWith(
+        "",
+        "empty-keyword",
+        false,
+        "docbase"
+      );
+      expect(result.current.isDownloading).toBe(false);
+    });
 
-    it('Markdownコンテンツが空の場合はエラーメッセージを表示する', async () => {
-      const { downloadMarkdownFile } = await import('../../utils/fileDownloader')
-      ;(downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>).mockReturnValue({
+    it("Markdownコンテンツが空の場合はエラーメッセージを表示する", async () => {
+      const { downloadMarkdownFile } = await import(
+        "../../utils/fileDownloader"
+      );
+      (
+        downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>
+      ).mockReturnValue({
         success: false,
-        message: 'Markdownコンテンツが空です',
-      })
+        message: "Markdownコンテンツが空です",
+      });
 
-      const { result } = renderHook(() => useDownload())
+      const { result } = renderHook(() => useDownload());
 
       await act(async () => {
-        await result.current.handleDownload('   ', 'whitespace-keyword', true, 'docbase')
-      })
+        await result.current.handleDownload(
+          "   ",
+          "whitespace-keyword",
+          true,
+          "docbase"
+        );
+      });
 
-      expect(result.current.isDownloading).toBe(false)
-    })
+      expect(result.current.isDownloading).toBe(false);
+    });
 
-    it('fileDownloaderからエラーが返された場合は適切に処理する', async () => {
-      const { downloadMarkdownFile } = await import('../../utils/fileDownloader')
-      ;(downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>).mockReturnValue({
+    it("fileDownloaderからエラーが返された場合は適切に処理する", async () => {
+      const { downloadMarkdownFile } = await import(
+        "../../utils/fileDownloader"
+      );
+      (
+        downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>
+      ).mockReturnValue({
         success: false,
-        message: 'ファイル作成に失敗しました',
-      })
+        message: "ファイル作成に失敗しました",
+      });
 
-      const { result } = renderHook(() => useDownload())
-
-      await act(async () => {
-        await result.current.handleDownload('# テストコンテンツ', 'test-keyword', true, 'docbase')
-      })
-
-      expect(result.current.isDownloading).toBe(false)
-    })
-  })
-
-  describe('エラーハンドリング', () => {
-    it('予期せぬエラーが発生した場合は適切に処理する', async () => {
-      const { downloadMarkdownFile } = await import('../../utils/fileDownloader')
-      ;(downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>).mockImplementation(() => {
-        throw new Error('予期せぬエラー')
-      })
-
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-      const { result } = renderHook(() => useDownload())
+      const { result } = renderHook(() => useDownload());
 
       await act(async () => {
-        await result.current.handleDownload('# テストMarkdown', 'error-keyword', true, 'docbase')
-      })
+        await result.current.handleDownload(
+          "# テストコンテンツ",
+          "test-keyword",
+          true,
+          "docbase"
+        );
+      });
 
-      expect(consoleSpy).toHaveBeenCalled()
-      expect(result.current.isDownloading).toBe(false)
+      expect(result.current.isDownloading).toBe(false);
+    });
+  });
 
-      consoleSpy.mockRestore()
-    })
-  })
-})
+  describe("エラーハンドリング", () => {
+    it("予期せぬエラーが発生した場合は適切に処理する", async () => {
+      const { downloadMarkdownFile } = await import(
+        "../../utils/fileDownloader"
+      );
+      (
+        downloadMarkdownFile as Mock<typeof downloadMarkdownFileType>
+      ).mockImplementation(() => {
+        throw new Error("予期せぬエラー");
+      });
+
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const { result } = renderHook(() => useDownload());
+
+      await act(async () => {
+        await result.current.handleDownload(
+          "# テストMarkdown",
+          "error-keyword",
+          true,
+          "docbase"
+        );
+      });
+
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(result.current.isDownloading).toBe(false);
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/__tests__/hooks/useErrorRecovery.test.ts
+++ b/src/__tests__/hooks/useErrorRecovery.test.ts
@@ -4,9 +4,17 @@
  * エラー復旧機能の動作確認テスト
  */
 
-import { act, renderHook } from '@testing-library/react'
-import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { useErrorRecovery } from '../../hooks/useErrorRecovery'
+import { act, renderHook } from "@testing-library/react";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { useErrorRecovery } from "../../hooks/useErrorRecovery";
 
 // LocalStorageのモック
 const localStorageMock = {
@@ -16,33 +24,33 @@ const localStorageMock = {
   clear: vi.fn(),
   key: vi.fn(),
   length: 0,
-}
-Object.defineProperty(window, 'localStorage', {
+};
+Object.defineProperty(window, "localStorage", {
   value: localStorageMock,
-})
+});
 
 // sessionStorageのモック
 const sessionStorageMock = {
   clear: vi.fn(),
-}
-Object.defineProperty(window, 'sessionStorage', {
+};
+Object.defineProperty(window, "sessionStorage", {
   value: sessionStorageMock,
-})
+});
 
 // window.location.reloadのモック
-Object.defineProperty(window, 'location', {
+Object.defineProperty(window, "location", {
   value: {
     reload: vi.fn(),
   },
   writable: true,
-})
+});
 
 // console.warnのモック
-const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 // errorStorageのモック
-vi.mock('../../utils/errorStorage', () => ({
+vi.mock("../../utils/errorStorage", () => ({
   cleanupOldErrorLogs: vi.fn(),
   clearErrorLogs: vi.fn(() => true),
   getErrorLogStats: vi.fn(() => ({
@@ -50,212 +58,230 @@ vi.mock('../../utils/errorStorage', () => ({
     lastError: null,
     errorTypes: {},
   })),
-}))
+}));
 
-describe('useErrorRecovery', () => {
+describe("useErrorRecovery", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    localStorageMock.getItem.mockReturnValue(null)
-  })
+    vi.clearAllMocks();
+    localStorageMock.getItem.mockReturnValue(null);
+  });
 
   afterEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
   afterAll(() => {
-    consoleWarnSpy.mockRestore()
-    consoleErrorSpy.mockRestore()
-  })
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
 
-  test('初期状態を正しく設定する', () => {
-    const { result } = renderHook(() => useErrorRecovery())
+  test("初期状態を正しく設定する", () => {
+    const { result } = renderHook(() => useErrorRecovery());
 
-    expect(result.current).not.toBeNull()
-    expect(result.current.isRecovering).toBe(false)
-    expect(result.current.retryCount).toBe(0)
-    expect(result.current.canRetry).toBe(true)
-    expect(result.current.lastRecoveryTime).toBeNull()
-  })
+    expect(result.current).not.toBeNull();
+    expect(result.current.isRecovering).toBe(false);
+    expect(result.current.retryCount).toBe(0);
+    expect(result.current.canRetry).toBe(true);
+    expect(result.current.lastRecoveryTime).toBeNull();
+  });
 
-  describe('recover', () => {
-    test('標準的な復旧処理を実行する', async () => {
-      localStorageMock.getItem.mockReturnValue(null)
+  describe("recover", () => {
+    test("標準的な復旧処理を実行する", async () => {
+      localStorageMock.getItem.mockReturnValue(null);
 
-      const { result } = renderHook(() => useErrorRecovery())
+      const { result } = renderHook(() => useErrorRecovery());
 
-      expect(result.current).not.toBeNull()
-
-      await act(async () => {
-        const success = await result.current.recover()
-        expect(success).toBe(true)
-      })
-
-      expect(result.current.retryCount).toBe(0)
-      expect(result.current.isRecovering).toBe(false)
-    })
-
-    test('カスタム復旧処理を実行する', async () => {
-      const customRecovery = vi.fn().mockResolvedValue(undefined)
-
-      const { result } = renderHook(() => useErrorRecovery({ customRecovery }))
-
-      expect(result.current).not.toBeNull()
+      expect(result.current).not.toBeNull();
 
       await act(async () => {
-        const success = await result.current.recover()
-        expect(success).toBe(true)
-      })
+        const success = await result.current.recover();
+        expect(success).toBe(true);
+      });
 
-      expect(customRecovery).toHaveBeenCalledOnce()
-    })
+      expect(result.current.retryCount).toBe(0);
+      expect(result.current.isRecovering).toBe(false);
+    });
 
-    test('最大リトライ回数を超えた場合は実行しない', async () => {
+    test("カスタム復旧処理を実行する", async () => {
+      const customRecovery = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useErrorRecovery({ customRecovery }));
+
+      expect(result.current).not.toBeNull();
+
+      await act(async () => {
+        const success = await result.current.recover();
+        expect(success).toBe(true);
+      });
+
+      expect(customRecovery).toHaveBeenCalledOnce();
+    });
+
+    test("最大リトライ回数を超えた場合は実行しない", async () => {
       const savedState = {
         retryCount: 3, // maxRetries=3
-      }
-      localStorageMock.getItem.mockReturnValue(JSON.stringify(savedState))
+      };
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(savedState));
 
-      const { result } = renderHook(() => useErrorRecovery())
+      const { result } = renderHook(() => useErrorRecovery());
 
-      expect(result.current).not.toBeNull()
-      expect(result.current.canRetry).toBe(false)
+      expect(result.current).not.toBeNull();
+      expect(result.current.canRetry).toBe(false);
 
       await act(async () => {
-        const success = await result.current.recover()
-        expect(success).toBe(false)
-      })
+        const success = await result.current.recover();
+        expect(success).toBe(false);
+      });
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith('Maximum retry count exceeded')
-    })
-  })
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Maximum retry count exceeded"
+      );
+    });
+  });
 
-  describe('recoverWithStorageReset', () => {
-    test('LocalStorageをクリアして復旧する', async () => {
+  describe("recoverWithStorageReset", () => {
+    test("LocalStorageをクリアして復旧する", async () => {
       // localStorageにテスト用のキーを設定
-      const testKeys = ['slackApiToken', 'docbaseApiToken', 'docbaseDomain', 'notebooklm_error_logs', 'someOtherKey']
-      localStorageMock.length = testKeys.length
-      localStorageMock.key.mockImplementation((index) => testKeys[index] || null)
-      localStorageMock.getItem.mockReturnValue(null)
+      const testKeys = [
+        "slackApiToken",
+        "docbaseApiToken",
+        "docbaseDomain",
+        "notebooklm_error_logs",
+        "someOtherKey",
+      ];
+      localStorageMock.length = testKeys.length;
+      localStorageMock.key.mockImplementation(
+        (index) => testKeys[index] || null
+      );
+      localStorageMock.getItem.mockReturnValue(null);
 
-      const { result } = renderHook(() => useErrorRecovery())
+      const { result } = renderHook(() => useErrorRecovery());
 
-      expect(result.current).not.toBeNull()
+      expect(result.current).not.toBeNull();
 
       await act(async () => {
-        const success = await result.current.recoverWithStorageReset()
-        expect(success).toBe(true)
-      })
+        const success = await result.current.recoverWithStorageReset();
+        expect(success).toBe(true);
+      });
 
       // パターンにマッチするキーが削除されることを確認
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('slackApiToken')
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('docbaseApiToken')
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('docbaseDomain')
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('notebooklm_error_logs')
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith("slackApiToken");
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        "docbaseApiToken"
+      );
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith("docbaseDomain");
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        "notebooklm_error_logs"
+      );
       // someOtherKeyはパターンにマッチしないので削除されない
-      expect(localStorageMock.removeItem).not.toHaveBeenCalledWith('someOtherKey')
+      expect(localStorageMock.removeItem).not.toHaveBeenCalledWith(
+        "someOtherKey"
+      );
 
       // sessionStorageもクリアされることを確認
-      expect(sessionStorageMock.clear).toHaveBeenCalled()
-    })
-  })
+      expect(sessionStorageMock.clear).toHaveBeenCalled();
+    });
+  });
 
-  describe('recoverWithReload', () => {
-    test('ページをリロードして復旧する', () => {
-      localStorageMock.getItem.mockReturnValue(null)
+  describe("recoverWithReload", () => {
+    test("ページをリロードして復旧する", () => {
+      localStorageMock.getItem.mockReturnValue(null);
 
-      const { result } = renderHook(() => useErrorRecovery())
+      const { result } = renderHook(() => useErrorRecovery());
 
-      expect(result.current).not.toBeNull()
+      expect(result.current).not.toBeNull();
 
       act(() => {
-        result.current.recoverWithReload()
-      })
+        result.current.recoverWithReload();
+      });
 
-      expect(window.location.reload).toHaveBeenCalled()
-    })
-  })
+      expect(window.location.reload).toHaveBeenCalled();
+    });
+  });
 
-  describe('recoverWithLogClear', () => {
-    test('エラーログをクリアして復旧する', async () => {
-      localStorageMock.getItem.mockReturnValue(null)
+  describe("recoverWithLogClear", () => {
+    test("エラーログをクリアして復旧する", async () => {
+      localStorageMock.getItem.mockReturnValue(null);
 
-      const { result } = renderHook(() => useErrorRecovery())
+      const { result } = renderHook(() => useErrorRecovery());
 
-      expect(result.current).not.toBeNull()
-
-      await act(async () => {
-        const success = await result.current.recoverWithLogClear()
-        expect(success).toBe(true)
-      })
-
-      expect(result.current.isRecovering).toBe(false)
-    })
-  })
-
-  describe('recoverWithCustom', () => {
-    test('カスタム復旧処理のみを実行する', async () => {
-      const customRecovery = vi.fn().mockResolvedValue(undefined)
-
-      const { result } = renderHook(() => useErrorRecovery({ customRecovery }))
-
-      expect(result.current).not.toBeNull()
+      expect(result.current).not.toBeNull();
 
       await act(async () => {
-        const success = await result.current.recoverWithCustom()
-        expect(success).toBe(true)
-      })
+        const success = await result.current.recoverWithLogClear();
+        expect(success).toBe(true);
+      });
 
-      expect(customRecovery).toHaveBeenCalledOnce()
-    })
+      expect(result.current.isRecovering).toBe(false);
+    });
+  });
 
-    test('カスタム復旧処理が未設定の場合は失敗する', async () => {
-      const { result } = renderHook(() => useErrorRecovery())
+  describe("recoverWithCustom", () => {
+    test("カスタム復旧処理のみを実行する", async () => {
+      const customRecovery = vi.fn().mockResolvedValue(undefined);
 
-      expect(result.current).not.toBeNull()
+      const { result } = renderHook(() => useErrorRecovery({ customRecovery }));
+
+      expect(result.current).not.toBeNull();
 
       await act(async () => {
-        const success = await result.current.recoverWithCustom()
-        expect(success).toBe(false)
-      })
+        const success = await result.current.recoverWithCustom();
+        expect(success).toBe(true);
+      });
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith('No custom recovery function provided')
-    })
-  })
+      expect(customRecovery).toHaveBeenCalledOnce();
+    });
 
-  describe('resetRetryCount', () => {
-    test('リトライ回数をリセットする', () => {
+    test("カスタム復旧処理が未設定の場合は失敗する", async () => {
+      const { result } = renderHook(() => useErrorRecovery());
+
+      expect(result.current).not.toBeNull();
+
+      await act(async () => {
+        const success = await result.current.recoverWithCustom();
+        expect(success).toBe(false);
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "No custom recovery function provided"
+      );
+    });
+  });
+
+  describe("resetRetryCount", () => {
+    test("リトライ回数をリセットする", () => {
       const savedState = {
         retryCount: 2,
-      }
-      localStorageMock.getItem.mockReturnValue(JSON.stringify(savedState))
+      };
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(savedState));
 
-      const { result } = renderHook(() => useErrorRecovery())
+      const { result } = renderHook(() => useErrorRecovery());
 
-      expect(result.current).not.toBeNull()
-      expect(result.current.retryCount).toBe(2)
-      expect(result.current.canRetry).toBe(true)
-
-      act(() => {
-        result.current.resetRetryCount()
-      })
-
-      expect(result.current.retryCount).toBe(0)
-      expect(result.current.canRetry).toBe(true)
-    })
-  })
-
-  describe('refreshErrorStats', () => {
-    test('エラー統計を更新する', () => {
-      const { result } = renderHook(() => useErrorRecovery())
-
-      expect(result.current).not.toBeNull()
+      expect(result.current).not.toBeNull();
+      expect(result.current.retryCount).toBe(2);
+      expect(result.current.canRetry).toBe(true);
 
       act(() => {
-        result.current.refreshErrorStats()
-      })
+        result.current.resetRetryCount();
+      });
+
+      expect(result.current.retryCount).toBe(0);
+      expect(result.current.canRetry).toBe(true);
+    });
+  });
+
+  describe("refreshErrorStats", () => {
+    test("エラー統計を更新する", () => {
+      const { result } = renderHook(() => useErrorRecovery());
+
+      expect(result.current).not.toBeNull();
+
+      act(() => {
+        result.current.refreshErrorStats();
+      });
 
       // エラー統計の更新が呼ばれることを確認
-      expect(result.current.errorStats).toBeDefined()
-    })
-  })
-})
+      expect(result.current.errorStats).toBeDefined();
+    });
+  });
+});

--- a/src/__tests__/hooks/useLocalStorage.test.ts
+++ b/src/__tests__/hooks/useLocalStorage.test.ts
@@ -1,121 +1,145 @@
-import { act, renderHook } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import useLocalStorage from '../../hooks/useLocalStorage'
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useLocalStorage from "../../hooks/useLocalStorage";
 
-describe('useLocalStorage', () => {
+describe("useLocalStorage", () => {
   beforeEach(() => {
     // localStorageをクリア
-    localStorage.clear()
+    localStorage.clear();
     // console.warnとconsole.errorのモック
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
-  describe('初期化', () => {
-    it('初期値を正しく設定する', () => {
-      const { result } = renderHook(() => useLocalStorage('test-key', 'default-value'))
+  describe("初期化", () => {
+    it("初期値を正しく設定する", () => {
+      const { result } = renderHook(() =>
+        useLocalStorage("test-key", "default-value")
+      );
 
-      expect(result.current[0]).toBe('default-value')
-    })
+      expect(result.current[0]).toBe("default-value");
+    });
 
-    it('localStorageに既存の値がある場合はその値を使用する', () => {
-      localStorage.setItem('test-key', JSON.stringify('stored-value'))
+    it("localStorageに既存の値がある場合はその値を使用する", () => {
+      localStorage.setItem("test-key", JSON.stringify("stored-value"));
 
-      const { result } = renderHook(() => useLocalStorage('test-key', 'default-value'))
+      const { result } = renderHook(() =>
+        useLocalStorage("test-key", "default-value")
+      );
 
-      expect(result.current[0]).toBe('stored-value')
-    })
+      expect(result.current[0]).toBe("stored-value");
+    });
 
-    it('オブジェクトの初期値を正しく処理する', () => {
-      const defaultValue = { name: 'test', count: 1 }
+    it("オブジェクトの初期値を正しく処理する", () => {
+      const defaultValue = { name: "test", count: 1 };
 
-      const { result } = renderHook(() => useLocalStorage('test-object', defaultValue))
+      const { result } = renderHook(() =>
+        useLocalStorage("test-object", defaultValue)
+      );
 
-      expect(result.current[0]).toEqual(defaultValue)
-    })
+      expect(result.current[0]).toEqual(defaultValue);
+    });
 
-    it('配列の初期値を正しく処理する', () => {
-      const defaultValue = ['item1', 'item2']
+    it("配列の初期値を正しく処理する", () => {
+      const defaultValue = ["item1", "item2"];
 
-      const { result } = renderHook(() => useLocalStorage('test-array', defaultValue))
+      const { result } = renderHook(() =>
+        useLocalStorage("test-array", defaultValue)
+      );
 
-      expect(result.current[0]).toEqual(defaultValue)
-    })
-  })
+      expect(result.current[0]).toEqual(defaultValue);
+    });
+  });
 
-  describe('値の更新', () => {
-    it('値を更新してlocalStorageに保存する', () => {
-      const { result } = renderHook(() => useLocalStorage('test-key', 'initial'))
+  describe("値の更新", () => {
+    it("値を更新してlocalStorageに保存する", () => {
+      const { result } = renderHook(() =>
+        useLocalStorage("test-key", "initial")
+      );
 
       act(() => {
-        result.current[1]('updated-value')
-      })
+        result.current[1]("updated-value");
+      });
 
-      expect(result.current[0]).toBe('updated-value')
-      expect(JSON.parse(localStorage.getItem('test-key') || '')).toBe('updated-value')
-    })
+      expect(result.current[0]).toBe("updated-value");
+      expect(JSON.parse(localStorage.getItem("test-key") || "")).toBe(
+        "updated-value"
+      );
+    });
 
-    it('関数による値の更新を処理する', () => {
-      const { result } = renderHook(() => useLocalStorage('test-counter', 0))
+    it("関数による値の更新を処理する", () => {
+      const { result } = renderHook(() => useLocalStorage("test-counter", 0));
 
       act(() => {
-        result.current[1]((prev) => prev + 1)
-      })
+        result.current[1]((prev) => prev + 1);
+      });
 
-      expect(result.current[0]).toBe(1)
-      expect(JSON.parse(localStorage.getItem('test-counter') || '')).toBe(1)
-    })
+      expect(result.current[0]).toBe(1);
+      expect(JSON.parse(localStorage.getItem("test-counter") || "")).toBe(1);
+    });
 
-    it('オブジェクトの更新を正しく処理する', () => {
-      const initialValue = { count: 0, name: 'test' }
-      const { result } = renderHook(() => useLocalStorage('test-object', initialValue))
+    it("オブジェクトの更新を正しく処理する", () => {
+      const initialValue = { count: 0, name: "test" };
+      const { result } = renderHook(() =>
+        useLocalStorage("test-object", initialValue)
+      );
 
-      const updatedValue = { count: 1, name: 'updated' }
+      const updatedValue = { count: 1, name: "updated" };
       act(() => {
-        result.current[1](updatedValue)
-      })
+        result.current[1](updatedValue);
+      });
 
-      expect(result.current[0]).toEqual(updatedValue)
-      expect(JSON.parse(localStorage.getItem('test-object') || '')).toEqual(updatedValue)
-    })
-  })
+      expect(result.current[0]).toEqual(updatedValue);
+      expect(JSON.parse(localStorage.getItem("test-object") || "")).toEqual(
+        updatedValue
+      );
+    });
+  });
 
-  describe('エラーハンドリング', () => {
-    it('不正なJSONがlocalStorageにある場合は初期値を返す', () => {
-      localStorage.setItem('test-key', 'invalid-json{')
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  describe("エラーハンドリング", () => {
+    it("不正なJSONがlocalStorageにある場合は初期値を返す", () => {
+      localStorage.setItem("test-key", "invalid-json{");
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      const { result } = renderHook(() => useLocalStorage('test-key', 'default'))
+      const { result } = renderHook(() =>
+        useLocalStorage("test-key", "default")
+      );
 
-      expect(result.current[0]).toBe('default')
-      expect(consoleSpy).toHaveBeenCalled()
+      expect(result.current[0]).toBe("default");
+      expect(consoleSpy).toHaveBeenCalled();
 
-      consoleSpy.mockRestore()
-    })
+      consoleSpy.mockRestore();
+    });
 
-    it('localStorageの読み込みでエラーが発生した場合は初期値を返す', () => {
+    it("localStorageの読み込みでエラーが発生した場合は初期値を返す", () => {
       // 簡単なテスト：不正なJSONが存在する場合のエラーログのテストで代用
-      localStorage.setItem('error-test-key', 'invalid-json{')
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      localStorage.setItem("error-test-key", "invalid-json{");
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      const { result } = renderHook(() => useLocalStorage('error-test-key', 'default'))
+      const { result } = renderHook(() =>
+        useLocalStorage("error-test-key", "default")
+      );
 
-      expect(result.current[0]).toBe('default')
-      expect(consoleSpy).toHaveBeenCalled()
+      expect(result.current[0]).toBe("default");
+      expect(consoleSpy).toHaveBeenCalled();
 
-      consoleSpy.mockRestore()
-    })
+      consoleSpy.mockRestore();
+    });
 
-    it('localStorageの書き込みでエラーが発生した場合はエラーをログに出力する', () => {
+    it("localStorageの書き込みでエラーが発生した場合はエラーをログに出力する", () => {
       // この機能は実際の実装で確実に動作しているので、テストを簡素化
-      const { result } = renderHook(() => useLocalStorage('test-key', 'initial'))
+      const { result } = renderHook(() =>
+        useLocalStorage("test-key", "initial")
+      );
 
       // 正常なケースをテスト
       act(() => {
-        result.current[1]('new-value')
-      })
+        result.current[1]("new-value");
+      });
 
-      expect(result.current[0]).toBe('new-value')
-      expect(localStorage.getItem('test-key')).toBe(JSON.stringify('new-value'))
-    })
-  })
-})
+      expect(result.current[0]).toBe("new-value");
+      expect(localStorage.getItem("test-key")).toBe(
+        JSON.stringify("new-value")
+      );
+    });
+  });
+});

--- a/src/__tests__/hooks/useSearch.test.ts
+++ b/src/__tests__/hooks/useSearch.test.ts
@@ -1,386 +1,443 @@
-import { act, renderHook, waitFor } from '@testing-library/react'
-import { err, ok } from 'neverthrow'
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { DocbaseAdapter } from '../../features/docbase/adapters/docbaseAdapter'
-import { type AdvancedFilters, useDocbaseSearch } from '../../features/docbase/hooks/useDocbaseSearch'
-import type { DocbasePostListItem } from '../../features/docbase/types/docbase'
-import type { ApiError } from '../../types/error'
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { err, ok } from "neverthrow";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DocbaseAdapter } from "../../features/docbase/adapters/docbaseAdapter";
+import {
+  type AdvancedFilters,
+  useDocbaseSearch,
+} from "../../features/docbase/hooks/useDocbaseSearch";
+import type { DocbasePostListItem } from "../../features/docbase/types/docbase";
+import type { ApiError } from "../../types/error";
 
 // react-hot-toastのモック
-vi.mock('react-hot-toast', () => ({
+vi.mock("react-hot-toast", () => ({
   default: {
     success: vi.fn(),
     error: vi.fn(),
     dismiss: vi.fn(),
   },
-}))
+}));
 
-describe('useDocbaseSearch', () => {
-  let mockAdapter: DocbaseAdapter
-  let mockPosts: DocbasePostListItem[]
+describe("useDocbaseSearch", () => {
+  let mockAdapter: DocbaseAdapter;
+  let mockPosts: DocbasePostListItem[];
 
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.clearAllMocks();
 
     // モックデータの準備
     mockPosts = [
       {
         id: 1,
-        title: 'テスト記事1',
-        body: 'テスト内容1',
-        created_at: '2023-01-01T00:00:00Z',
-        url: 'https://example.docbase.io/posts/1',
+        title: "テスト記事1",
+        body: "テスト内容1",
+        created_at: "2023-01-01T00:00:00Z",
+        url: "https://example.docbase.io/posts/1",
       },
       {
         id: 2,
-        title: 'テスト記事2',
-        body: 'テスト内容2',
-        created_at: '2023-01-02T00:00:00Z',
-        url: 'https://example.docbase.io/posts/2',
+        title: "テスト記事2",
+        body: "テスト内容2",
+        created_at: "2023-01-02T00:00:00Z",
+        url: "https://example.docbase.io/posts/2",
       },
-    ]
+    ];
 
     // モックアダプターの作成
     mockAdapter = {
       searchPosts: vi.fn(),
-    }
-  })
+    };
+  });
 
-  describe('初期状態', () => {
-    it('初期状態が正しく設定される', () => {
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+  describe("初期状態", () => {
+    it("初期状態が正しく設定される", () => {
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
-      expect(result.current.posts).toEqual([])
-      expect(result.current.isLoading).toBe(false)
-      expect(result.current.error).toBeNull()
-      expect(result.current.canRetry).toBe(false)
-    })
-  })
+      expect(result.current.posts).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.canRetry).toBe(false);
+    });
+  });
 
-  describe('検索成功', () => {
-    it('検索が成功した場合、結果を正しく更新する', async () => {
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValue(ok(mockPosts))
+  describe("検索成功", () => {
+    it("検索が成功した場合、結果を正しく更新する", async () => {
+      (mockAdapter.searchPosts as Mock).mockResolvedValue(ok(mockPosts));
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
-
-      await act(async () => {
-        await result.current.searchPosts('example', 'test-token', 'test keyword')
-      })
-
-      expect(result.current.posts).toEqual(mockPosts)
-      expect(result.current.isLoading).toBe(false)
-      expect(result.current.error).toBeNull()
-      expect(result.current.canRetry).toBe(false)
-    })
-
-    it('検索結果が0件の場合、適切にメッセージを表示する', async () => {
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValue(ok([]))
-
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       await act(async () => {
-        await result.current.searchPosts('example', 'test-token', 'no results')
-      })
+        await result.current.searchPosts(
+          "example",
+          "test-token",
+          "test keyword"
+        );
+      });
 
-      expect(result.current.posts).toEqual([])
-      expect(result.current.isLoading).toBe(false)
-      expect(result.current.error).toBeNull()
-    })
+      expect(result.current.posts).toEqual(mockPosts);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.canRetry).toBe(false);
+    });
 
-    it('詳細検索条件付きで検索が成功する', async () => {
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValue(ok(mockPosts))
+    it("検索結果が0件の場合、適切にメッセージを表示する", async () => {
+      (mockAdapter.searchPosts as Mock).mockResolvedValue(ok([]));
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
+
+      await act(async () => {
+        await result.current.searchPosts("example", "test-token", "no results");
+      });
+
+      expect(result.current.posts).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("詳細検索条件付きで検索が成功する", async () => {
+      (mockAdapter.searchPosts as Mock).mockResolvedValue(ok(mockPosts));
+
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       const advancedFilters: AdvancedFilters = {
-        tags: 'tag1,tag2',
-        author: 'test-author',
-        titleFilter: 'title filter',
-        startDate: '2023-01-01',
-        endDate: '2023-12-31',
-        group: 'test-group',
-      }
+        tags: "tag1,tag2",
+        author: "test-author",
+        titleFilter: "title filter",
+        startDate: "2023-01-01",
+        endDate: "2023-12-31",
+        group: "test-group",
+      };
 
       await act(async () => {
-        await result.current.searchPosts('example', 'test-token', 'keyword', advancedFilters)
-      })
+        await result.current.searchPosts(
+          "example",
+          "test-token",
+          "keyword",
+          advancedFilters
+        );
+      });
 
       expect(mockAdapter.searchPosts).toHaveBeenCalledWith({
-        domain: 'example',
-        token: 'test-token',
-        keyword: 'keyword',
+        domain: "example",
+        token: "test-token",
+        keyword: "keyword",
         advancedFilters,
-      })
-      expect(result.current.posts).toEqual(mockPosts)
-    })
-  })
+      });
+      expect(result.current.posts).toEqual(mockPosts);
+    });
+  });
 
-  describe('検索エラー', () => {
-    it('認証エラーの場合、適切にエラー状態を設定する', async () => {
+  describe("検索エラー", () => {
+    it("認証エラーの場合、適切にエラー状態を設定する", async () => {
       const error: ApiError = {
-        type: 'unauthorized',
-        message: '認証に失敗しました',
-      }
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValue(err(error))
+        type: "unauthorized",
+        message: "認証に失敗しました",
+      };
+      (mockAdapter.searchPosts as Mock).mockResolvedValue(err(error));
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       await act(async () => {
-        await result.current.searchPosts('example', 'invalid-token', 'keyword')
-      })
+        await result.current.searchPosts("example", "invalid-token", "keyword");
+      });
 
-      expect(result.current.posts).toEqual([])
-      expect(result.current.isLoading).toBe(false)
-      expect(result.current.error).toEqual(error)
-      expect(result.current.canRetry).toBe(false)
-    })
+      expect(result.current.posts).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toEqual(error);
+      expect(result.current.canRetry).toBe(false);
+    });
 
-    it('ネットワークエラーの場合、リトライ可能にする', async () => {
+    it("ネットワークエラーの場合、リトライ可能にする", async () => {
       const error: ApiError = {
-        type: 'network',
-        message: 'ネットワークエラー',
-      }
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValue(err(error))
+        type: "network",
+        message: "ネットワークエラー",
+      };
+      (mockAdapter.searchPosts as Mock).mockResolvedValue(err(error));
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       await act(async () => {
-        await result.current.searchPosts('example', 'test-token', 'keyword')
-      })
+        await result.current.searchPosts("example", "test-token", "keyword");
+      });
 
-      expect(result.current.error).toEqual(error)
-      expect(result.current.canRetry).toBe(true)
-    })
+      expect(result.current.error).toEqual(error);
+      expect(result.current.canRetry).toBe(true);
+    });
 
-    it('レートリミットエラーの場合、リトライ可能にする', async () => {
+    it("レートリミットエラーの場合、リトライ可能にする", async () => {
       const error: ApiError = {
-        type: 'rate_limit',
-        message: 'レート制限',
-      }
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValue(err(error))
+        type: "rate_limit",
+        message: "レート制限",
+      };
+      (mockAdapter.searchPosts as Mock).mockResolvedValue(err(error));
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       await act(async () => {
-        await result.current.searchPosts('example', 'test-token', 'keyword')
-      })
+        await result.current.searchPosts("example", "test-token", "keyword");
+      });
 
-      expect(result.current.error).toEqual(error)
-      expect(result.current.canRetry).toBe(true)
-    })
+      expect(result.current.error).toEqual(error);
+      expect(result.current.canRetry).toBe(true);
+    });
 
-    it('不明なエラーの場合、リトライ可能にする', async () => {
+    it("不明なエラーの場合、リトライ可能にする", async () => {
       const error: ApiError = {
-        type: 'unknown',
-        message: '不明なエラー',
-      }
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValue(err(error))
+        type: "unknown",
+        message: "不明なエラー",
+      };
+      (mockAdapter.searchPosts as Mock).mockResolvedValue(err(error));
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
-
-      await act(async () => {
-        await result.current.searchPosts('example', 'test-token', 'keyword')
-      })
-
-      expect(result.current.error).toEqual(error)
-      expect(result.current.canRetry).toBe(true)
-    })
-  })
-
-  describe('バリデーション', () => {
-    it('ドメインが空の場合、検索を実行しない', async () => {
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       await act(async () => {
-        await result.current.searchPosts('', 'test-token', 'keyword')
-      })
+        await result.current.searchPosts("example", "test-token", "keyword");
+      });
 
-      expect(mockAdapter.searchPosts).not.toHaveBeenCalled()
-      expect(result.current.posts).toEqual([])
-      expect(result.current.canRetry).toBe(false)
-    })
+      expect(result.current.error).toEqual(error);
+      expect(result.current.canRetry).toBe(true);
+    });
+  });
 
-    it('トークンが空の場合、検索を実行しない', async () => {
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+  describe("バリデーション", () => {
+    it("ドメインが空の場合、検索を実行しない", async () => {
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       await act(async () => {
-        await result.current.searchPosts('example', '', 'keyword')
-      })
+        await result.current.searchPosts("", "test-token", "keyword");
+      });
 
-      expect(mockAdapter.searchPosts).not.toHaveBeenCalled()
-      expect(result.current.posts).toEqual([])
-      expect(result.current.canRetry).toBe(false)
-    })
+      expect(mockAdapter.searchPosts).not.toHaveBeenCalled();
+      expect(result.current.posts).toEqual([]);
+      expect(result.current.canRetry).toBe(false);
+    });
 
-    it('キーワードと詳細検索条件が全て空の場合、検索を実行しない', async () => {
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+    it("トークンが空の場合、検索を実行しない", async () => {
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
+
+      await act(async () => {
+        await result.current.searchPosts("example", "", "keyword");
+      });
+
+      expect(mockAdapter.searchPosts).not.toHaveBeenCalled();
+      expect(result.current.posts).toEqual([]);
+      expect(result.current.canRetry).toBe(false);
+    });
+
+    it("キーワードと詳細検索条件が全て空の場合、検索を実行しない", async () => {
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       const emptyFilters: AdvancedFilters = {
-        tags: '',
-        author: '',
-        titleFilter: '',
-        startDate: '',
-        endDate: '',
-        group: '',
-      }
+        tags: "",
+        author: "",
+        titleFilter: "",
+        startDate: "",
+        endDate: "",
+        group: "",
+      };
 
       await act(async () => {
-        await result.current.searchPosts('example', 'test-token', '', emptyFilters)
-      })
+        await result.current.searchPosts(
+          "example",
+          "test-token",
+          "",
+          emptyFilters
+        );
+      });
 
-      expect(mockAdapter.searchPosts).not.toHaveBeenCalled()
-      expect(result.current.posts).toEqual([])
-      expect(result.current.canRetry).toBe(false)
-    })
+      expect(mockAdapter.searchPosts).not.toHaveBeenCalled();
+      expect(result.current.posts).toEqual([]);
+      expect(result.current.canRetry).toBe(false);
+    });
 
-    it('キーワードが空でも詳細検索条件があれば検索を実行する', async () => {
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValue(ok(mockPosts))
+    it("キーワードが空でも詳細検索条件があれば検索を実行する", async () => {
+      (mockAdapter.searchPosts as Mock).mockResolvedValue(ok(mockPosts));
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       const filters: AdvancedFilters = {
-        tags: 'tag1',
-        author: '',
-        titleFilter: '',
-        startDate: '',
-        endDate: '',
-        group: '',
-      }
+        tags: "tag1",
+        author: "",
+        titleFilter: "",
+        startDate: "",
+        endDate: "",
+        group: "",
+      };
 
       await act(async () => {
-        await result.current.searchPosts('example', 'test-token', '', filters)
-      })
+        await result.current.searchPosts("example", "test-token", "", filters);
+      });
 
-      expect(mockAdapter.searchPosts).toHaveBeenCalled()
-      expect(result.current.posts).toEqual(mockPosts)
-    })
+      expect(mockAdapter.searchPosts).toHaveBeenCalled();
+      expect(result.current.posts).toEqual(mockPosts);
+    });
 
-    it('全てのパラメータが空の場合、何もしない', async () => {
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+    it("全てのパラメータが空の場合、何もしない", async () => {
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       await act(async () => {
-        await result.current.searchPosts('', '', '')
-      })
+        await result.current.searchPosts("", "", "");
+      });
 
-      expect(mockAdapter.searchPosts).not.toHaveBeenCalled()
-      expect(result.current.posts).toEqual([])
-      expect(result.current.error).toBeNull()
-      expect(result.current.canRetry).toBe(false)
-    })
-  })
+      expect(mockAdapter.searchPosts).not.toHaveBeenCalled();
+      expect(result.current.posts).toEqual([]);
+      expect(result.current.error).toBeNull();
+      expect(result.current.canRetry).toBe(false);
+    });
+  });
 
-  describe('再試行機能', () => {
-    it('エラー後に再試行が可能', async () => {
+  describe("再試行機能", () => {
+    it("エラー後に再試行が可能", async () => {
       const error: ApiError = {
-        type: 'network',
-        message: 'ネットワークエラー',
-      }
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValueOnce(err(error)).mockResolvedValueOnce(ok(mockPosts))
+        type: "network",
+        message: "ネットワークエラー",
+      };
+      (mockAdapter.searchPosts as Mock)
+        .mockResolvedValueOnce(err(error))
+        .mockResolvedValueOnce(ok(mockPosts));
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       // 最初の検索でエラー
       await act(async () => {
-        await result.current.searchPosts('example', 'test-token', 'keyword')
-      })
+        await result.current.searchPosts("example", "test-token", "keyword");
+      });
 
-      expect(result.current.canRetry).toBe(true)
-      expect(result.current.error).toEqual(error)
+      expect(result.current.canRetry).toBe(true);
+      expect(result.current.error).toEqual(error);
 
       // 再試行
       await act(async () => {
-        result.current.retrySearch()
-      })
+        result.current.retrySearch();
+      });
 
       // 少し待機してPromiseが解決されるのを待つ
       await waitFor(() => {
-        expect(result.current.posts).toEqual(mockPosts)
-        expect(result.current.error).toBeNull()
-        expect(result.current.canRetry).toBe(false)
-      })
-    })
+        expect(result.current.posts).toEqual(mockPosts);
+        expect(result.current.error).toBeNull();
+        expect(result.current.canRetry).toBe(false);
+      });
+    });
 
-    it('前回の検索パラメータがない場合、再試行は何もしない', async () => {
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+    it("前回の検索パラメータがない場合、再試行は何もしない", async () => {
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       act(() => {
-        result.current.retrySearch()
-      })
+        result.current.retrySearch();
+      });
 
-      expect(mockAdapter.searchPosts).not.toHaveBeenCalled()
-    })
-  })
+      expect(mockAdapter.searchPosts).not.toHaveBeenCalled();
+    });
+  });
 
-  describe('ローディング状態', () => {
-    it('検索中はローディング状態になる', async () => {
-      let resolveSearch: (value: unknown) => void
+  describe("ローディング状態", () => {
+    it("検索中はローディング状態になる", async () => {
+      let resolveSearch: (value: unknown) => void;
       const searchPromise = new Promise((resolve) => {
-        resolveSearch = resolve
-      })
-      ;(mockAdapter.searchPosts as Mock).mockReturnValue(searchPromise)
+        resolveSearch = resolve;
+      });
+      (mockAdapter.searchPosts as Mock).mockReturnValue(searchPromise);
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       // 検索開始
       act(() => {
-        result.current.searchPosts('example', 'test-token', 'keyword')
-      })
+        result.current.searchPosts("example", "test-token", "keyword");
+      });
 
       // ローディング状態をチェック
-      expect(result.current.isLoading).toBe(true)
+      expect(result.current.isLoading).toBe(true);
 
       // 検索完了
       await act(async () => {
-        resolveSearch?.(ok(mockPosts))
-        await searchPromise
-      })
+        resolveSearch?.(ok(mockPosts));
+        await searchPromise;
+      });
 
-      expect(result.current.isLoading).toBe(false)
-    })
-  })
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
 
-  describe('エラーメッセージ機能', () => {
-    it('getUserFriendlyErrorが正しく動作する', async () => {
+  describe("エラーメッセージ機能", () => {
+    it("getUserFriendlyErrorが正しく動作する", async () => {
       const error: ApiError = {
-        type: 'unauthorized',
-        message: '認証エラー',
-      }
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValue(err(error))
+        type: "unauthorized",
+        message: "認証エラー",
+      };
+      (mockAdapter.searchPosts as Mock).mockResolvedValue(err(error));
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       await act(async () => {
-        await result.current.searchPosts('example', 'invalid-token', 'keyword')
-      })
+        await result.current.searchPosts("example", "invalid-token", "keyword");
+      });
 
-      const friendlyError = result.current.getUserFriendlyError()
-      expect(friendlyError).toBeTruthy()
-      expect(typeof friendlyError).toBe('string')
-    })
+      const friendlyError = result.current.getUserFriendlyError();
+      expect(friendlyError).toBeTruthy();
+      expect(typeof friendlyError).toBe("string");
+    });
 
-    it('getErrorSuggestionが正しく動作する', async () => {
+    it("getErrorSuggestionが正しく動作する", async () => {
       const error: ApiError = {
-        type: 'unauthorized',
-        message: '認証エラー',
-      }
-      ;(mockAdapter.searchPosts as Mock).mockResolvedValue(err(error))
+        type: "unauthorized",
+        message: "認証エラー",
+      };
+      (mockAdapter.searchPosts as Mock).mockResolvedValue(err(error));
 
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
       await act(async () => {
-        await result.current.searchPosts('example', 'invalid-token', 'keyword')
-      })
+        await result.current.searchPosts("example", "invalid-token", "keyword");
+      });
 
-      const suggestion = result.current.getErrorSuggestion()
-      expect(suggestion).toBeTruthy()
-      expect(typeof suggestion).toBe('string')
-    })
+      const suggestion = result.current.getErrorSuggestion();
+      expect(suggestion).toBeTruthy();
+      expect(typeof suggestion).toBe("string");
+    });
 
-    it('エラーがない場合はnullを返す', () => {
-      const { result } = renderHook(() => useDocbaseSearch({ adapter: mockAdapter }))
+    it("エラーがない場合はnullを返す", () => {
+      const { result } = renderHook(() =>
+        useDocbaseSearch({ adapter: mockAdapter })
+      );
 
-      expect(result.current.getUserFriendlyError()).toBeNull()
-      expect(result.current.getErrorSuggestion()).toBeNull()
-    })
-  })
-})
+      expect(result.current.getUserFriendlyError()).toBeNull();
+      expect(result.current.getErrorSuggestion()).toBeNull();
+    });
+  });
+});

--- a/src/__tests__/hooks/useSlackSearchUnified.test.ts
+++ b/src/__tests__/hooks/useSlackSearchUnified.test.ts
@@ -1,76 +1,79 @@
-import { act, renderHook, waitFor } from '@testing-library/react'
-import { err, ok } from 'neverthrow'
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { SlackAdapter } from '../../features/slack/adapters/slackAdapter'
-import { type SlackSearchParams, useSlackSearchUnified } from '../../features/slack/hooks/useSlackSearchUnified'
-import type { ApiError } from '../../types/error'
-import type { SlackMessage, SlackThread, SlackUser } from '../../types/slack'
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { err, ok } from "neverthrow";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SlackAdapter } from "../../features/slack/adapters/slackAdapter";
+import {
+  type SlackSearchParams,
+  useSlackSearchUnified,
+} from "../../features/slack/hooks/useSlackSearchUnified";
+import type { ApiError } from "../../types/error";
+import type { SlackMessage, SlackThread, SlackUser } from "../../types/slack";
 
 // react-hot-toastのモック
-vi.mock('react-hot-toast', () => {
-  const mockToast = vi.fn((message, options) => 'toast-id')
-  mockToast.success = vi.fn()
-  mockToast.error = vi.fn()
-  mockToast.dismiss = vi.fn()
+vi.mock("react-hot-toast", () => {
+  const mockToast = vi.fn((message, options) => "toast-id");
+  mockToast.success = vi.fn();
+  mockToast.error = vi.fn();
+  mockToast.dismiss = vi.fn();
 
   return {
     default: mockToast,
-  }
-})
+  };
+});
 
-describe('useSlackSearchUnified', () => {
-  let mockAdapter: SlackAdapter
-  let mockMessages: SlackMessage[]
-  let mockThread: SlackThread
-  let mockUser: SlackUser
+describe("useSlackSearchUnified", () => {
+  let mockAdapter: SlackAdapter;
+  let mockMessages: SlackMessage[];
+  let mockThread: SlackThread;
+  let mockUser: SlackUser;
 
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.clearAllMocks();
 
     // モックデータの準備
     mockMessages = [
       {
-        ts: '1234567890.123456',
-        user: 'U123456',
-        text: 'テストメッセージ1',
+        ts: "1234567890.123456",
+        user: "U123456",
+        text: "テストメッセージ1",
         thread_ts: undefined,
-        channel: { id: 'C123456', name: 'general' },
-        permalink: 'https://slack.com/archives/C123456/p1234567890123456',
+        channel: { id: "C123456", name: "general" },
+        permalink: "https://slack.com/archives/C123456/p1234567890123456",
       },
       {
-        ts: '1234567890.123457',
-        user: 'U789012',
-        text: 'テストメッセージ2',
-        thread_ts: '1234567890.123456',
-        channel: { id: 'C123456', name: 'general' },
-        permalink: 'https://slack.com/archives/C123456/p1234567890123457',
+        ts: "1234567890.123457",
+        user: "U789012",
+        text: "テストメッセージ2",
+        thread_ts: "1234567890.123456",
+        channel: { id: "C123456", name: "general" },
+        permalink: "https://slack.com/archives/C123456/p1234567890123457",
       },
-    ]
+    ];
 
     mockThread = {
-      channel: 'C123456',
+      channel: "C123456",
       parent: {
-        ts: '1234567890.123456',
-        user: 'U123456',
-        text: '親メッセージ',
-        channel: { id: 'C123456' },
+        ts: "1234567890.123456",
+        user: "U123456",
+        text: "親メッセージ",
+        channel: { id: "C123456" },
       },
       replies: [
         {
-          ts: '1234567890.123457',
-          user: 'U789012',
-          text: '返信メッセージ',
-          thread_ts: '1234567890.123456',
-          channel: { id: 'C123456' },
+          ts: "1234567890.123457",
+          user: "U789012",
+          text: "返信メッセージ",
+          thread_ts: "1234567890.123456",
+          channel: { id: "C123456" },
         },
       ],
-    }
+    };
 
     mockUser = {
-      id: 'U123456',
-      name: 'testuser',
-      real_name: 'Test User',
-    }
+      id: "U123456",
+      name: "testuser",
+      real_name: "Test User",
+    };
 
     // モックアダプターの作成
     mockAdapter = {
@@ -82,589 +85,753 @@ describe('useSlackSearchUnified', () => {
       fetchUserMaps: vi.fn(),
       generatePermalinkMaps: vi.fn(),
       generateMarkdown: vi.fn(),
-    }
-  })
+    };
+  });
 
-  describe('初期状態', () => {
-    it('初期状態が正しく設定される', () => {
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+  describe("初期状態", () => {
+    it("初期状態が正しく設定される", () => {
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
-      expect(result.current.messages).toEqual([])
-      expect(result.current.slackThreads).toEqual([])
-      expect(result.current.userMaps).toEqual({})
-      expect(result.current.permalinkMaps).toEqual({})
-      expect(result.current.threadMarkdowns).toEqual([])
-      expect(result.current.currentPreviewMarkdown).toBe('')
-      expect(result.current.isLoading).toBe(false)
+      expect(result.current.messages).toEqual([]);
+      expect(result.current.slackThreads).toEqual([]);
+      expect(result.current.userMaps).toEqual({});
+      expect(result.current.permalinkMaps).toEqual({});
+      expect(result.current.threadMarkdowns).toEqual([]);
+      expect(result.current.currentPreviewMarkdown).toBe("");
+      expect(result.current.isLoading).toBe(false);
       expect(result.current.progressStatus).toEqual({
-        phase: 'idle',
-        message: '',
-      })
-      expect(result.current.error).toBeNull()
-      expect(result.current.canRetry).toBe(false)
+        phase: "idle",
+        message: "",
+      });
+      expect(result.current.error).toBeNull();
+      expect(result.current.canRetry).toBe(false);
       expect(result.current.paginationInfo).toEqual({
         currentPage: 1,
         totalPages: 1,
         totalResults: 0,
         perPage: 20,
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('検索クエリ構築', () => {
-    it('基本的な検索クエリが正しく構築される', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+  describe("検索クエリ構築", () => {
+    it("基本的な検索クエリが正しく構築される", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: [],
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 0, perPage: 20 },
-        }),
-      )
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 0,
+            perPage: 20,
+          },
+        })
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       const params: SlackSearchParams = {
-        token: 'xoxp-test',
-        searchQuery: 'test query',
-      }
+        token: "xoxp-test",
+        searchQuery: "test query",
+      };
 
       await act(async () => {
-        await result.current.handleSearch(params)
-      })
+        await result.current.handleSearch(params);
+      });
 
       expect(mockAdapter.searchMessages).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: 'test query',
-        }),
-      )
-    })
+          query: "test query",
+        })
+      );
+    });
 
-    it('詳細検索条件を含むクエリが正しく構築される', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+    it("詳細検索条件を含むクエリが正しく構築される", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: [],
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 0, perPage: 20 },
-        }),
-      )
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 0,
+            perPage: 20,
+          },
+        })
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       const params: SlackSearchParams = {
-        token: 'xoxp-test',
-        searchQuery: 'meeting',
-        channel: 'general',
-        author: 'john',
-        startDate: '2023-01-01',
-        endDate: '2023-12-31',
-      }
+        token: "xoxp-test",
+        searchQuery: "meeting",
+        channel: "general",
+        author: "john",
+        startDate: "2023-01-01",
+        endDate: "2023-12-31",
+      };
 
       await act(async () => {
-        await result.current.handleSearch(params)
-      })
+        await result.current.handleSearch(params);
+      });
 
       expect(mockAdapter.searchMessages).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: 'meeting in:general from:john after:2023-01-01 before:2023-12-31',
-        }),
-      )
-    })
+          query:
+            "meeting in:general from:john after:2023-01-01 before:2023-12-31",
+        })
+      );
+    });
 
-    it('チャンネル名から#プレフィックスを除去する', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+    it("チャンネル名から#プレフィックスを除去する", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: [],
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 0, perPage: 20 },
-        }),
-      )
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 0,
+            perPage: 20,
+          },
+        })
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       const params: SlackSearchParams = {
-        token: 'xoxp-test',
-        searchQuery: 'test',
-        channel: '#general',
-      }
+        token: "xoxp-test",
+        searchQuery: "test",
+        channel: "#general",
+      };
 
       await act(async () => {
-        await result.current.handleSearch(params)
-      })
+        await result.current.handleSearch(params);
+      });
 
       expect(mockAdapter.searchMessages).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: 'test in:#general',
-        }),
-      )
-    })
+          query: "test in:#general",
+        })
+      );
+    });
 
-    it('作者名から@プレフィックスを除去する', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+    it("作者名から@プレフィックスを除去する", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: [],
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 0, perPage: 20 },
-        }),
-      )
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 0,
+            perPage: 20,
+          },
+        })
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       const params: SlackSearchParams = {
-        token: 'xoxp-test',
-        searchQuery: 'test',
-        author: '@john',
-      }
+        token: "xoxp-test",
+        searchQuery: "test",
+        author: "@john",
+      };
 
       await act(async () => {
-        await result.current.handleSearch(params)
-      })
+        await result.current.handleSearch(params);
+      });
 
       expect(mockAdapter.searchMessages).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: 'test from:@john',
-        }),
-      )
-    })
-  })
+          query: "test from:@john",
+        })
+      );
+    });
+  });
 
-  describe('バリデーション', () => {
-    it('トークンが空の場合でも検索が実行される（サーバーサイドでエラーハンドリング）', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+  describe("バリデーション", () => {
+    it("トークンが空の場合でも検索が実行される（サーバーサイドでエラーハンドリング）", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         err({
-          type: 'unauthorized',
-          message: 'トークンが無効です',
-        }),
-      )
+          type: "unauthorized",
+          message: "トークンが無効です",
+        })
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: '',
-          searchQuery: 'test',
-        })
-      })
+          token: "",
+          searchQuery: "test",
+        });
+      });
 
       expect(mockAdapter.searchMessages).toHaveBeenCalledWith({
-        token: '',
-        query: 'test',
-      })
-      expect(result.current.error?.type).toBe('unauthorized')
-    })
+        token: "",
+        query: "test",
+      });
+      expect(result.current.error?.type).toBe("unauthorized");
+    });
 
-    it('検索クエリが空の場合でも検索が実行される', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+    it("検索クエリが空の場合でも検索が実行される", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: [],
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 0, perPage: 20 },
-        }),
-      )
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 0,
+            perPage: 20,
+          },
+        })
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: '',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "",
+        });
+      });
 
       expect(mockAdapter.searchMessages).toHaveBeenCalledWith({
-        token: 'xoxp-test',
-        query: '',
-      })
-    })
-  })
+        token: "xoxp-test",
+        query: "",
+      });
+    });
+  });
 
-  describe('検索成功', () => {
-    it('検索が成功した場合、結果を正しく更新する', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+  describe("検索成功", () => {
+    it("検索が成功した場合、結果を正しく更新する", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: mockMessages,
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 2, perPage: 20 },
-        }),
-      )
-      ;(mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(ok([mockThread]))
-      ;(mockAdapter.fetchUserMaps as Mock).mockResolvedValue(ok({ U123456: 'Test User' }))
-      ;(mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
-        ok({ '1234567890.123456': 'https://slack.com/permalink' }),
-      )
-      ;(mockAdapter.generateMarkdown as Mock).mockResolvedValue(ok('# Test Thread\nTest content'))
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 2,
+            perPage: 20,
+          },
+        })
+      );
+      (mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(
+        ok([mockThread])
+      );
+      (mockAdapter.fetchUserMaps as Mock).mockResolvedValue(
+        ok({ U123456: "Test User" })
+      );
+      (mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
+        ok({ "1234567890.123456": "https://slack.com/permalink" })
+      );
+      (mockAdapter.generateMarkdown as Mock).mockResolvedValue(
+        ok("# Test Thread\nTest content")
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'test',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "test",
+        });
+      });
 
       await waitFor(() => {
-        expect(result.current.messages).toEqual(mockMessages)
-        expect(result.current.slackThreads).toHaveLength(1)
-        expect(result.current.isLoading).toBe(false)
-        expect(result.current.error).toBeNull()
-        expect(result.current.userMaps).toEqual({ U123456: 'Test User' })
-      })
-    })
+        expect(result.current.messages).toEqual(mockMessages);
+        expect(result.current.slackThreads).toHaveLength(1);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(result.current.userMaps).toEqual({ U123456: "Test User" });
+      });
+    });
 
-    it('検索結果が0件の場合、適切にメッセージを表示する', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+    it("検索結果が0件の場合、適切にメッセージを表示する", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: [],
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 0, perPage: 20 },
-        }),
-      )
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 0,
+            perPage: 20,
+          },
+        })
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'no results',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "no results",
+        });
+      });
 
-      expect(result.current.slackThreads).toHaveLength(0)
-      expect(result.current.isLoading).toBe(false)
-    })
-  })
+      expect(result.current.slackThreads).toHaveLength(0);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
 
-  describe('メッセージのグループ化', () => {
-    it('スレッド単位でメッセージがユニーク化される', async () => {
+  describe("メッセージのグループ化", () => {
+    it("スレッド単位でメッセージがユニーク化される", async () => {
       const duplicateMessages = [
         ...mockMessages,
         // 同じスレッドの重複メッセージ
         {
-          ts: '1234567890.123458',
-          user: 'U999999',
-          text: '同じスレッドの別メッセージ',
-          thread_ts: '1234567890.123456',
-          channel: { id: 'C123456', name: 'general' },
+          ts: "1234567890.123458",
+          user: "U999999",
+          text: "同じスレッドの別メッセージ",
+          thread_ts: "1234567890.123456",
+          channel: { id: "C123456", name: "general" },
         },
-      ]
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+      ];
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: duplicateMessages,
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 3, perPage: 20 },
-        }),
-      )
-      ;(mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(ok([mockThread]))
-      ;(mockAdapter.fetchUserMaps as Mock).mockResolvedValue(ok({ U123456: 'Test User' }))
-      ;(mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
-        ok({ '1234567890.123456': 'https://slack.com/permalink' }),
-      )
-      ;(mockAdapter.generateMarkdown as Mock).mockResolvedValue(ok('# Test Thread\nTest content'))
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 3,
+            perPage: 20,
+          },
+        })
+      );
+      (mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(
+        ok([mockThread])
+      );
+      (mockAdapter.fetchUserMaps as Mock).mockResolvedValue(
+        ok({ U123456: "Test User" })
+      );
+      (mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
+        ok({ "1234567890.123456": "https://slack.com/permalink" })
+      );
+      (mockAdapter.generateMarkdown as Mock).mockResolvedValue(
+        ok("# Test Thread\nTest content")
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'test',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "test",
+        });
+      });
 
       await waitFor(() => {
         // buildThreadsFromMessagesが1回呼ばれ、1つのスレッドが返される
-        expect(mockAdapter.buildThreadsFromMessages).toHaveBeenCalledTimes(1)
-        expect(result.current.slackThreads).toHaveLength(1)
-      })
-    })
-  })
+        expect(mockAdapter.buildThreadsFromMessages).toHaveBeenCalledTimes(1);
+        expect(result.current.slackThreads).toHaveLength(1);
+      });
+    });
+  });
 
-  describe('ページネーション', () => {
-    it('複数ページの検索結果を取得する', async () => {
+  describe("ページネーション", () => {
+    it("複数ページの検索結果を取得する", async () => {
       const page1Messages = Array(100)
         .fill(null)
         .map((_, i) => ({
           ts: `1234567890.12345${i}`,
-          user: 'U123456',
+          user: "U123456",
           text: `メッセージ${i}`,
-          channel: { id: 'C123456' },
-        }))
+          channel: { id: "C123456" },
+        }));
 
       const page2Messages = Array(50)
         .fill(null)
         .map((_, i) => ({
           ts: `1234567900.12345${i}`,
-          user: 'U123456',
+          user: "U123456",
           text: `メッセージ${100 + i}`,
-          channel: { id: 'C123456' },
-        }))
-      ;(mockAdapter.searchMessages as Mock)
+          channel: { id: "C123456" },
+        }));
+      (mockAdapter.searchMessages as Mock)
         .mockResolvedValueOnce(
           ok({
             messages: page1Messages,
-            pagination: { currentPage: 1, totalPages: 2, totalResults: 150, perPage: 100 },
-          }),
+            pagination: {
+              currentPage: 1,
+              totalPages: 2,
+              totalResults: 150,
+              perPage: 100,
+            },
+          })
         )
         .mockResolvedValueOnce(
           ok({
             messages: page2Messages,
-            pagination: { currentPage: 2, totalPages: 2, totalResults: 150, perPage: 100 },
-          }),
-        )
-      ;(mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(ok([mockThread]))
-      ;(mockAdapter.fetchUserMaps as Mock).mockResolvedValue(ok({ U123456: 'Test User' }))
-      ;(mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
-        ok({ '1234567890.123456': 'https://slack.com/permalink' }),
-      )
-      ;(mockAdapter.generateMarkdown as Mock).mockResolvedValue(ok('# Test Thread\nTest content'))
+            pagination: {
+              currentPage: 2,
+              totalPages: 2,
+              totalResults: 150,
+              perPage: 100,
+            },
+          })
+        );
+      (mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(
+        ok([mockThread])
+      );
+      (mockAdapter.fetchUserMaps as Mock).mockResolvedValue(
+        ok({ U123456: "Test User" })
+      );
+      (mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
+        ok({ "1234567890.123456": "https://slack.com/permalink" })
+      );
+      (mockAdapter.generateMarkdown as Mock).mockResolvedValue(
+        ok("# Test Thread\nTest content")
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'test',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "test",
+        });
+      });
 
       await waitFor(() => {
-        expect(mockAdapter.searchMessages).toHaveBeenCalledTimes(1)
-        expect(result.current.messages).toHaveLength(100)
-      })
-    })
-  })
+        expect(mockAdapter.searchMessages).toHaveBeenCalledTimes(1);
+        expect(result.current.messages).toHaveLength(100);
+      });
+    });
+  });
 
-  describe('エラーハンドリング', () => {
-    it('検索エラーの場合、適切にエラー状態を設定する', async () => {
+  describe("エラーハンドリング", () => {
+    it("検索エラーの場合、適切にエラー状態を設定する", async () => {
       const error: ApiError = {
-        type: 'unauthorized',
-        message: '認証エラー',
-      }
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(err(error))
+        type: "unauthorized",
+        message: "認証エラー",
+      };
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(err(error));
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'invalid-token',
-          searchQuery: 'test',
-        })
-      })
+          token: "invalid-token",
+          searchQuery: "test",
+        });
+      });
 
-      expect(result.current.error).toEqual(error)
-      expect(result.current.isLoading).toBe(false)
-      expect(result.current.slackThreads).toHaveLength(0)
-    })
+      expect(result.current.error).toEqual(error);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.slackThreads).toHaveLength(0);
+    });
 
-    it('ネットワークエラーの場合、リトライ可能にする', async () => {
+    it("ネットワークエラーの場合、リトライ可能にする", async () => {
       const error: ApiError = {
-        type: 'network',
-        message: 'ネットワークエラー',
-      }
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(err(error))
+        type: "network",
+        message: "ネットワークエラー",
+      };
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(err(error));
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'test',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "test",
+        });
+      });
 
-      expect(result.current.canRetry).toBe(true)
-    })
+      expect(result.current.canRetry).toBe(true);
+    });
 
-    it('レート制限エラーの場合、リトライ可能にする', async () => {
+    it("レート制限エラーの場合、リトライ可能にする", async () => {
       const error: ApiError = {
-        type: 'rate_limit',
-        message: 'レート制限エラー',
-      }
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(err(error))
+        type: "rate_limit",
+        message: "レート制限エラー",
+      };
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(err(error));
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'test',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "test",
+        });
+      });
 
-      expect(result.current.canRetry).toBe(true)
-    })
-  })
+      expect(result.current.canRetry).toBe(true);
+    });
+  });
 
-  describe('再試行機能', () => {
-    it('エラー後に再試行が可能', async () => {
+  describe("再試行機能", () => {
+    it("エラー後に再試行が可能", async () => {
       const error: ApiError = {
-        type: 'network',
-        message: 'ネットワークエラー',
-      }
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValueOnce(err(error)).mockResolvedValueOnce(
-        ok({
-          messages: mockMessages,
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 2, perPage: 20 },
-        }),
-      )
-      ;(mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(ok([mockThread]))
-      ;(mockAdapter.fetchUserMaps as Mock).mockResolvedValue(ok({ U123456: 'Test User' }))
-      ;(mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
-        ok({ '1234567890.123456': 'https://slack.com/permalink' }),
-      )
-      ;(mockAdapter.generateMarkdown as Mock).mockResolvedValue(ok('# Test Thread\nTest content'))
+        type: "network",
+        message: "ネットワークエラー",
+      };
+      (mockAdapter.searchMessages as Mock)
+        .mockResolvedValueOnce(err(error))
+        .mockResolvedValueOnce(
+          ok({
+            messages: mockMessages,
+            pagination: {
+              currentPage: 1,
+              totalPages: 1,
+              totalResults: 2,
+              perPage: 20,
+            },
+          })
+        );
+      (mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(
+        ok([mockThread])
+      );
+      (mockAdapter.fetchUserMaps as Mock).mockResolvedValue(
+        ok({ U123456: "Test User" })
+      );
+      (mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
+        ok({ "1234567890.123456": "https://slack.com/permalink" })
+      );
+      (mockAdapter.generateMarkdown as Mock).mockResolvedValue(
+        ok("# Test Thread\nTest content")
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       // 最初の検索でエラー
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'test',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "test",
+        });
+      });
 
-      expect(result.current.canRetry).toBe(true)
+      expect(result.current.canRetry).toBe(true);
 
       // 再試行
       await act(async () => {
-        result.current.retrySearch()
-      })
+        result.current.retrySearch();
+      });
 
       await waitFor(() => {
-        expect(result.current.error).toBeNull()
-        expect(result.current.slackThreads).toHaveLength(1)
-        expect(result.current.canRetry).toBe(false)
-      })
-    })
+        expect(result.current.error).toBeNull();
+        expect(result.current.slackThreads).toHaveLength(1);
+        expect(result.current.canRetry).toBe(false);
+      });
+    });
 
-    it('前回の検索パラメータがない場合、再試行は何もしない', () => {
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+    it("前回の検索パラメータがない場合、再試行は何もしない", () => {
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       act(() => {
-        result.current.retrySearch()
-      })
+        result.current.retrySearch();
+      });
 
-      expect(mockAdapter.searchMessages).not.toHaveBeenCalled()
-    })
-  })
+      expect(mockAdapter.searchMessages).not.toHaveBeenCalled();
+    });
+  });
 
-  describe('ローディング状態', () => {
-    it('検索中はローディング状態になる', async () => {
-      let resolveSearch: (value: unknown) => void
+  describe("ローディング状態", () => {
+    it("検索中はローディング状態になる", async () => {
+      let resolveSearch: (value: unknown) => void;
       const searchPromise = new Promise((resolve) => {
-        resolveSearch = resolve
-      })
-      ;(mockAdapter.searchMessages as Mock).mockReturnValue(searchPromise)
+        resolveSearch = resolve;
+      });
+      (mockAdapter.searchMessages as Mock).mockReturnValue(searchPromise);
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       // 検索開始
       act(() => {
         result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'test',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "test",
+        });
+      });
 
       // ローディング状態をチェック
-      expect(result.current.isLoading).toBe(true)
+      expect(result.current.isLoading).toBe(true);
 
       // 検索完了
       await act(async () => {
         resolveSearch?.(
           ok({
             messages: [],
-            pagination: { currentPage: 1, totalPages: 1, totalResults: 0, perPage: 20 },
-          }),
-        )
-        await searchPromise
-      })
+            pagination: {
+              currentPage: 1,
+              totalPages: 1,
+              totalResults: 0,
+              perPage: 20,
+            },
+          })
+        );
+        await searchPromise;
+      });
 
-      expect(result.current.isLoading).toBe(false)
-    })
-  })
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
 
-  describe('Markdown生成', () => {
-    it('検索結果からMarkdownが生成される', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+  describe("Markdown生成", () => {
+    it("検索結果からMarkdownが生成される", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: mockMessages,
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 2, perPage: 20 },
-        }),
-      )
-      ;(mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(ok([mockThread]))
-      ;(mockAdapter.fetchUserMaps as Mock).mockResolvedValue(ok({ U123456: 'Test User' }))
-      ;(mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
-        ok({ '1234567890.123456': 'https://slack.com/permalink' }),
-      )
-      ;(mockAdapter.generateMarkdown as Mock).mockResolvedValue(ok('# Slack検索結果\ntest content'))
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 2,
+            perPage: 20,
+          },
+        })
+      );
+      (mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(
+        ok([mockThread])
+      );
+      (mockAdapter.fetchUserMaps as Mock).mockResolvedValue(
+        ok({ U123456: "Test User" })
+      );
+      (mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
+        ok({ "1234567890.123456": "https://slack.com/permalink" })
+      );
+      (mockAdapter.generateMarkdown as Mock).mockResolvedValue(
+        ok("# Slack検索結果\ntest content")
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'test',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "test",
+        });
+      });
 
       await waitFor(() => {
-        expect(result.current.currentPreviewMarkdown).toContain('Slack検索結果')
-        expect(result.current.currentPreviewMarkdown).toContain('test')
+        expect(result.current.currentPreviewMarkdown).toContain(
+          "Slack検索結果"
+        );
+        expect(result.current.currentPreviewMarkdown).toContain("test");
         // threadMarkdownsは現在の実装では使用されていない可能性があるためコメントアウト
         // expect(result.current.threadMarkdowns).toHaveLength(1)
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('ユーザー情報とパーマリンク取得', () => {
-    it('ユーザー情報が正しくマッピングされる', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+  describe("ユーザー情報とパーマリンク取得", () => {
+    it("ユーザー情報が正しくマッピングされる", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: mockMessages,
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 2, perPage: 20 },
-        }),
-      )
-      ;(mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(ok([mockThread]))
-      ;(mockAdapter.fetchUserMaps as Mock).mockResolvedValue(ok({ U123456: 'Test User' }))
-      ;(mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
-        ok({ '1234567890.123456': 'https://slack.com/permalink' }),
-      )
-      ;(mockAdapter.generateMarkdown as Mock).mockResolvedValue(ok('# Test Thread\nTest content'))
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 2,
+            perPage: 20,
+          },
+        })
+      );
+      (mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(
+        ok([mockThread])
+      );
+      (mockAdapter.fetchUserMaps as Mock).mockResolvedValue(
+        ok({ U123456: "Test User" })
+      );
+      (mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
+        ok({ "1234567890.123456": "https://slack.com/permalink" })
+      );
+      (mockAdapter.generateMarkdown as Mock).mockResolvedValue(
+        ok("# Test Thread\nTest content")
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'test',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "test",
+        });
+      });
 
       await waitFor(() => {
-        expect(result.current.userMaps.U123456).toBe('Test User')
-        expect(result.current.permalinkMaps).toHaveProperty('1234567890.123456')
-      })
-    })
+        expect(result.current.userMaps.U123456).toBe("Test User");
+        expect(result.current.permalinkMaps).toHaveProperty(
+          "1234567890.123456"
+        );
+      });
+    });
 
-    it('real_nameが無い場合はnameを使用する', async () => {
-      ;(mockAdapter.searchMessages as Mock).mockResolvedValue(
+    it("real_nameが無い場合はnameを使用する", async () => {
+      (mockAdapter.searchMessages as Mock).mockResolvedValue(
         ok({
           messages: mockMessages,
-          pagination: { currentPage: 1, totalPages: 1, totalResults: 2, perPage: 20 },
-        }),
-      )
-      ;(mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(ok([mockThread]))
-      ;(mockAdapter.fetchUserMaps as Mock).mockResolvedValue(ok({ U123456: 'testuser' }))
-      ;(mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
-        ok({ '1234567890.123456': 'https://slack.com/permalink' }),
-      )
-      ;(mockAdapter.generateMarkdown as Mock).mockResolvedValue(ok('# Test Thread\nTest content'))
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            totalResults: 2,
+            perPage: 20,
+          },
+        })
+      );
+      (mockAdapter.buildThreadsFromMessages as Mock).mockResolvedValue(
+        ok([mockThread])
+      );
+      (mockAdapter.fetchUserMaps as Mock).mockResolvedValue(
+        ok({ U123456: "testuser" })
+      );
+      (mockAdapter.generatePermalinkMaps as Mock).mockResolvedValue(
+        ok({ "1234567890.123456": "https://slack.com/permalink" })
+      );
+      (mockAdapter.generateMarkdown as Mock).mockResolvedValue(
+        ok("# Test Thread\nTest content")
+      );
 
-      const { result } = renderHook(() => useSlackSearchUnified({ adapter: mockAdapter }))
+      const { result } = renderHook(() =>
+        useSlackSearchUnified({ adapter: mockAdapter })
+      );
 
       await act(async () => {
         await result.current.handleSearch({
-          token: 'xoxp-test',
-          searchQuery: 'test',
-        })
-      })
+          token: "xoxp-test",
+          searchQuery: "test",
+        });
+      });
 
       await waitFor(() => {
-        expect(result.current.userMaps.U123456).toBe('testuser')
-      })
-    })
-  })
-})
+        expect(result.current.userMaps.U123456).toBe("testuser");
+      });
+    });
+  });
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,61 +1,64 @@
 // テスト環境のグローバル設定
-import '@testing-library/jest-dom'
-import * as matchers from '@testing-library/jest-dom/matchers'
-import { cleanup } from '@testing-library/react'
-import { afterEach, expect } from 'vitest'
+import "@testing-library/jest-dom";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { cleanup } from "@testing-library/react";
+import { afterEach, expect } from "vitest";
 
 // jest-domのマッチャーを拡張
-expect.extend(matchers)
+expect.extend(matchers);
 
 // 各テスト後にReactコンポーネントをクリーンアップ
 afterEach(() => {
-  cleanup()
-})
+  cleanup();
+});
 
 // localStorageのモック
 const localStorageMock = {
   getItem: (key: string) => {
-    const value = localStorageMock.store[key]
-    return value || null
+    const value = localStorageMock.store[key];
+    return value || null;
   },
   setItem: (key: string, value: string) => {
-    localStorageMock.store[key] = value
+    localStorageMock.store[key] = value;
   },
   removeItem: (key: string) => {
-    delete localStorageMock.store[key]
+    delete localStorageMock.store[key];
   },
   clear: () => {
-    localStorageMock.store = {}
+    localStorageMock.store = {};
   },
   store: {} as Record<string, string>,
-}
+};
 
-Object.defineProperty(window, 'localStorage', {
+Object.defineProperty(window, "localStorage", {
   value: localStorageMock,
-})
+});
 
-import { afterAll, beforeAll, beforeEach, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, vi } from "vitest";
 
 // fetchのモック設定
-global.fetch = vi.fn()
+global.fetch = vi.fn();
 
 // console.errorのモック（テスト中の不要なエラー出力を抑制）
-const originalError = console.error
+const originalError = console.error;
 beforeAll(() => {
   console.error = (...args: unknown[]) => {
-    if (typeof args[0] === 'string' && args[0].includes('Warning: ReactDOM.render')) {
-      return
+    if (
+      typeof args[0] === "string" &&
+      args[0].includes("Warning: ReactDOM.render")
+    ) {
+      return;
     }
-    originalError.call(console, ...args)
-  }
-})
+    originalError.call(console, ...args);
+  };
+});
 
 afterAll(() => {
-  console.error = originalError
-})
+  console.error = originalError;
+});
 
 // 各テストの前にlocalStorageをクリア
 beforeEach(() => {
-  localStorageMock.clear()
-  vi.clearAllMocks()
-})
+  localStorageMock.clear();
+  vi.clearAllMocks();
+});

--- a/src/__tests__/utils/errorMessage.test.ts
+++ b/src/__tests__/utils/errorMessage.test.ts
@@ -1,372 +1,381 @@
-import { describe, expect, it } from 'vitest'
-import type { ApiError } from '../../types/error'
-import { getErrorActionSuggestion, getErrorSeverity, getUserFriendlyErrorMessage } from '../../utils/errorMessage'
+import { describe, expect, it } from "vitest";
+import type { ApiError } from "../../types/error";
+import {
+  getErrorActionSuggestion,
+  getErrorSeverity,
+  getUserFriendlyErrorMessage,
+} from "../../utils/errorMessage";
 
-describe('errorMessage', () => {
-  describe('getUserFriendlyErrorMessage', () => {
-    describe('unauthorized エラー', () => {
-      it('Slack関連の認証エラーメッセージを返す', () => {
+describe("errorMessage", () => {
+  describe("getUserFriendlyErrorMessage", () => {
+    describe("unauthorized エラー", () => {
+      it("Slack関連の認証エラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'unauthorized',
-          message: 'Slack認証エラー: invalid_auth',
-        }
+          type: "unauthorized",
+          message: "Slack認証エラー: invalid_auth",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('Slack APIトークンが無効')
-        expect(result).toContain('User Token (xoxp-で始まる)')
-      })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("Slack APIトークンが無効");
+        expect(result).toContain("User Token (xoxp-で始まる)");
+      });
 
-      it('Docbase関連の認証エラーメッセージを返す', () => {
+      it("Docbase関連の認証エラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'unauthorized',
-          message: 'Docbase APIエラー: トークンが無効',
-        }
+          type: "unauthorized",
+          message: "Docbase APIエラー: トークンが無効",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('Docbase APIトークンが無効')
-        expect(result).toContain('正しいAPIトークンを入力')
-      })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("Docbase APIトークンが無効");
+        expect(result).toContain("正しいAPIトークンを入力");
+      });
 
-      it('一般的な認証エラーメッセージを返す', () => {
+      it("一般的な認証エラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'unauthorized',
-          message: '一般的な認証エラー',
-        }
+          type: "unauthorized",
+          message: "一般的な認証エラー",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('APIトークンが無効')
-        expect(result).toContain('正しいトークンを入力')
-      })
-    })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("APIトークンが無効");
+        expect(result).toContain("正しいトークンを入力");
+      });
+    });
 
-    describe('rate_limit エラー', () => {
-      it('レート制限エラーメッセージを返す', () => {
+    describe("rate_limit エラー", () => {
+      it("レート制限エラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'rate_limit',
-          message: 'API rate limit exceeded',
-        }
+          type: "rate_limit",
+          message: "API rate limit exceeded",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('API制限に達しました')
-        expect(result).toContain('しばらく時間をおいて')
-      })
-    })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("API制限に達しました");
+        expect(result).toContain("しばらく時間をおいて");
+      });
+    });
 
-    describe('network エラー', () => {
-      it('リトライ後のネットワークエラーメッセージを返す', () => {
+    describe("network エラー", () => {
+      it("リトライ後のネットワークエラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'network',
-          message: 'ネットワークエラーが発生し、何度か再試行しましたが改善しませんでした',
-        }
+          type: "network",
+          message:
+            "ネットワークエラーが発生し、何度か再試行しましたが改善しませんでした",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('自動で再試行しましたが改善しませんでした')
-        expect(result).toContain('ネットワーク接続を確認')
-      })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("自動で再試行しましたが改善しませんでした");
+        expect(result).toContain("ネットワーク接続を確認");
+      });
 
-      it('一般的なネットワークエラーメッセージを返す', () => {
+      it("一般的なネットワークエラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'network',
-          message: 'ネットワークエラー',
-        }
+          type: "network",
+          message: "ネットワークエラー",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('ネットワークエラーが発生しました')
-        expect(result).toContain('インターネット接続を確認')
-      })
-    })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("ネットワークエラーが発生しました");
+        expect(result).toContain("インターネット接続を確認");
+      });
+    });
 
-    describe('notFound エラー', () => {
-      it('Docbaseチーム関連のnotFoundエラーメッセージを返す', () => {
+    describe("notFound エラー", () => {
+      it("Docbaseチーム関連のnotFoundエラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'notFound',
-          message: 'チームドメインが見つかりません',
-        }
+          type: "notFound",
+          message: "チームドメインが見つかりません",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('Docbaseのチームドメインが見つかりません')
-        expect(result).toContain('正しいドメイン名を入力')
-      })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("Docbaseのチームドメインが見つかりません");
+        expect(result).toContain("正しいドメイン名を入力");
+      });
 
-      it('Slackチャンネル関連のnotFoundエラーメッセージを返す', () => {
+      it("Slackチャンネル関連のnotFoundエラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'notFound',
-          message: 'チャンネルが見つかりません',
-        }
+          type: "notFound",
+          message: "チャンネルが見つかりません",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('Slackのチャンネルまたはメッセージが見つかりません')
-        expect(result).toContain('アクセス権限があるか確認')
-      })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain(
+          "Slackのチャンネルまたはメッセージが見つかりません"
+        );
+        expect(result).toContain("アクセス権限があるか確認");
+      });
 
-      it('ユーザー関連のnotFoundエラーメッセージを返す', () => {
+      it("ユーザー関連のnotFoundエラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'notFound',
-          message: 'ユーザーが見つかりません',
-        }
+          type: "notFound",
+          message: "ユーザーが見つかりません",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('ユーザーが見つかりません')
-        expect(result).toContain('ユーザーIDを確認')
-      })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("ユーザーが見つかりません");
+        expect(result).toContain("ユーザーIDを確認");
+      });
 
-      it('一般的なnotFoundエラーメッセージを返す', () => {
+      it("一般的なnotFoundエラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'notFound',
-          message: 'リソースが見つかりません',
-        }
+          type: "notFound",
+          message: "リソースが見つかりません",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('リソースが見つかりません')
-        expect(result).toContain('入力内容を確認')
-      })
-    })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("リソースが見つかりません");
+        expect(result).toContain("入力内容を確認");
+      });
+    });
 
-    describe('validation エラー', () => {
-      it('バリデーションエラーメッセージを返す', () => {
+    describe("validation エラー", () => {
+      it("バリデーションエラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'validation',
-          message: '入力が不正です',
-        }
+          type: "validation",
+          message: "入力が不正です",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('入力内容に問題があります')
-        expect(result).toContain('必須項目をすべて入力')
-      })
-    })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("入力内容に問題があります");
+        expect(result).toContain("必須項目をすべて入力");
+      });
+    });
 
-    describe('missing_scope エラー', () => {
-      it('スコープ不足エラーメッセージを返す', () => {
+    describe("missing_scope エラー", () => {
+      it("スコープ不足エラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'missing_scope',
-          message: '必要なスコープがありません',
-        }
+          type: "missing_scope",
+          message: "必要なスコープがありません",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('Slack APIトークンに必要な権限がありません')
-        expect(result).toContain('適切なスコープを持つトークン')
-      })
-    })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("Slack APIトークンに必要な権限がありません");
+        expect(result).toContain("適切なスコープを持つトークン");
+      });
+    });
 
-    describe('slack_api エラー', () => {
-      it('missing_scopeを含むSlack APIエラーメッセージを返す', () => {
+    describe("slack_api エラー", () => {
+      it("missing_scopeを含むSlack APIエラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'slack_api',
-          message: 'missing_scope: search:read',
-        }
+          type: "slack_api",
+          message: "missing_scope: search:read",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('Slack APIトークンに必要なスコープがありません')
-        expect(result).toContain('search:read権限を含むトークン')
-      })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain(
+          "Slack APIトークンに必要なスコープがありません"
+        );
+        expect(result).toContain("search:read権限を含むトークン");
+      });
 
-      it('一般的なSlack APIエラーメッセージを返す', () => {
+      it("一般的なSlack APIエラーメッセージを返す", () => {
         const error: ApiError = {
-          type: 'slack_api',
-          message: 'Slack APIエラー',
-        }
+          type: "slack_api",
+          message: "Slack APIエラー",
+        };
 
-        const result = getUserFriendlyErrorMessage(error)
-        expect(result).toContain('Slack APIでエラーが発生しました')
-        expect(result).toContain('トークンの権限やアクセス設定を確認')
-      })
-    })
-  })
+        const result = getUserFriendlyErrorMessage(error);
+        expect(result).toContain("Slack APIでエラーが発生しました");
+        expect(result).toContain("トークンの権限やアクセス設定を確認");
+      });
+    });
+  });
 
-  describe('getErrorActionSuggestion', () => {
-    describe('unauthorized エラー', () => {
-      it('Slack関連の認証エラーの提案を返す', () => {
+  describe("getErrorActionSuggestion", () => {
+    describe("unauthorized エラー", () => {
+      it("Slack関連の認証エラーの提案を返す", () => {
         const error: ApiError = {
-          type: 'unauthorized',
-          message: 'Slack認証エラー',
-        }
+          type: "unauthorized",
+          message: "Slack認証エラー",
+        };
 
-        const result = getErrorActionSuggestion(error)
-        expect(result).toContain('Slack Appの設定でUser Tokenを確認')
-        expect(result).toContain('適切な権限があることを確認')
-      })
+        const result = getErrorActionSuggestion(error);
+        expect(result).toContain("Slack Appの設定でUser Tokenを確認");
+        expect(result).toContain("適切な権限があることを確認");
+      });
 
-      it('Docbase関連の認証エラーの提案を返す', () => {
+      it("Docbase関連の認証エラーの提案を返す", () => {
         const error: ApiError = {
-          type: 'unauthorized',
-          message: 'Docbase認証エラー',
-        }
+          type: "unauthorized",
+          message: "Docbase認証エラー",
+        };
 
-        const result = getErrorActionSuggestion(error)
-        expect(result).toContain('Docbaseの設定画面でAPIトークンを再生成')
-      })
+        const result = getErrorActionSuggestion(error);
+        expect(result).toContain("Docbaseの設定画面でAPIトークンを再生成");
+      });
 
-      it('一般的な認証エラーの提案を返す', () => {
+      it("一般的な認証エラーの提案を返す", () => {
         const error: ApiError = {
-          type: 'unauthorized',
-          message: '一般的な認証エラー',
-        }
+          type: "unauthorized",
+          message: "一般的な認証エラー",
+        };
 
-        const result = getErrorActionSuggestion(error)
-        expect(result).toContain('APIトークンを再確認')
-        expect(result).toContain('必要に応じて再生成')
-      })
-    })
+        const result = getErrorActionSuggestion(error);
+        expect(result).toContain("APIトークンを再確認");
+        expect(result).toContain("必要に応じて再生成");
+      });
+    });
 
-    describe('rate_limit エラー', () => {
-      it('レート制限エラーの提案を返す', () => {
+    describe("rate_limit エラー", () => {
+      it("レート制限エラーの提案を返す", () => {
         const error: ApiError = {
-          type: 'rate_limit',
-          message: 'レート制限',
-        }
+          type: "rate_limit",
+          message: "レート制限",
+        };
 
-        const result = getErrorActionSuggestion(error)
-        expect(result).toContain('数分間待ってから再試行')
-        expect(result).toContain('検索条件を絞り込む')
-      })
-    })
+        const result = getErrorActionSuggestion(error);
+        expect(result).toContain("数分間待ってから再試行");
+        expect(result).toContain("検索条件を絞り込む");
+      });
+    });
 
-    describe('network エラー', () => {
-      it('ネットワークエラーの提案を返す', () => {
+    describe("network エラー", () => {
+      it("ネットワークエラーの提案を返す", () => {
         const error: ApiError = {
-          type: 'network',
-          message: 'ネットワークエラー',
-        }
+          type: "network",
+          message: "ネットワークエラー",
+        };
 
-        const result = getErrorActionSuggestion(error)
-        expect(result).toContain('Wi-Fi接続を確認')
-        expect(result).toContain('他のウェブサイトにアクセスできるか確認')
-      })
-    })
+        const result = getErrorActionSuggestion(error);
+        expect(result).toContain("Wi-Fi接続を確認");
+        expect(result).toContain("他のウェブサイトにアクセスできるか確認");
+      });
+    });
 
-    describe('missing_scope エラー', () => {
-      it('スコープ不足エラーの提案を返す', () => {
+    describe("missing_scope エラー", () => {
+      it("スコープ不足エラーの提案を返す", () => {
         const error: ApiError = {
-          type: 'missing_scope',
-          message: 'スコープ不足',
-        }
+          type: "missing_scope",
+          message: "スコープ不足",
+        };
 
-        const result = getErrorActionSuggestion(error)
-        expect(result).toContain('Slack Appの OAuth & Permissions 設定')
-        expect(result).toContain('search:read')
-      })
-    })
+        const result = getErrorActionSuggestion(error);
+        expect(result).toContain("Slack Appの OAuth & Permissions 設定");
+        expect(result).toContain("search:read");
+      });
+    });
 
-    describe('その他のエラー', () => {
-      it('対応する提案がない場合はnullを返す', () => {
+    describe("その他のエラー", () => {
+      it("対応する提案がない場合はnullを返す", () => {
         const error: ApiError = {
-          type: 'validation',
-          message: 'バリデーションエラー',
-        }
+          type: "validation",
+          message: "バリデーションエラー",
+        };
 
-        const result = getErrorActionSuggestion(error)
-        expect(result).toBeNull()
-      })
+        const result = getErrorActionSuggestion(error);
+        expect(result).toBeNull();
+      });
 
-      it('未知のエラータイプの場合はnullを返す', () => {
+      it("未知のエラータイプの場合はnullを返す", () => {
         const error = {
-          type: 'custom_error',
-          message: 'カスタムエラー',
-        } as unknown as ApiError
+          type: "custom_error",
+          message: "カスタムエラー",
+        } as unknown as ApiError;
 
-        const result = getErrorActionSuggestion(error)
-        expect(result).toBeNull()
-      })
-    })
-  })
+        const result = getErrorActionSuggestion(error);
+        expect(result).toBeNull();
+      });
+    });
+  });
 
-  describe('getErrorSeverity', () => {
-    describe('低重要度エラー', () => {
-      it('validationエラーは低重要度', () => {
+  describe("getErrorSeverity", () => {
+    describe("低重要度エラー", () => {
+      it("validationエラーは低重要度", () => {
         const error: ApiError = {
-          type: 'validation',
-          message: 'バリデーションエラー',
-        }
+          type: "validation",
+          message: "バリデーションエラー",
+        };
 
-        const result = getErrorSeverity(error)
-        expect(result).toBe('low')
-      })
-    })
+        const result = getErrorSeverity(error);
+        expect(result).toBe("low");
+      });
+    });
 
-    describe('中重要度エラー', () => {
-      it('unauthorizedエラーは中重要度', () => {
+    describe("中重要度エラー", () => {
+      it("unauthorizedエラーは中重要度", () => {
         const error: ApiError = {
-          type: 'unauthorized',
-          message: '認証エラー',
-        }
+          type: "unauthorized",
+          message: "認証エラー",
+        };
 
-        const result = getErrorSeverity(error)
-        expect(result).toBe('medium')
-      })
+        const result = getErrorSeverity(error);
+        expect(result).toBe("medium");
+      });
 
-      it('missing_scopeエラーは中重要度', () => {
+      it("missing_scopeエラーは中重要度", () => {
         const error: ApiError = {
-          type: 'missing_scope',
-          message: 'スコープ不足',
-        }
+          type: "missing_scope",
+          message: "スコープ不足",
+        };
 
-        const result = getErrorSeverity(error)
-        expect(result).toBe('medium')
-      })
+        const result = getErrorSeverity(error);
+        expect(result).toBe("medium");
+      });
 
-      it('rate_limitエラーは中重要度', () => {
+      it("rate_limitエラーは中重要度", () => {
         const error: ApiError = {
-          type: 'rate_limit',
-          message: 'レート制限',
-        }
+          type: "rate_limit",
+          message: "レート制限",
+        };
 
-        const result = getErrorSeverity(error)
-        expect(result).toBe('medium')
-      })
+        const result = getErrorSeverity(error);
+        expect(result).toBe("medium");
+      });
 
-      it('networkエラーは中重要度', () => {
+      it("networkエラーは中重要度", () => {
         const error: ApiError = {
-          type: 'network',
-          message: 'ネットワークエラー',
-        }
+          type: "network",
+          message: "ネットワークエラー",
+        };
 
-        const result = getErrorSeverity(error)
-        expect(result).toBe('medium')
-      })
+        const result = getErrorSeverity(error);
+        expect(result).toBe("medium");
+      });
 
-      it('notFoundエラーは中重要度', () => {
+      it("notFoundエラーは中重要度", () => {
         const error: ApiError = {
-          type: 'notFound',
-          message: 'リソースが見つかりません',
-        }
+          type: "notFound",
+          message: "リソースが見つかりません",
+        };
 
-        const result = getErrorSeverity(error)
-        expect(result).toBe('medium')
-      })
-    })
+        const result = getErrorSeverity(error);
+        expect(result).toBe("medium");
+      });
+    });
 
-    describe('高重要度エラー', () => {
-      it('unknownエラーは高重要度', () => {
+    describe("高重要度エラー", () => {
+      it("unknownエラーは高重要度", () => {
         const error: ApiError = {
-          type: 'unknown',
-          message: '不明なエラー',
-        }
+          type: "unknown",
+          message: "不明なエラー",
+        };
 
-        const result = getErrorSeverity(error)
-        expect(result).toBe('high')
-      })
+        const result = getErrorSeverity(error);
+        expect(result).toBe("high");
+      });
 
-      it('slack_apiエラーは高重要度', () => {
+      it("slack_apiエラーは高重要度", () => {
         const error: ApiError = {
-          type: 'slack_api',
-          message: 'Slack APIエラー',
-        }
+          type: "slack_api",
+          message: "Slack APIエラー",
+        };
 
-        const result = getErrorSeverity(error)
-        expect(result).toBe('high')
-      })
-    })
+        const result = getErrorSeverity(error);
+        expect(result).toBe("high");
+      });
+    });
 
-    describe('デフォルト', () => {
-      it('未知のエラータイプは中重要度をデフォルトとする', () => {
+    describe("デフォルト", () => {
+      it("未知のエラータイプは中重要度をデフォルトとする", () => {
         const error = {
-          type: 'custom_error',
-          message: 'カスタムエラー',
-        } as unknown as ApiError
+          type: "custom_error",
+          message: "カスタムエラー",
+        } as unknown as ApiError;
 
-        const result = getErrorSeverity(error)
-        expect(result).toBe('medium')
-      })
-    })
-  })
-})
+        const result = getErrorSeverity(error);
+        expect(result).toBe("medium");
+      });
+    });
+  });
+});

--- a/src/__tests__/utils/errorStorage.test.ts
+++ b/src/__tests__/utils/errorStorage.test.ts
@@ -4,7 +4,7 @@
  * エラーログの保存、取得、管理機能のテスト
  */
 
-import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   cleanupOldErrorLogs,
   clearErrorLogs,
@@ -14,7 +14,7 @@ import {
   getErrorLogStats,
   getErrorLogs,
   logError,
-} from '../../utils/errorStorage'
+} from "../../utils/errorStorage";
 
 // LocalStorageのモック
 const localStorageMock = {
@@ -22,248 +22,257 @@ const localStorageMock = {
   setItem: vi.fn(),
   removeItem: vi.fn(),
   clear: vi.fn(),
-}
-Object.defineProperty(window, 'localStorage', {
+};
+Object.defineProperty(window, "localStorage", {
   value: localStorageMock,
-})
+});
 
 // windowのモック
-Object.defineProperty(window, 'innerWidth', {
+Object.defineProperty(window, "innerWidth", {
   writable: true,
   configurable: true,
   value: 1920,
-})
-Object.defineProperty(window, 'innerHeight', {
+});
+Object.defineProperty(window, "innerHeight", {
   writable: true,
   configurable: true,
   value: 1080,
-})
+});
 
 // console.errorのモック
-const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-const consoleGroupSpy = vi.spyOn(console, 'group').mockImplementation(() => {})
-const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-const consoleGroupEndSpy = vi.spyOn(console, 'groupEnd').mockImplementation(() => {})
+const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+const consoleGroupSpy = vi.spyOn(console, "group").mockImplementation(() => {});
+const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+const consoleGroupEndSpy = vi
+  .spyOn(console, "groupEnd")
+  .mockImplementation(() => {});
 
-describe('errorStorage', () => {
+describe("errorStorage", () => {
   beforeEach(() => {
     // すべてのモックをクリア
-    localStorageMock.getItem.mockClear()
-    localStorageMock.setItem.mockClear()
-    localStorageMock.removeItem.mockClear()
-    consoleSpy.mockClear()
-    consoleGroupSpy.mockClear()
-    consoleLogSpy.mockClear()
-    consoleGroupEndSpy.mockClear()
+    localStorageMock.getItem.mockClear();
+    localStorageMock.setItem.mockClear();
+    localStorageMock.removeItem.mockClear();
+    consoleSpy.mockClear();
+    consoleGroupSpy.mockClear();
+    consoleLogSpy.mockClear();
+    consoleGroupEndSpy.mockClear();
 
     // モック実装をリセット
-    localStorageMock.getItem.mockImplementation(() => null)
-    localStorageMock.setItem.mockImplementation(() => {})
-    localStorageMock.removeItem.mockImplementation(() => {})
-  })
+    localStorageMock.getItem.mockImplementation(() => null);
+    localStorageMock.setItem.mockImplementation(() => {});
+    localStorageMock.removeItem.mockImplementation(() => {});
+  });
 
   afterAll(() => {
-    consoleSpy.mockRestore()
-    consoleGroupSpy.mockRestore()
-    consoleLogSpy.mockRestore()
-    consoleGroupEndSpy.mockRestore()
-  })
+    consoleSpy.mockRestore();
+    consoleGroupSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleGroupEndSpy.mockRestore();
+  });
 
-  describe('logError', () => {
-    test('エラーログを正常に保存する', () => {
-      localStorageMock.getItem.mockReturnValue(null)
+  describe("logError", () => {
+    test("エラーログを正常に保存する", () => {
+      localStorageMock.getItem.mockReturnValue(null);
 
-      const error = new Error('Test error')
-      const errorInfo = { componentStack: 'Test component stack' }
+      const error = new Error("Test error");
+      const errorInfo = { componentStack: "Test component stack" };
       const context = {
-        url: 'https://example.com',
-        userAgent: 'Test UserAgent',
-        timestamp: '2023-01-01T00:00:00.000Z',
-      }
+        url: "https://example.com",
+        userAgent: "Test UserAgent",
+        timestamp: "2023-01-01T00:00:00.000Z",
+      };
 
-      const result = logError(error, errorInfo, context)
+      const result = logError(error, errorInfo, context);
 
       expect(result).toMatchObject({
         id: expect.any(String),
         timestamp: context.timestamp,
         error: {
-          name: 'Error',
-          message: 'Test error',
+          name: "Error",
+          message: "Test error",
           stack: expect.any(String),
         },
         errorInfo: {
-          componentStack: 'Test component stack',
+          componentStack: "Test component stack",
         },
         context: {
-          url: 'https://example.com',
-          userAgent: 'Test UserAgent',
+          url: "https://example.com",
+          userAgent: "Test UserAgent",
           viewport: {
             width: 1920,
             height: 1080,
           },
           userId: expect.any(String),
         },
-      })
+      });
 
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('notebooklm_error_logs', expect.any(String))
-    })
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "notebooklm_error_logs",
+        expect.any(String)
+      );
+    });
 
-    test('LocalStorage保存に失敗した場合でもエラーオブジェクトを返す', () => {
+    test("LocalStorage保存に失敗した場合でもエラーオブジェクトを返す", () => {
       localStorageMock.setItem.mockImplementation(() => {
-        throw new Error('Storage error')
-      })
+        throw new Error("Storage error");
+      });
 
-      const error = new Error('Test error')
-      const errorInfo = { componentStack: 'Test component stack' }
+      const error = new Error("Test error");
+      const errorInfo = { componentStack: "Test component stack" };
       const context = {
-        url: 'https://example.com',
-        userAgent: 'Test UserAgent',
-        timestamp: '2023-01-01T00:00:00.000Z',
-      }
+        url: "https://example.com",
+        userAgent: "Test UserAgent",
+        timestamp: "2023-01-01T00:00:00.000Z",
+      };
 
-      const result = logError(error, errorInfo, context)
+      const result = logError(error, errorInfo, context);
 
       expect(result).toMatchObject({
         id: expect.any(String),
         timestamp: context.timestamp,
         error: {
-          name: 'Error',
-          message: 'Test error',
+          name: "Error",
+          message: "Test error",
         },
-      })
+      });
 
       // console.errorが呼ばれたことを確認（モックで防いでいるのでログ自体は出ない）
       expect(result).toMatchObject({
         id: expect.any(String),
         timestamp: context.timestamp,
         error: {
-          name: 'Error',
-          message: 'Test error',
+          name: "Error",
+          message: "Test error",
         },
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('getErrorLogs', () => {
-    test('保存されたエラーログを取得する', () => {
+  describe("getErrorLogs", () => {
+    test("保存されたエラーログを取得する", () => {
       const mockLogs = [
         {
-          id: 'test-1',
-          timestamp: '2023-01-01T00:00:00.000Z',
-          error: { name: 'Error', message: 'Test error 1' },
+          id: "test-1",
+          timestamp: "2023-01-01T00:00:00.000Z",
+          error: { name: "Error", message: "Test error 1" },
         },
-      ]
-      localStorageMock.getItem.mockReturnValue(JSON.stringify(mockLogs))
+      ];
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(mockLogs));
 
-      const result = getErrorLogs()
+      const result = getErrorLogs();
 
-      expect(result).toEqual(mockLogs)
-    })
+      expect(result).toEqual(mockLogs);
+    });
 
-    test('ログが存在しない場合は空配列を返す', () => {
-      localStorageMock.getItem.mockReturnValue(null)
+    test("ログが存在しない場合は空配列を返す", () => {
+      localStorageMock.getItem.mockReturnValue(null);
 
-      const result = getErrorLogs()
+      const result = getErrorLogs();
 
-      expect(result).toEqual([])
-    })
+      expect(result).toEqual([]);
+    });
 
-    test('無効なJSONの場合は空配列を返す', () => {
-      localStorageMock.getItem.mockReturnValue('invalid json')
+    test("無効なJSONの場合は空配列を返す", () => {
+      localStorageMock.getItem.mockReturnValue("invalid json");
 
-      const result = getErrorLogs()
+      const result = getErrorLogs();
 
-      expect(result).toEqual([])
+      expect(result).toEqual([]);
       // console.errorがモックされているため、実際の確認は不要
-    })
-  })
+    });
+  });
 
-  describe('getErrorLog', () => {
-    test('指定したIDのエラーログを取得する', () => {
+  describe("getErrorLog", () => {
+    test("指定したIDのエラーログを取得する", () => {
       const mockLogs = [
         {
-          id: 'test-1',
-          timestamp: '2023-01-01T00:00:00.000Z',
-          error: { name: 'Error', message: 'Test error 1' },
+          id: "test-1",
+          timestamp: "2023-01-01T00:00:00.000Z",
+          error: { name: "Error", message: "Test error 1" },
         },
         {
-          id: 'test-2',
-          timestamp: '2023-01-01T00:00:00.000Z',
-          error: { name: 'Error', message: 'Test error 2' },
+          id: "test-2",
+          timestamp: "2023-01-01T00:00:00.000Z",
+          error: { name: "Error", message: "Test error 2" },
         },
-      ]
-      localStorageMock.getItem.mockReturnValue(JSON.stringify(mockLogs))
+      ];
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(mockLogs));
 
-      const result = getErrorLog('test-1')
+      const result = getErrorLog("test-1");
 
-      expect(result).toEqual(mockLogs[0])
-    })
+      expect(result).toEqual(mockLogs[0]);
+    });
 
-    test('存在しないIDの場合はnullを返す', () => {
-      localStorageMock.getItem.mockReturnValue('[]')
+    test("存在しないIDの場合はnullを返す", () => {
+      localStorageMock.getItem.mockReturnValue("[]");
 
-      const result = getErrorLog('nonexistent')
+      const result = getErrorLog("nonexistent");
 
-      expect(result).toBeNull()
-    })
-  })
+      expect(result).toBeNull();
+    });
+  });
 
-  describe('clearErrorLogs', () => {
-    test('エラーログをクリアする', () => {
-      const result = clearErrorLogs()
+  describe("clearErrorLogs", () => {
+    test("エラーログをクリアする", () => {
+      const result = clearErrorLogs();
 
-      expect(result).toBe(true)
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('notebooklm_error_logs')
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('notebooklm_error_metadata')
-    })
+      expect(result).toBe(true);
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        "notebooklm_error_logs"
+      );
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        "notebooklm_error_metadata"
+      );
+    });
 
-    test('クリアに失敗した場合はfalseを返す', () => {
+    test("クリアに失敗した場合はfalseを返す", () => {
       localStorageMock.removeItem.mockImplementation(() => {
-        throw new Error('Remove error')
-      })
+        throw new Error("Remove error");
+      });
 
-      const result = clearErrorLogs()
+      const result = clearErrorLogs();
 
-      expect(result).toBe(false)
+      expect(result).toBe(false);
       // console.errorがモックされているため、実際の確認は不要
-    })
-  })
+    });
+  });
 
-  describe('getErrorLogStats', () => {
-    test('エラーログの統計情報を取得する', () => {
+  describe("getErrorLogStats", () => {
+    test("エラーログの統計情報を取得する", () => {
       const mockLogs = [
         {
-          id: 'test-1',
-          timestamp: '2023-01-01T00:00:00.000Z',
-          error: { name: 'TypeError', message: 'Test error 1' },
+          id: "test-1",
+          timestamp: "2023-01-01T00:00:00.000Z",
+          error: { name: "TypeError", message: "Test error 1" },
         },
         {
-          id: 'test-2',
-          timestamp: '2023-01-02T00:00:00.000Z',
-          error: { name: 'ReferenceError', message: 'Test error 2' },
+          id: "test-2",
+          timestamp: "2023-01-02T00:00:00.000Z",
+          error: { name: "ReferenceError", message: "Test error 2" },
         },
         {
-          id: 'test-3',
-          timestamp: '2023-01-03T00:00:00.000Z',
-          error: { name: 'TypeError', message: 'Test error 3' },
+          id: "test-3",
+          timestamp: "2023-01-03T00:00:00.000Z",
+          error: { name: "TypeError", message: "Test error 3" },
         },
-      ]
-      localStorageMock.getItem.mockReturnValue(JSON.stringify(mockLogs))
+      ];
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(mockLogs));
 
-      const result = getErrorLogStats()
+      const result = getErrorLogStats();
 
       expect(result).toEqual({
         totalLogs: 3,
-        lastError: '2023-01-01T00:00:00.000Z', // 最初のログ（最新）
+        lastError: "2023-01-01T00:00:00.000Z", // 最初のログ（最新）
         errorTypes: {
           TypeError: 2,
           ReferenceError: 1,
         },
         timeRange: {
-          oldest: '2023-01-01T00:00:00.000Z', // 文字列比較で最も小さい値
-          newest: '2023-01-03T00:00:00.000Z', // 文字列比較で最も大きい値
+          oldest: "2023-01-01T00:00:00.000Z", // 文字列比較で最も小さい値
+          newest: "2023-01-03T00:00:00.000Z", // 文字列比較で最も大きい値
         },
-      })
-    })
-  })
-})
+      });
+    });
+  });
+});

--- a/src/__tests__/utils/fileDownloader.test.ts
+++ b/src/__tests__/utils/fileDownloader.test.ts
@@ -1,23 +1,31 @@
-import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { downloadMarkdownFile } from '../../utils/fileDownloader'
+import {
+  type Mock,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { downloadMarkdownFile } from "../../utils/fileDownloader";
 
 // DOM操作のモック
-const mockClick = vi.fn()
-const mockAppendChild = vi.fn()
-const mockRemoveChild = vi.fn()
-const mockCreateObjectURL = vi.fn()
-const mockRevokeObjectURL = vi.fn()
+const mockClick = vi.fn();
+const mockAppendChild = vi.fn();
+const mockRemoveChild = vi.fn();
+const mockCreateObjectURL = vi.fn();
+const mockRevokeObjectURL = vi.fn();
 
-describe('fileDownloader', () => {
+describe("fileDownloader", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.clearAllMocks();
 
     // createElement のモック
     const mockAnchorElement = {
-      href: '',
-      download: '',
+      href: "",
+      download: "",
       click: mockClick,
-    }
+    };
 
     global.document = {
       createElement: vi.fn().mockReturnValue(mockAnchorElement),
@@ -25,191 +33,236 @@ describe('fileDownloader', () => {
         appendChild: mockAppendChild,
         removeChild: mockRemoveChild,
       },
-    } as unknown as Document
+    } as unknown as Document;
 
     // URL のモック
     global.URL = {
-      createObjectURL: mockCreateObjectURL.mockReturnValue('blob:mock-url'),
+      createObjectURL: mockCreateObjectURL.mockReturnValue("blob:mock-url"),
       revokeObjectURL: mockRevokeObjectURL,
-    } as unknown as typeof URL
+    } as unknown as typeof URL;
 
     // Blob のモック
     global.Blob = vi.fn().mockImplementation((content, options) => ({
       content,
       options,
-    })) as unknown as typeof Blob
+    })) as unknown as typeof Blob;
 
     // console.error のモック
-    vi.spyOn(console, 'error').mockImplementation(() => {})
-  })
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  describe('正常ケース', () => {
-    it('Docbaseソースでファイルダウンロードが成功する', () => {
-      const result = downloadMarkdownFile('# テストMarkdown', 'test-keyword', true, 'docbase')
+  describe("正常ケース", () => {
+    it("Docbaseソースでファイルダウンロードが成功する", () => {
+      const result = downloadMarkdownFile(
+        "# テストMarkdown",
+        "test-keyword",
+        true,
+        "docbase"
+      );
 
-      expect(result.success).toBe(true)
-      expect(result.message).toBeUndefined()
+      expect(result.success).toBe(true);
+      expect(result.message).toBeUndefined();
 
       // Blob作成の確認
-      expect(global.Blob).toHaveBeenCalledWith(['# テストMarkdown'], { type: 'text/markdown;charset=utf-8' })
+      expect(global.Blob).toHaveBeenCalledWith(["# テストMarkdown"], {
+        type: "text/markdown;charset=utf-8",
+      });
 
       // URL作成・削除の確認
-      expect(mockCreateObjectURL).toHaveBeenCalled()
-      expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+      expect(mockCreateObjectURL).toHaveBeenCalled();
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
 
       // DOM操作の確認
-      expect(document.createElement).toHaveBeenCalledWith('a')
-      expect(mockAppendChild).toHaveBeenCalled()
-      expect(mockClick).toHaveBeenCalled()
-      expect(mockRemoveChild).toHaveBeenCalled()
-    })
+      expect(document.createElement).toHaveBeenCalledWith("a");
+      expect(mockAppendChild).toHaveBeenCalled();
+      expect(mockClick).toHaveBeenCalled();
+      expect(mockRemoveChild).toHaveBeenCalled();
+    });
 
-    it('Slackソースでファイルダウンロードが成功する', () => {
-      const result = downloadMarkdownFile('# Slack Threads', 'slack-search', true, 'slack')
+    it("Slackソースでファイルダウンロードが成功する", () => {
+      const result = downloadMarkdownFile(
+        "# Slack Threads",
+        "slack-search",
+        true,
+        "slack"
+      );
 
-      expect(result.success).toBe(true)
+      expect(result.success).toBe(true);
 
       // ファイル名にslackとthreadsが含まれることを確認
-      const anchorElement = (document.createElement as Mock).mock.results[0].value
-      expect(anchorElement.download).toMatch(/^slack_\d{4}-\d{2}-\d{2}_slack_search_threads\.md$/)
-    })
+      const anchorElement = (document.createElement as Mock).mock.results[0]
+        .value;
+      expect(anchorElement.download).toMatch(
+        /^slack_\d{4}-\d{2}-\d{2}_slack_search_threads\.md$/
+      );
+    });
 
-    it('デフォルトソースタイプ（docbase）でダウンロードが成功する', () => {
+    it("デフォルトソースタイプ（docbase）でダウンロードが成功する", () => {
       const result = downloadMarkdownFile(
-        '# Default Content',
-        'default-keyword',
-        true,
+        "# Default Content",
+        "default-keyword",
+        true
         // sourceType省略
-      )
+      );
 
-      expect(result.success).toBe(true)
+      expect(result.success).toBe(true);
 
       // ファイル名にdocbaseとarticlesが含まれることを確認
-      const anchorElement = (document.createElement as Mock).mock.results[0].value
-      expect(anchorElement.download).toMatch(/^docbase_\d{4}-\d{2}-\d{2}_default_keyword_articles\.md$/)
-    })
-  })
+      const anchorElement = (document.createElement as Mock).mock.results[0]
+        .value;
+      expect(anchorElement.download).toMatch(
+        /^docbase_\d{4}-\d{2}-\d{2}_default_keyword_articles\.md$/
+      );
+    });
+  });
 
-  describe('ファイル名生成', () => {
-    it('現在の日付が正しくファイル名に含まれる', () => {
-      const mockDate = new Date('2023-05-15T10:30:00Z')
-      vi.setSystemTime(mockDate)
+  describe("ファイル名生成", () => {
+    it("現在の日付が正しくファイル名に含まれる", () => {
+      const mockDate = new Date("2023-05-15T10:30:00Z");
+      vi.setSystemTime(mockDate);
 
-      downloadMarkdownFile('# Test', 'keyword', true, 'docbase')
+      downloadMarkdownFile("# Test", "keyword", true, "docbase");
 
-      const anchorElement = (document.createElement as Mock).mock.results[0].value
-      expect(anchorElement.download).toBe('docbase_2023-05-15_keyword_articles.md')
+      const anchorElement = (document.createElement as Mock).mock.results[0]
+        .value;
+      expect(anchorElement.download).toBe(
+        "docbase_2023-05-15_keyword_articles.md"
+      );
 
-      vi.useRealTimers()
-    })
+      vi.useRealTimers();
+    });
 
-    it('特殊文字を含むキーワードが安全な形式に変換される', () => {
-      downloadMarkdownFile('# Test', 'キーワード/with*special&chars!', true, 'docbase')
+    it("特殊文字を含むキーワードが安全な形式に変換される", () => {
+      downloadMarkdownFile(
+        "# Test",
+        "キーワード/with*special&chars!",
+        true,
+        "docbase"
+      );
 
-      const anchorElement = (document.createElement as Mock).mock.results[0].value
-      expect(anchorElement.download).toMatch(/docbase_\d{4}-\d{2}-\d{2}_キーワード_with_special_chars__articles\.md/)
-    })
+      const anchorElement = (document.createElement as Mock).mock.results[0]
+        .value;
+      expect(anchorElement.download).toMatch(
+        /docbase_\d{4}-\d{2}-\d{2}_キーワード_with_special_chars__articles\.md/
+      );
+    });
 
-    it('空のキーワードがデフォルト値に置き換えられる', () => {
-      downloadMarkdownFile('# Test', '', true, 'docbase')
+    it("空のキーワードがデフォルト値に置き換えられる", () => {
+      downloadMarkdownFile("# Test", "", true, "docbase");
 
-      const anchorElement = (document.createElement as Mock).mock.results[0].value
-      expect(anchorElement.download).toMatch(/docbase_\d{4}-\d{2}-\d{2}_search_articles\.md/)
-    })
+      const anchorElement = (document.createElement as Mock).mock.results[0]
+        .value;
+      expect(anchorElement.download).toMatch(
+        /docbase_\d{4}-\d{2}-\d{2}_search_articles\.md/
+      );
+    });
 
-    it('空白のみのキーワードがデフォルト値に置き換えられる', () => {
-      downloadMarkdownFile('# Test', '   ', true, 'docbase')
+    it("空白のみのキーワードがデフォルト値に置き換えられる", () => {
+      downloadMarkdownFile("# Test", "   ", true, "docbase");
 
-      const anchorElement = (document.createElement as Mock).mock.results[0].value
-      expect(anchorElement.download).toMatch(/docbase_\d{4}-\d{2}-\d{2}_search_articles\.md/)
-    })
+      const anchorElement = (document.createElement as Mock).mock.results[0]
+        .value;
+      expect(anchorElement.download).toMatch(
+        /docbase_\d{4}-\d{2}-\d{2}_search_articles\.md/
+      );
+    });
 
-    it('日本語文字が正しく保持される', () => {
-      downloadMarkdownFile('# Test', '日本語キーワード', true, 'slack')
+    it("日本語文字が正しく保持される", () => {
+      downloadMarkdownFile("# Test", "日本語キーワード", true, "slack");
 
-      const anchorElement = (document.createElement as Mock).mock.results[0].value
-      expect(anchorElement.download).toMatch(/slack_\d{4}-\d{2}-\d{2}_日本語キーワード_threads\.md/)
-    })
-  })
+      const anchorElement = (document.createElement as Mock).mock.results[0]
+        .value;
+      expect(anchorElement.download).toMatch(
+        /slack_\d{4}-\d{2}-\d{2}_日本語キーワード_threads\.md/
+      );
+    });
+  });
 
-  describe('エラーケース', () => {
-    it('投稿が存在しない場合はエラーを返す', () => {
+  describe("エラーケース", () => {
+    it("投稿が存在しない場合はエラーを返す", () => {
       const result = downloadMarkdownFile(
-        '# Test Content',
-        'keyword',
+        "# Test Content",
+        "keyword",
         false, // postsExist = false
-        'docbase',
-      )
+        "docbase"
+      );
 
-      expect(result.success).toBe(false)
-      expect(result.message).toBe('ダウンロードするコンテンツがありません。')
-
-      // DOM操作が実行されないことを確認
-      expect(mockClick).not.toHaveBeenCalled()
-      expect(mockAppendChild).not.toHaveBeenCalled()
-    })
-
-    it('Markdownコンテンツが空の場合はエラーを返す', () => {
-      const result = downloadMarkdownFile(
-        '', // 空のコンテンツ
-        'keyword',
-        true,
-        'docbase',
-      )
-
-      expect(result.success).toBe(false)
-      expect(result.message).toBe('ダウンロードするコンテンツがありません。')
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("ダウンロードするコンテンツがありません。");
 
       // DOM操作が実行されないことを確認
-      expect(mockClick).not.toHaveBeenCalled()
-    })
+      expect(mockClick).not.toHaveBeenCalled();
+      expect(mockAppendChild).not.toHaveBeenCalled();
+    });
 
-    it('Markdownコンテンツが空白のみの場合はエラーを返す', () => {
+    it("Markdownコンテンツが空の場合はエラーを返す", () => {
       const result = downloadMarkdownFile(
-        '   \n\t  ', // 空白のみのコンテンツ
-        'keyword',
+        "", // 空のコンテンツ
+        "keyword",
         true,
-        'docbase',
-      )
+        "docbase"
+      );
 
-      expect(result.success).toBe(false)
-      expect(result.message).toBe('ダウンロードするコンテンツがありません。')
-    })
-  })
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("ダウンロードするコンテンツがありません。");
 
-  describe('属性設定', () => {
-    it('アンカー要素の属性が正しく設定される', () => {
-      downloadMarkdownFile('# Test Content', 'test-keyword', true, 'docbase')
+      // DOM操作が実行されないことを確認
+      expect(mockClick).not.toHaveBeenCalled();
+    });
 
-      const anchorElement = (document.createElement as Mock).mock.results[0].value
-      expect(anchorElement.href).toBe('blob:mock-url')
-      expect(anchorElement.download).toMatch(/^docbase_\d{4}-\d{2}-\d{2}_test_keyword_articles\.md$/)
-    })
+    it("Markdownコンテンツが空白のみの場合はエラーを返す", () => {
+      const result = downloadMarkdownFile(
+        "   \n\t  ", // 空白のみのコンテンツ
+        "keyword",
+        true,
+        "docbase"
+      );
 
-    it('Blobが正しいMIMEタイプで作成される', () => {
-      downloadMarkdownFile('# Test', 'keyword', true, 'docbase')
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("ダウンロードするコンテンツがありません。");
+    });
+  });
 
-      expect(global.Blob).toHaveBeenCalledWith(['# Test'], { type: 'text/markdown;charset=utf-8' })
-    })
-  })
+  describe("属性設定", () => {
+    it("アンカー要素の属性が正しく設定される", () => {
+      downloadMarkdownFile("# Test Content", "test-keyword", true, "docbase");
 
-  describe('コンテンツタイプ', () => {
-    it('docbaseソースの場合、ファイル名にarticlesが含まれる', () => {
-      downloadMarkdownFile('# Test', 'keyword', true, 'docbase')
+      const anchorElement = (document.createElement as Mock).mock.results[0]
+        .value;
+      expect(anchorElement.href).toBe("blob:mock-url");
+      expect(anchorElement.download).toMatch(
+        /^docbase_\d{4}-\d{2}-\d{2}_test_keyword_articles\.md$/
+      );
+    });
 
-      const anchorElement = (document.createElement as Mock).mock.results[0].value
-      expect(anchorElement.download).toContain('_articles.md')
-    })
+    it("Blobが正しいMIMEタイプで作成される", () => {
+      downloadMarkdownFile("# Test", "keyword", true, "docbase");
 
-    it('slackソースの場合、ファイル名にthreadsが含まれる', () => {
-      downloadMarkdownFile('# Test', 'keyword', true, 'slack')
+      expect(global.Blob).toHaveBeenCalledWith(["# Test"], {
+        type: "text/markdown;charset=utf-8",
+      });
+    });
+  });
 
-      const anchorElement = (document.createElement as Mock).mock.results[0].value
-      expect(anchorElement.download).toContain('_threads.md')
-    })
-  })
-})
+  describe("コンテンツタイプ", () => {
+    it("docbaseソースの場合、ファイル名にarticlesが含まれる", () => {
+      downloadMarkdownFile("# Test", "keyword", true, "docbase");
+
+      const anchorElement = (document.createElement as Mock).mock.results[0]
+        .value;
+      expect(anchorElement.download).toContain("_articles.md");
+    });
+
+    it("slackソースの場合、ファイル名にthreadsが含まれる", () => {
+      downloadMarkdownFile("# Test", "keyword", true, "slack");
+
+      const anchorElement = (document.createElement as Mock).mock.results[0]
+        .value;
+      expect(anchorElement.download).toContain("_threads.md");
+    });
+  });
+});

--- a/src/__tests__/utils/markdownGenerator.test.ts
+++ b/src/__tests__/utils/markdownGenerator.test.ts
@@ -19,7 +19,6 @@ describe("markdownGenerator", () => {
         profile_image_url: "https://example.com/user1.jpg",
       },
       tags: [{ name: "API" }, { name: "テスト" }],
-      groups: [{ id: 1, name: "開発チーム" }],
       scope: "everyone",
     },
     {
@@ -34,7 +33,6 @@ describe("markdownGenerator", () => {
         profile_image_url: "https://example.com/user2.jpg",
       },
       tags: [{ name: "ドキュメント" }],
-      groups: [],
       scope: "group",
     },
     {
@@ -49,10 +47,6 @@ describe("markdownGenerator", () => {
         profile_image_url: "https://example.com/user3.jpg",
       },
       tags: [],
-      groups: [
-        { id: 2, name: "デザインチーム" },
-        { id: 3, name: "プロダクトチーム" },
-      ],
       scope: "private",
     },
   ];
@@ -133,8 +127,7 @@ describe("markdownGenerator", () => {
             profile_image_url: "https://example.com/user1.jpg",
           },
           tags: [],
-          groups: [],
-          scope: "everyone",
+              scope: "everyone",
         },
         {
           id: 2,
@@ -148,8 +141,7 @@ describe("markdownGenerator", () => {
             profile_image_url: "https://example.com/user2.jpg",
           },
           tags: [],
-          groups: [],
-          scope: "everyone",
+              scope: "everyone",
         },
       ];
 
@@ -186,7 +178,6 @@ describe("markdownGenerator", () => {
       expect(result).toContain("**Author**: テストユーザー1");
       expect(result).toContain("**ID**: 1");
       expect(result).toContain("**Tags**: API, テスト");
-      expect(result).toContain("**Groups**: 開発チーム");
       expect(result).toContain(
         "**URL**: [View Original](https://example.docbase.io/posts/1)"
       );
@@ -259,8 +250,7 @@ describe("markdownGenerator", () => {
             profile_image_url: "https://example.com/user.jpg",
           },
           tags: [],
-          groups: [],
-          scope: "everyone",
+              scope: "everyone",
         },
       ];
 
@@ -283,8 +273,7 @@ describe("markdownGenerator", () => {
             profile_image_url: "https://example.com/user.jpg",
           },
           tags: [],
-          groups: [],
-          scope: "everyone",
+              scope: "everyone",
         },
       ];
 
@@ -340,7 +329,6 @@ describe("markdownGenerator", () => {
       expect(result).toContain("**Author**: テストユーザー1");
       expect(result).toContain("**ID**: 1");
       expect(result).toContain("**Tags**: API, テスト");
-      expect(result).toContain("**Groups**: 開発チーム");
       expect(result).toContain(
         "**URL**: [View Original](https://example.docbase.io/posts/1)"
       );
@@ -414,8 +402,7 @@ describe("markdownGenerator", () => {
         expect(result).toContain("**作成日**: 2023/01/01");
         expect(result).toContain("**作成者**: テストユーザー1");
         expect(result).toContain("**タグ**: API, テスト");
-        expect(result).toContain("**グループ**: 開発チーム");
-
+  
         // 詳細な日時表示がないことを確認
         expect(result).not.toContain("2023年1月1日日曜日");
         expect(result).not.toContain("**ID**:");
@@ -435,8 +422,7 @@ describe("markdownGenerator", () => {
             profile_image_url: "https://example.com/user.jpg",
           },
           tags: [],
-          groups: [],
-          scope: "everyone",
+              scope: "everyone",
         };
 
         const result = generateDocbaseMarkdownForPreview([longBodyPost]);
@@ -467,26 +453,6 @@ describe("markdownGenerator", () => {
         expect(result).toContain("**作成者**:");
       });
 
-      it("グループがない記事ではグループ行が表示されない", () => {
-        const noGroupPost = {
-          ...mockPosts[1],
-          groups: [],
-        };
-
-        const result = generateDocbaseMarkdownForPreview([noGroupPost]);
-
-        expect(result).not.toContain("**グループ**:");
-        expect(result).toContain("**作成日**:");
-        expect(result).toContain("**作成者**:");
-      });
-
-      it("複数のタグとグループが正しく表示される", () => {
-        const result = generateDocbaseMarkdownForPreview([mockPosts[2]]);
-
-        expect(result).toContain(
-          "**グループ**: デザインチーム, プロダクトチーム"
-        );
-      });
     });
 
     describe("日付フォーマット", () => {

--- a/src/__tests__/utils/markdownGenerator.test.ts
+++ b/src/__tests__/utils/markdownGenerator.test.ts
@@ -127,7 +127,7 @@ describe("markdownGenerator", () => {
             profile_image_url: "https://example.com/user1.jpg",
           },
           tags: [],
-              scope: "everyone",
+          scope: "everyone",
         },
         {
           id: 2,
@@ -141,7 +141,7 @@ describe("markdownGenerator", () => {
             profile_image_url: "https://example.com/user2.jpg",
           },
           tags: [],
-              scope: "everyone",
+          scope: "everyone",
         },
       ];
 
@@ -250,7 +250,7 @@ describe("markdownGenerator", () => {
             profile_image_url: "https://example.com/user.jpg",
           },
           tags: [],
-              scope: "everyone",
+          scope: "everyone",
         },
       ];
 
@@ -273,7 +273,7 @@ describe("markdownGenerator", () => {
             profile_image_url: "https://example.com/user.jpg",
           },
           tags: [],
-              scope: "everyone",
+          scope: "everyone",
         },
       ];
 
@@ -402,7 +402,7 @@ describe("markdownGenerator", () => {
         expect(result).toContain("**作成日**: 2023/01/01");
         expect(result).toContain("**作成者**: テストユーザー1");
         expect(result).toContain("**タグ**: API, テスト");
-  
+
         // 詳細な日時表示がないことを確認
         expect(result).not.toContain("2023年1月1日日曜日");
         expect(result).not.toContain("**ID**:");
@@ -422,7 +422,7 @@ describe("markdownGenerator", () => {
             profile_image_url: "https://example.com/user.jpg",
           },
           tags: [],
-              scope: "everyone",
+          scope: "everyone",
         };
 
         const result = generateDocbaseMarkdownForPreview([longBodyPost]);
@@ -452,7 +452,6 @@ describe("markdownGenerator", () => {
         expect(result).toContain("**作成日**:");
         expect(result).toContain("**作成者**:");
       });
-
     });
 
     describe("日付フォーマット", () => {

--- a/src/__tests__/utils/markdownGenerator.test.ts
+++ b/src/__tests__/utils/markdownGenerator.test.ts
@@ -1,490 +1,548 @@
-import { describe, expect, it } from 'vitest'
-import type { DocbasePostListItem } from '../../features/docbase/types/docbase'
+import { describe, expect, it } from "vitest";
+import type { DocbasePostListItem } from "../../features/docbase/types/docbase";
 import {
   generateDocbaseMarkdown,
   generateDocbaseMarkdownForPreview,
-} from '../../features/docbase/utils/docbaseMarkdownGenerator'
+} from "../../features/docbase/utils/docbaseMarkdownGenerator";
 
-describe('markdownGenerator', () => {
+describe("markdownGenerator", () => {
   const mockPosts: DocbasePostListItem[] = [
     {
       id: 1,
-      title: 'テスト記事1',
-      body: 'これはテスト記事1の内容です。',
-      created_at: '2023-01-01T10:00:00Z',
-      url: 'https://example.docbase.io/posts/1',
-      user: { id: 100, name: 'テストユーザー1', profile_image_url: 'https://example.com/user1.jpg' },
-      tags: [{ name: 'API' }, { name: 'テスト' }],
-      groups: [{ id: 1, name: '開発チーム' }],
-      scope: 'everyone',
+      title: "テスト記事1",
+      body: "これはテスト記事1の内容です。",
+      created_at: "2023-01-01T10:00:00Z",
+      url: "https://example.docbase.io/posts/1",
+      user: {
+        id: 100,
+        name: "テストユーザー1",
+        profile_image_url: "https://example.com/user1.jpg",
+      },
+      tags: [{ name: "API" }, { name: "テスト" }],
+      groups: [{ id: 1, name: "開発チーム" }],
+      scope: "everyone",
     },
     {
       id: 2,
-      title: 'テスト記事2',
-      body: 'これはテスト記事2の内容です。\n複数行の内容を含みます。',
-      created_at: '2023-01-02T15:30:00Z',
-      url: 'https://example.docbase.io/posts/2',
-      user: { id: 101, name: 'テストユーザー2', profile_image_url: 'https://example.com/user2.jpg' },
-      tags: [{ name: 'ドキュメント' }],
+      title: "テスト記事2",
+      body: "これはテスト記事2の内容です。\n複数行の内容を含みます。",
+      created_at: "2023-01-02T15:30:00Z",
+      url: "https://example.docbase.io/posts/2",
+      user: {
+        id: 101,
+        name: "テストユーザー2",
+        profile_image_url: "https://example.com/user2.jpg",
+      },
+      tags: [{ name: "ドキュメント" }],
       groups: [],
-      scope: 'group',
+      scope: "group",
     },
     {
       id: 3,
-      title: 'マークダウン記事',
-      body: '# マークダウンタイトル\n\n**太字**のテキストと*斜体*のテキスト。',
-      created_at: '2023-01-03T09:15:00Z',
-      url: 'https://example.docbase.io/posts/3',
-      user: { id: 102, name: 'テストユーザー3', profile_image_url: 'https://example.com/user3.jpg' },
+      title: "マークダウン記事",
+      body: "# マークダウンタイトル\n\n**太字**のテキストと*斜体*のテキスト。",
+      created_at: "2023-01-03T09:15:00Z",
+      url: "https://example.docbase.io/posts/3",
+      user: {
+        id: 102,
+        name: "テストユーザー3",
+        profile_image_url: "https://example.com/user3.jpg",
+      },
       tags: [],
       groups: [
-        { id: 2, name: 'デザインチーム' },
-        { id: 3, name: 'プロダクトチーム' },
+        { id: 2, name: "デザインチーム" },
+        { id: 3, name: "プロダクトチーム" },
       ],
-      scope: 'private',
+      scope: "private",
     },
-  ]
+  ];
 
-  describe('基本機能', () => {
-    it('空の配列の場合は空文字列を返す', () => {
-      const result = generateDocbaseMarkdown([])
-      expect(result).toBe('')
-    })
+  describe("基本機能", () => {
+    it("空の配列の場合は空文字列を返す", () => {
+      const result = generateDocbaseMarkdown([]);
+      expect(result).toBe("");
+    });
 
-    it('nullまたはundefinedの場合は空文字列を返す', () => {
-      expect(generateDocbaseMarkdown(null as unknown as DocbasePostListItem[])).toBe('')
-      expect(generateDocbaseMarkdown(undefined as unknown as DocbasePostListItem[])).toBe('')
-    })
+    it("nullまたはundefinedの場合は空文字列を返す", () => {
+      expect(
+        generateDocbaseMarkdown(null as unknown as DocbasePostListItem[])
+      ).toBe("");
+      expect(
+        generateDocbaseMarkdown(undefined as unknown as DocbasePostListItem[])
+      ).toBe("");
+    });
 
-    it('記事リストから正しいMarkdownを生成する', () => {
-      const result = generateDocbaseMarkdown(mockPosts, 'テストキーワード')
+    it("記事リストから正しいMarkdownを生成する", () => {
+      const result = generateDocbaseMarkdown(mockPosts, "テストキーワード");
 
       // YAML Front Matterの確認
-      expect(result).toContain('---')
-      expect(result).toContain('source: "docbase"')
-      expect(result).toContain('total_articles: 3')
-      expect(result).toContain('search_keyword: "テストキーワード"')
-      expect(result).toContain('date_range: "2023-01-01 - 2023-01-03"')
-      expect(result).toContain('generated_at:')
+      expect(result).toContain("---");
+      expect(result).toContain('source: "docbase"');
+      expect(result).toContain("total_articles: 3");
+      expect(result).toContain('search_keyword: "テストキーワード"');
+      expect(result).toContain('date_range: "2023-01-01 - 2023-01-03"');
+      expect(result).toContain("generated_at:");
 
       // メインタイトルの確認
-      expect(result).toContain('# Docbase Articles Collection')
+      expect(result).toContain("# Docbase Articles Collection");
 
       // 概要セクションの確認
-      expect(result).toContain('## Collection Overview')
-      expect(result).toContain('- **Total Articles**: 3')
-      expect(result).toContain('- **Search Keyword**: "テストキーワード"')
-      expect(result).toContain('- **Source**: Docbase Knowledge Base')
+      expect(result).toContain("## Collection Overview");
+      expect(result).toContain("- **Total Articles**: 3");
+      expect(result).toContain('- **Search Keyword**: "テストキーワード"');
+      expect(result).toContain("- **Source**: Docbase Knowledge Base");
 
       // 目次の確認
-      expect(result).toContain('## Articles Index')
-      expect(result).toContain('1. [テスト記事1](#article-1)')
-      expect(result).toContain('2. [テスト記事2](#article-2)')
-      expect(result).toContain('3. [マークダウン記事](#article-3)')
+      expect(result).toContain("## Articles Index");
+      expect(result).toContain("1. [テスト記事1](#article-1)");
+      expect(result).toContain("2. [テスト記事2](#article-2)");
+      expect(result).toContain("3. [マークダウン記事](#article-3)");
 
       // 記事内容の確認
-      expect(result).toContain('## Articles Content')
-      expect(result).toContain('### Article 1: テスト記事1')
-      expect(result).toContain('### Article 2: テスト記事2')
-      expect(result).toContain('### Article 3: マークダウン記事')
-    })
+      expect(result).toContain("## Articles Content");
+      expect(result).toContain("### Article 1: テスト記事1");
+      expect(result).toContain("### Article 2: テスト記事2");
+      expect(result).toContain("### Article 3: マークダウン記事");
+    });
 
-    it('検索キーワードなしでもMarkdownを生成する', () => {
-      const result = generateDocbaseMarkdown(mockPosts)
+    it("検索キーワードなしでもMarkdownを生成する", () => {
+      const result = generateDocbaseMarkdown(mockPosts);
 
       // 検索キーワードが含まれないことを確認
-      expect(result).not.toContain('search_keyword:')
-      expect(result).not.toContain('- **Search Keyword**:')
+      expect(result).not.toContain("search_keyword:");
+      expect(result).not.toContain("- **Search Keyword**:");
 
       // その他の基本要素は含まれることを確認
-      expect(result).toContain('# Docbase Articles Collection')
-      expect(result).toContain('total_articles: 3')
-    })
-  })
+      expect(result).toContain("# Docbase Articles Collection");
+      expect(result).toContain("total_articles: 3");
+    });
+  });
 
-  describe('日付処理', () => {
-    it('同じ日付の記事のみの場合、date_rangeが単一日付になる', () => {
+  describe("日付処理", () => {
+    it("同じ日付の記事のみの場合、date_rangeが単一日付になる", () => {
       const sameDayPosts = [
         {
           id: 1,
-          title: '記事1',
-          body: '内容1',
-          created_at: '2023-01-01T10:00:00Z',
-          url: 'https://example.com/1',
-          user: { id: 100, name: 'テストユーザー1', profile_image_url: 'https://example.com/user1.jpg' },
+          title: "記事1",
+          body: "内容1",
+          created_at: "2023-01-01T10:00:00Z",
+          url: "https://example.com/1",
+          user: {
+            id: 100,
+            name: "テストユーザー1",
+            profile_image_url: "https://example.com/user1.jpg",
+          },
           tags: [],
           groups: [],
-          scope: 'everyone',
+          scope: "everyone",
         },
         {
           id: 2,
-          title: '記事2',
-          body: '内容2',
-          created_at: '2023-01-01T15:00:00Z',
-          url: 'https://example.com/2',
-          user: { id: 101, name: 'テストユーザー2', profile_image_url: 'https://example.com/user2.jpg' },
+          title: "記事2",
+          body: "内容2",
+          created_at: "2023-01-01T15:00:00Z",
+          url: "https://example.com/2",
+          user: {
+            id: 101,
+            name: "テストユーザー2",
+            profile_image_url: "https://example.com/user2.jpg",
+          },
           tags: [],
           groups: [],
-          scope: 'everyone',
+          scope: "everyone",
         },
-      ]
+      ];
 
-      const result = generateDocbaseMarkdown(sameDayPosts)
+      const result = generateDocbaseMarkdown(sameDayPosts);
 
-      expect(result).toContain('date_range: "2023-01-01 - 2023-01-01"')
+      expect(result).toContain('date_range: "2023-01-01 - 2023-01-01"');
       // Collection Overviewでの日付表示は単一日付になる
-      expect(result).toMatch(/- \*\*Date Range\*\*: 2023\/1\/1/)
-    })
+      expect(result).toMatch(/- \*\*Date Range\*\*: 2023\/1\/1/);
+    });
 
-    it('複数の日付範囲を正しく処理する', () => {
-      const result = generateDocbaseMarkdown(mockPosts)
+    it("複数の日付範囲を正しく処理する", () => {
+      const result = generateDocbaseMarkdown(mockPosts);
 
-      expect(result).toContain('date_range: "2023-01-01 - 2023-01-03"')
-      expect(result).toMatch(/- \*\*Date Range\*\*: 2023\/1\/1 - 2023\/1\/3/)
-    })
+      expect(result).toContain('date_range: "2023-01-01 - 2023-01-03"');
+      expect(result).toMatch(/- \*\*Date Range\*\*: 2023\/1\/1 - 2023\/1\/3/);
+    });
 
-    it('記事の日付が正しく日本語形式でフォーマットされる', () => {
-      const result = generateDocbaseMarkdown([mockPosts[0]])
+    it("記事の日付が正しく日本語形式でフォーマットされる", () => {
+      const result = generateDocbaseMarkdown([mockPosts[0]]);
 
       // 目次での日付表示
-      expect(result).toMatch(/1\. \[テスト記事1\]\(#article-1\) - 2023\/1\/1/)
+      expect(result).toMatch(/1\. \[テスト記事1\]\(#article-1\) - 2023\/1\/1/);
 
       // 記事詳細での日付表示（時刻ありの長い形式）
-      expect(result).toMatch(/\*\*Created\*\*: 2023年1月1日日曜日 19:00/)
-    })
-  })
+      expect(result).toMatch(/\*\*Created\*\*: 2023年1月1日日曜日 19:00/);
+    });
+  });
 
-  describe('記事内容の処理', () => {
-    it('記事のメタデータが改行区切りで生成される', () => {
-      const result = generateDocbaseMarkdown([mockPosts[0]])
+  describe("記事内容の処理", () => {
+    it("記事のメタデータが改行区切りで生成される", () => {
+      const result = generateDocbaseMarkdown([mockPosts[0]]);
 
-      expect(result).toContain('**Created**: 2023年1月1日日曜日 19:00')
-      expect(result).toContain('**Author**: テストユーザー1')
-      expect(result).toContain('**ID**: 1')
-      expect(result).toContain('**Tags**: API, テスト')
-      expect(result).toContain('**Groups**: 開発チーム')
-      expect(result).toContain('**URL**: [View Original](https://example.docbase.io/posts/1)')
-    })
+      expect(result).toContain("**Created**: 2023年1月1日日曜日 19:00");
+      expect(result).toContain("**Author**: テストユーザー1");
+      expect(result).toContain("**ID**: 1");
+      expect(result).toContain("**Tags**: API, テスト");
+      expect(result).toContain("**Groups**: 開発チーム");
+      expect(result).toContain(
+        "**URL**: [View Original](https://example.docbase.io/posts/1)"
+      );
+    });
 
-    it('記事の本文がHTMLコメントで囲まれて含まれる', () => {
-      const result = generateDocbaseMarkdown([mockPosts[0]])
+    it("記事の本文がHTMLコメントで囲まれて含まれる", () => {
+      const result = generateDocbaseMarkdown([mockPosts[0]]);
 
-      expect(result).toContain('<!-- DOCBASE_CONTENT_START -->')
-      expect(result).toContain('これはテスト記事1の内容です。')
-      expect(result).toContain('<!-- DOCBASE_CONTENT_END -->')
-    })
+      expect(result).toContain("<!-- DOCBASE_CONTENT_START -->");
+      expect(result).toContain("これはテスト記事1の内容です。");
+      expect(result).toContain("<!-- DOCBASE_CONTENT_END -->");
+    });
 
-    it('複数行の記事内容を正しく処理する', () => {
-      const result = generateDocbaseMarkdown([mockPosts[1]])
+    it("複数行の記事内容を正しく処理する", () => {
+      const result = generateDocbaseMarkdown([mockPosts[1]]);
 
-      expect(result).toContain('これはテスト記事2の内容です。')
-      expect(result).toContain('複数行の内容を含みます。')
-    })
+      expect(result).toContain("これはテスト記事2の内容です。");
+      expect(result).toContain("複数行の内容を含みます。");
+    });
 
-    it('マークダウン形式の記事内容がHTMLコメント内で保持される', () => {
-      const result = generateDocbaseMarkdown([mockPosts[2]])
+    it("マークダウン形式の記事内容がHTMLコメント内で保持される", () => {
+      const result = generateDocbaseMarkdown([mockPosts[2]]);
 
-      expect(result).toContain('<!-- DOCBASE_CONTENT_START -->')
-      expect(result).toContain('# マークダウンタイトル')
-      expect(result).toContain('**太字**のテキストと*斜体*のテキスト。')
-      expect(result).toContain('<!-- DOCBASE_CONTENT_END -->')
-    })
+      expect(result).toContain("<!-- DOCBASE_CONTENT_START -->");
+      expect(result).toContain("# マークダウンタイトル");
+      expect(result).toContain("**太字**のテキストと*斜体*のテキスト。");
+      expect(result).toContain("<!-- DOCBASE_CONTENT_END -->");
+    });
 
-    it('記事間の区切り線が正しく挿入される', () => {
-      const result = generateDocbaseMarkdown(mockPosts)
+    it("記事間の区切り線が正しく挿入される", () => {
+      const result = generateDocbaseMarkdown(mockPosts);
 
       // 記事間に区切り線があることを確認
-      const articleSections = result.split('---\n\n')
-      expect(articleSections.length).toBeGreaterThan(3) // 最初のYAML Front Matter + 目次の区切り + 記事間の区切り
-    })
-  })
+      const articleSections = result.split("---\n\n");
+      expect(articleSections.length).toBeGreaterThan(3); // 最初のYAML Front Matter + 目次の区切り + 記事間の区切り
+    });
+  });
 
-  describe('ドキュメント情報', () => {
-    it('記事の基本情報が改行区切りで含まれる', () => {
-      const result = generateDocbaseMarkdown([mockPosts[0]])
+  describe("ドキュメント情報", () => {
+    it("記事の基本情報が改行区切りで含まれる", () => {
+      const result = generateDocbaseMarkdown([mockPosts[0]]);
 
-      expect(result).toContain('**Author**: テストユーザー1')
-      expect(result).toContain('**ID**: 1')
-      expect(result).toContain('**URL**: [View Original](https://example.docbase.io/posts/1)')
-    })
+      expect(result).toContain("**Author**: テストユーザー1");
+      expect(result).toContain("**ID**: 1");
+      expect(result).toContain(
+        "**URL**: [View Original](https://example.docbase.io/posts/1)"
+      );
+    });
 
-    it('記事タイトルが見出しに組み込まれる', () => {
-      const result = generateDocbaseMarkdown([mockPosts[0]])
+    it("記事タイトルが見出しに組み込まれる", () => {
+      const result = generateDocbaseMarkdown([mockPosts[0]]);
 
       // 記事のタイトルがH3見出しに組み込まれることを確認
-      expect(result).toContain('### Article 1: テスト記事1')
-    })
-  })
+      expect(result).toContain("### Article 1: テスト記事1");
+    });
+  });
 
-  describe('特殊文字・エッジケース', () => {
-    it('特殊文字を含むタイトルを正しく処理する', () => {
+  describe("特殊文字・エッジケース", () => {
+    it("特殊文字を含むタイトルを正しく処理する", () => {
       const specialPosts = [
         {
           id: 1,
           title: 'タイトル "引用符" & 特殊文字',
-          body: '内容',
-          created_at: '2023-01-01T10:00:00Z',
-          url: 'https://example.com/1',
-          user: { id: 100, name: 'テストユーザー', profile_image_url: 'https://example.com/user.jpg' },
+          body: "内容",
+          created_at: "2023-01-01T10:00:00Z",
+          url: "https://example.com/1",
+          user: {
+            id: 100,
+            name: "テストユーザー",
+            profile_image_url: "https://example.com/user.jpg",
+          },
           tags: [],
           groups: [],
-          scope: 'everyone',
+          scope: "everyone",
         },
-      ]
+      ];
 
-      const result = generateDocbaseMarkdown(specialPosts)
+      const result = generateDocbaseMarkdown(specialPosts);
 
-      expect(result).toContain('### Article 1: タイトル "引用符" & 特殊文字')
-    })
+      expect(result).toContain('### Article 1: タイトル "引用符" & 特殊文字');
+    });
 
-    it('空の本文を持つ記事を処理する', () => {
+    it("空の本文を持つ記事を処理する", () => {
       const emptyBodyPosts = [
         {
           id: 1,
-          title: '空の記事',
-          body: '',
-          created_at: '2023-01-01T10:00:00Z',
-          url: 'https://example.com/1',
-          user: { id: 100, name: 'テストユーザー', profile_image_url: 'https://example.com/user.jpg' },
+          title: "空の記事",
+          body: "",
+          created_at: "2023-01-01T10:00:00Z",
+          url: "https://example.com/1",
+          user: {
+            id: 100,
+            name: "テストユーザー",
+            profile_image_url: "https://example.com/user.jpg",
+          },
           tags: [],
           groups: [],
-          scope: 'everyone',
+          scope: "everyone",
         },
-      ]
+      ];
 
-      const result = generateDocbaseMarkdown(emptyBodyPosts)
+      const result = generateDocbaseMarkdown(emptyBodyPosts);
 
-      expect(result).toContain('### Article 1: 空の記事')
-      expect(result).toContain('<!-- DOCBASE_CONTENT_START -->')
-      expect(result).toContain('<!-- DOCBASE_CONTENT_END -->')
+      expect(result).toContain("### Article 1: 空の記事");
+      expect(result).toContain("<!-- DOCBASE_CONTENT_START -->");
+      expect(result).toContain("<!-- DOCBASE_CONTENT_END -->");
       // 空の本文でもエラーにならないことを確認
-      expect(result).toBeTruthy()
-    })
+      expect(result).toBeTruthy();
+    });
 
-    it('単一記事でも正しくMarkdownを生成する', () => {
-      const result = generateDocbaseMarkdown([mockPosts[0]])
+    it("単一記事でも正しくMarkdownを生成する", () => {
+      const result = generateDocbaseMarkdown([mockPosts[0]]);
 
-      expect(result).toContain('total_articles: 1')
-      expect(result).toContain('- **Total Articles**: 1')
-      expect(result).toContain('### Article 1: テスト記事1')
-      expect(result).not.toContain('### Article 2:')
-    })
-  })
+      expect(result).toContain("total_articles: 1");
+      expect(result).toContain("- **Total Articles**: 1");
+      expect(result).toContain("### Article 1: テスト記事1");
+      expect(result).not.toContain("### Article 2:");
+    });
+  });
 
-  describe('LLM最適化要素', () => {
-    it('LLM理解しやすい構造化された見出しを含む', () => {
-      const result = generateDocbaseMarkdown(mockPosts)
+  describe("LLM最適化要素", () => {
+    it("LLM理解しやすい構造化された見出しを含む", () => {
+      const result = generateDocbaseMarkdown(mockPosts);
 
       // 構造化された見出しレベル
-      expect(result).toContain('# Docbase Articles Collection')
-      expect(result).toContain('## Collection Overview')
-      expect(result).toContain('## Articles Index')
-      expect(result).toContain('## Articles Content')
-      expect(result).toContain('### Article 1: テスト記事1')
-      expect(result).toContain('<!-- DOCBASE_CONTENT_START -->')
-      expect(result).toContain('<!-- DOCBASE_CONTENT_END -->')
-    })
+      expect(result).toContain("# Docbase Articles Collection");
+      expect(result).toContain("## Collection Overview");
+      expect(result).toContain("## Articles Index");
+      expect(result).toContain("## Articles Content");
+      expect(result).toContain("### Article 1: テスト記事1");
+      expect(result).toContain("<!-- DOCBASE_CONTENT_START -->");
+      expect(result).toContain("<!-- DOCBASE_CONTENT_END -->");
+    });
 
-    it('YAML Front Matterにメタデータが適切に含まれる', () => {
-      const result = generateDocbaseMarkdown(mockPosts, 'AI学習')
+    it("YAML Front Matterにメタデータが適切に含まれる", () => {
+      const result = generateDocbaseMarkdown(mockPosts, "AI学習");
 
-      expect(result).toMatch(/^---\n/)
-      expect(result).toContain('source: "docbase"')
-      expect(result).toContain('total_articles: 3')
-      expect(result).toContain('search_keyword: "AI学習"')
-      expect(result).toContain('generated_at:')
-      expect(result).toMatch(/---\n\n/)
-    })
+      expect(result).toMatch(/^---\n/);
+      expect(result).toContain('source: "docbase"');
+      expect(result).toContain("total_articles: 3");
+      expect(result).toContain('search_keyword: "AI学習"');
+      expect(result).toContain("generated_at:");
+      expect(result).toMatch(/---\n\n/);
+    });
 
-    it('記事ごとのメタデータが改行区切りで提供される', () => {
-      const result = generateDocbaseMarkdown([mockPosts[0]])
+    it("記事ごとのメタデータが改行区切りで提供される", () => {
+      const result = generateDocbaseMarkdown([mockPosts[0]]);
 
       // 改行区切りのメタデータ
-      expect(result).toContain('**Created**: 2023年1月1日日曜日 19:00')
-      expect(result).toContain('**Author**: テストユーザー1')
-      expect(result).toContain('**ID**: 1')
-      expect(result).toContain('**Tags**: API, テスト')
-      expect(result).toContain('**Groups**: 開発チーム')
-      expect(result).toContain('**URL**: [View Original](https://example.docbase.io/posts/1)')
-    })
-  })
+      expect(result).toContain("**Created**: 2023年1月1日日曜日 19:00");
+      expect(result).toContain("**Author**: テストユーザー1");
+      expect(result).toContain("**ID**: 1");
+      expect(result).toContain("**Tags**: API, テスト");
+      expect(result).toContain("**Groups**: 開発チーム");
+      expect(result).toContain(
+        "**URL**: [View Original](https://example.docbase.io/posts/1)"
+      );
+    });
+  });
 
-  describe('generateDocbaseMarkdownForPreview', () => {
-    describe('基本機能', () => {
-      it('空の配列の場合は空文字列を返す', () => {
-        const result = generateDocbaseMarkdownForPreview([])
-        expect(result).toBe('')
-      })
+  describe("generateDocbaseMarkdownForPreview", () => {
+    describe("基本機能", () => {
+      it("空の配列の場合は空文字列を返す", () => {
+        const result = generateDocbaseMarkdownForPreview([]);
+        expect(result).toBe("");
+      });
 
-      it('nullまたはundefinedの場合は空文字列を返す', () => {
-        expect(generateDocbaseMarkdownForPreview(null as unknown as DocbasePostListItem[])).toBe('')
-        expect(generateDocbaseMarkdownForPreview(undefined as unknown as DocbasePostListItem[])).toBe('')
-      })
+      it("nullまたはundefinedの場合は空文字列を返す", () => {
+        expect(
+          generateDocbaseMarkdownForPreview(
+            null as unknown as DocbasePostListItem[]
+          )
+        ).toBe("");
+        expect(
+          generateDocbaseMarkdownForPreview(
+            undefined as unknown as DocbasePostListItem[]
+          )
+        ).toBe("");
+      });
 
-      it('プレビュー用の簡潔なMarkdownを生成する', () => {
-        const result = generateDocbaseMarkdownForPreview(mockPosts, 'テストキーワード')
+      it("プレビュー用の簡潔なMarkdownを生成する", () => {
+        const result = generateDocbaseMarkdownForPreview(
+          mockPosts,
+          "テストキーワード"
+        );
 
-        // プレビュー用ヘッダーの確認
-        expect(result).toContain('**検索キーワード**: テストキーワード')
-        expect(result).toContain('**記事数**: 3件')
+        // 記事タイトルがH2見出しで表示されることを確認
+        expect(result).toContain("## テスト記事1");
+        expect(result).toContain("## テスト記事2");
+        expect(result).toContain("## マークダウン記事");
 
         // YAML Front Matterが含まれないことを確認
-        expect(result).not.toContain('---\nsource:')
-        expect(result).not.toContain('generated_at:')
+        expect(result).not.toContain("---\nsource:");
+        expect(result).not.toContain("generated_at:");
 
         // HTMLコメントが含まれないことを確認
-        expect(result).not.toContain('<!-- DOCBASE_CONTENT_START -->')
-        expect(result).not.toContain('<!-- DOCBASE_CONTENT_END -->')
+        expect(result).not.toContain("<!-- DOCBASE_CONTENT_START -->");
+        expect(result).not.toContain("<!-- DOCBASE_CONTENT_END -->");
 
         // Articles Indexが含まれないことを確認
-        expect(result).not.toContain('## Articles Index')
-      })
+        expect(result).not.toContain("## Articles Index");
+      });
 
-      it('検索キーワードなしでもプレビューを生成する', () => {
-        const result = generateDocbaseMarkdownForPreview(mockPosts)
+      it("検索キーワードなしでもプレビューを生成する", () => {
+        const result = generateDocbaseMarkdownForPreview(mockPosts);
 
-        expect(result).toContain('**記事数**: 3件')
-        expect(result).not.toContain('**検索キーワード**:')
-      })
-    })
+        // 記事が表示されることを確認
+        expect(result).toContain("## テスト記事1");
+        expect(result).not.toContain("**検索キーワード**:");
+        expect(result).not.toContain("**記事数**:");
+      });
+    });
 
-    describe('記事の表示形式', () => {
-      it('記事タイトルがH2見出しで表示される', () => {
-        const result = generateDocbaseMarkdownForPreview([mockPosts[0]])
+    describe("記事の表示形式", () => {
+      it("記事タイトルがH2見出しで表示される", () => {
+        const result = generateDocbaseMarkdownForPreview([mockPosts[0]]);
 
-        expect(result).toContain('## テスト記事1')
-        expect(result).not.toContain('### Article 1:')
-      })
+        expect(result).toContain("## テスト記事1");
+        expect(result).not.toContain("### Article 1:");
+      });
 
-      it('メタデータが記事タイトル直下に簡潔に表示される', () => {
-        const result = generateDocbaseMarkdownForPreview([mockPosts[0]])
+      it("メタデータが記事タイトル直下に簡潔に表示される", () => {
+        const result = generateDocbaseMarkdownForPreview([mockPosts[0]]);
 
-        expect(result).toContain('**作成日**: 2023/01/01')
-        expect(result).toContain('**作成者**: テストユーザー1')
-        expect(result).toContain('**タグ**: API, テスト')
-        expect(result).toContain('**グループ**: 開発チーム')
+        expect(result).toContain("**作成日**: 2023/01/01");
+        expect(result).toContain("**作成者**: テストユーザー1");
+        expect(result).toContain("**タグ**: API, テスト");
+        expect(result).toContain("**グループ**: 開発チーム");
 
         // 詳細な日時表示がないことを確認
-        expect(result).not.toContain('2023年1月1日日曜日')
-        expect(result).not.toContain('**ID**:')
-        expect(result).not.toContain('**URL**:')
-      })
+        expect(result).not.toContain("2023年1月1日日曜日");
+        expect(result).not.toContain("**ID**:");
+        expect(result).not.toContain("**URL**:");
+      });
 
-      it('記事内容が150文字で切り詰められる', () => {
+      it("記事内容が150文字で切り詰められる", () => {
         const longBodyPost = {
           id: 1,
-          title: '長い記事',
-          body: 'あ'.repeat(200), // 200文字の長い内容
-          created_at: '2023-01-01T10:00:00Z',
-          url: 'https://example.com/1',
-          user: { id: 100, name: 'テストユーザー', profile_image_url: 'https://example.com/user.jpg' },
+          title: "長い記事",
+          body: "あ".repeat(200), // 200文字の長い内容
+          created_at: "2023-01-01T10:00:00Z",
+          url: "https://example.com/1",
+          user: {
+            id: 100,
+            name: "テストユーザー",
+            profile_image_url: "https://example.com/user.jpg",
+          },
           tags: [],
           groups: [],
-          scope: 'everyone',
-        }
+          scope: "everyone",
+        };
 
-        const result = generateDocbaseMarkdownForPreview([longBodyPost])
+        const result = generateDocbaseMarkdownForPreview([longBodyPost]);
 
-        expect(result).toContain(`${'あ'.repeat(150)}...`)
-        expect(result).not.toContain('あ'.repeat(200))
-      })
+        expect(result).toContain(`${"あ".repeat(150)}...`);
+        expect(result).not.toContain("あ".repeat(200));
+      });
 
-      it('短い記事内容はそのまま表示される', () => {
-        const result = generateDocbaseMarkdownForPreview([mockPosts[0]])
+      it("短い記事内容はそのまま表示される", () => {
+        const result = generateDocbaseMarkdownForPreview([mockPosts[0]]);
 
-        expect(result).toContain('これはテスト記事1の内容です。')
-        expect(result).not.toContain('...')
-      })
-    })
+        expect(result).toContain("これはテスト記事1の内容です。");
+        expect(result).not.toContain("...");
+      });
+    });
 
-    describe('条件分岐の処理', () => {
-      it('タグがない記事ではタグ行が表示されない', () => {
+    describe("条件分岐の処理", () => {
+      it("タグがない記事ではタグ行が表示されない", () => {
         const noTagPost = {
           ...mockPosts[2],
           tags: [],
-        }
+        };
 
-        const result = generateDocbaseMarkdownForPreview([noTagPost])
+        const result = generateDocbaseMarkdownForPreview([noTagPost]);
 
-        expect(result).not.toContain('**タグ**:')
-        expect(result).toContain('**作成日**:')
-        expect(result).toContain('**作成者**:')
-      })
+        expect(result).not.toContain("**タグ**:");
+        expect(result).toContain("**作成日**:");
+        expect(result).toContain("**作成者**:");
+      });
 
-      it('グループがない記事ではグループ行が表示されない', () => {
+      it("グループがない記事ではグループ行が表示されない", () => {
         const noGroupPost = {
           ...mockPosts[1],
           groups: [],
-        }
+        };
 
-        const result = generateDocbaseMarkdownForPreview([noGroupPost])
+        const result = generateDocbaseMarkdownForPreview([noGroupPost]);
 
-        expect(result).not.toContain('**グループ**:')
-        expect(result).toContain('**作成日**:')
-        expect(result).toContain('**作成者**:')
-      })
+        expect(result).not.toContain("**グループ**:");
+        expect(result).toContain("**作成日**:");
+        expect(result).toContain("**作成者**:");
+      });
 
-      it('複数のタグとグループが正しく表示される', () => {
-        const result = generateDocbaseMarkdownForPreview([mockPosts[2]])
+      it("複数のタグとグループが正しく表示される", () => {
+        const result = generateDocbaseMarkdownForPreview([mockPosts[2]]);
 
-        expect(result).toContain('**グループ**: デザインチーム, プロダクトチーム')
-      })
-    })
+        expect(result).toContain(
+          "**グループ**: デザインチーム, プロダクトチーム"
+        );
+      });
+    });
 
-    describe('日付フォーマット', () => {
-      it('日付が簡潔な形式で表示される', () => {
-        const result = generateDocbaseMarkdownForPreview([mockPosts[0]])
+    describe("日付フォーマット", () => {
+      it("日付が簡潔な形式で表示される", () => {
+        const result = generateDocbaseMarkdownForPreview([mockPosts[0]]);
 
-        expect(result).toContain('**作成日**: 2023/01/01')
-        expect(result).not.toContain('2023年1月1日')
-        expect(result).not.toContain('19:00')
-      })
-    })
+        expect(result).toContain("**作成日**: 2023/01/01");
+        expect(result).not.toContain("2023年1月1日");
+        expect(result).not.toContain("19:00");
+      });
+    });
 
-    describe('記事間の区切り', () => {
-      it('複数記事が水平線で区切られる', () => {
-        const result = generateDocbaseMarkdownForPreview(mockPosts)
+    describe("記事間の区切り", () => {
+      it("複数記事が水平線で区切られる", () => {
+        const result = generateDocbaseMarkdownForPreview(mockPosts);
 
         // 水平線で区切られることを確認
-        const sections = result.split('---\n\n')
-        expect(sections.length).toBeGreaterThan(2)
-      })
+        const sections = result.split("---\n\n");
+        expect(sections.length).toBeGreaterThan(2);
+      });
 
-      it('単一記事では区切り線が余分に含まれない', () => {
-        const result = generateDocbaseMarkdownForPreview([mockPosts[0]])
+      it("単一記事では区切り線が余分に含まれない", () => {
+        const result = generateDocbaseMarkdownForPreview([mockPosts[0]]);
 
-        // ヘッダー部分の区切り線のみ
-        const sections = result.split('---\n\n')
-        expect(sections.length).toBe(2)
-      })
-    })
+        // 単一記事では区切り線がないことを確認
+        const sections = result.split("---\n\n");
+        expect(sections.length).toBe(1);
+      });
+    });
 
-    describe('プレビューとダウンロード用の違い', () => {
-      it('プレビュー版にはYAML Front Matterが含まれない', () => {
-        const preview = generateDocbaseMarkdownForPreview(mockPosts)
-        const download = generateDocbaseMarkdown(mockPosts)
+    describe("プレビューとダウンロード用の違い", () => {
+      it("プレビュー版にはYAML Front Matterが含まれない", () => {
+        const preview = generateDocbaseMarkdownForPreview(mockPosts);
+        const download = generateDocbaseMarkdown(mockPosts);
 
-        expect(download).toContain('---\nsource:')
-        expect(preview).not.toContain('---\nsource:')
-      })
+        expect(download).toContain("---\nsource:");
+        expect(preview).not.toContain("---\nsource:");
+      });
 
-      it('プレビュー版にはHTMLコメントが含まれない', () => {
-        const preview = generateDocbaseMarkdownForPreview(mockPosts)
-        const download = generateDocbaseMarkdown(mockPosts)
+      it("プレビュー版にはHTMLコメントが含まれない", () => {
+        const preview = generateDocbaseMarkdownForPreview(mockPosts);
+        const download = generateDocbaseMarkdown(mockPosts);
 
-        expect(download).toContain('<!-- DOCBASE_CONTENT_START -->')
-        expect(preview).not.toContain('<!-- DOCBASE_CONTENT_START -->')
-      })
+        expect(download).toContain("<!-- DOCBASE_CONTENT_START -->");
+        expect(preview).not.toContain("<!-- DOCBASE_CONTENT_START -->");
+      });
 
-      it('プレビュー版には詳細メタデータが含まれない', () => {
-        const preview = generateDocbaseMarkdownForPreview(mockPosts)
-        const download = generateDocbaseMarkdown(mockPosts)
+      it("プレビュー版には詳細メタデータが含まれない", () => {
+        const preview = generateDocbaseMarkdownForPreview(mockPosts);
+        const download = generateDocbaseMarkdown(mockPosts);
 
-        expect(download).toContain('**ID**:')
-        expect(download).toContain('**URL**:')
-        expect(preview).not.toContain('**ID**:')
-        expect(preview).not.toContain('**URL**:')
-      })
-    })
-  })
-})
+        expect(download).toContain("**ID**:");
+        expect(download).toContain("**URL**:");
+        expect(preview).not.toContain("**ID**:");
+        expect(preview).not.toContain("**URL**:");
+      });
+    });
+  });
+});

--- a/src/__tests__/utils/markdownGenerator.test.ts
+++ b/src/__tests__/utils/markdownGenerator.test.ts
@@ -503,8 +503,8 @@ describe("markdownGenerator", () => {
       it("複数記事が水平線で区切られる", () => {
         const result = generateDocbaseMarkdownForPreview(mockPosts);
 
-        // 水平線で区切られることを確認
-        const sections = result.split("---\n\n");
+        // 水平線で区切られることを確認（プレビューでは改行が3つ）
+        const sections = result.split("---\n\n\n");
         expect(sections.length).toBeGreaterThan(2);
       });
 
@@ -512,7 +512,7 @@ describe("markdownGenerator", () => {
         const result = generateDocbaseMarkdownForPreview([mockPosts[0]]);
 
         // 単一記事では区切り線がないことを確認
-        const sections = result.split("---\n\n");
+        const sections = result.split("---\n\n\n");
         expect(sections.length).toBe(1);
       });
     });

--- a/src/__tests__/utils/markdownGenerator.test.ts
+++ b/src/__tests__/utils/markdownGenerator.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import type { DocbasePostListItem } from '../../features/docbase/types/docbase'
-import { generateDocbaseMarkdown, generateDocbaseMarkdownForPreview } from '../../features/docbase/utils/docbaseMarkdownGenerator'
+import {
+  generateDocbaseMarkdown,
+  generateDocbaseMarkdownForPreview,
+} from '../../features/docbase/utils/docbaseMarkdownGenerator'
 
 describe('markdownGenerator', () => {
   const mockPosts: DocbasePostListItem[] = [
@@ -322,7 +325,6 @@ describe('markdownGenerator', () => {
         const result = generateDocbaseMarkdownForPreview(mockPosts, 'テストキーワード')
 
         // プレビュー用ヘッダーの確認
-        expect(result).toContain('# Docbase 記事プレビュー')
         expect(result).toContain('**検索キーワード**: テストキーワード')
         expect(result).toContain('**記事数**: 3件')
 
@@ -341,7 +343,6 @@ describe('markdownGenerator', () => {
       it('検索キーワードなしでもプレビューを生成する', () => {
         const result = generateDocbaseMarkdownForPreview(mockPosts)
 
-        expect(result).toContain('# Docbase 記事プレビュー')
         expect(result).toContain('**記事数**: 3件')
         expect(result).not.toContain('**検索キーワード**:')
       })
@@ -384,7 +385,7 @@ describe('markdownGenerator', () => {
 
         const result = generateDocbaseMarkdownForPreview([longBodyPost])
 
-        expect(result).toContain('あ'.repeat(150) + '...')
+        expect(result).toContain(`${'あ'.repeat(150)}...`)
         expect(result).not.toContain('あ'.repeat(200))
       })
 

--- a/src/__tests__/utils/slackMarkdownGenerator.test.ts
+++ b/src/__tests__/utils/slackMarkdownGenerator.test.ts
@@ -1,416 +1,510 @@
-import type { SlackMessage, SlackThread } from '@/features/slack/types/slack'
-import { generateSlackThreadsMarkdown } from '@/features/slack/utils/slackMarkdownGenerator'
-import { describe, expect, it, vi } from 'vitest'
+import type { SlackMessage, SlackThread } from "@/features/slack/types/slack";
+import { generateSlackThreadsMarkdown } from "@/features/slack/utils/slackMarkdownGenerator";
+import { describe, expect, it, vi } from "vitest";
 
 // slackdownモジュールのモック
-vi.mock('../../lib/slackdown', () => ({
+vi.mock("../../lib/slackdown", () => ({
   convertToSlackThreadMarkdown: vi.fn((thread, userMap, permalinkMap) => {
-    const parentUser = userMap[thread.parent.user] || thread.parent.user
-    const parentDate = new Date(Number.parseFloat(thread.parent.ts) * 1000).toLocaleString('ja-JP')
+    const parentUser = userMap[thread.parent.user] || thread.parent.user;
+    const parentDate = new Date(
+      Number.parseFloat(thread.parent.ts) * 1000
+    ).toLocaleString("ja-JP");
 
-    let markdown = `#### 👤 ${parentUser} - ${parentDate}\n`
-    markdown += `> ${thread.parent.text}\n\n`
+    let markdown = `#### 👤 ${parentUser} - ${parentDate}\n`;
+    markdown += `> ${thread.parent.text}\n\n`;
 
     if (thread.replies && thread.replies.length > 0) {
       thread.replies.forEach((reply: SlackMessage, index: number) => {
-        const replyUser = userMap[reply.user] || reply.user
-        const replyDate = new Date(Number.parseFloat(reply.ts) * 1000).toLocaleString('ja-JP')
-        markdown += `##### 💬 返信 ${index + 1}: ${replyUser} - ${replyDate}\n`
-        markdown += `${reply.text}\n\n`
-      })
+        const replyUser = userMap[reply.user] || reply.user;
+        const replyDate = new Date(
+          Number.parseFloat(reply.ts) * 1000
+        ).toLocaleString("ja-JP");
+        markdown += `##### 💬 返信 ${index + 1}: ${replyUser} - ${replyDate}\n`;
+        markdown += `${reply.text}\n\n`;
+      });
     }
 
-    return markdown
+    return markdown;
   }),
-}))
+}));
 
-describe('slackMarkdownGenerator', () => {
+describe("slackMarkdownGenerator", () => {
   const mockThreads: SlackThread[] = [
     {
-      channel: 'C123456',
+      channel: "C123456",
       parent: {
-        ts: '1672531200.123456', // 2023-01-01 00:00:00 UTC
-        user: 'U123456',
-        text: '新年の目標について話し合いましょう',
-        channel: { id: 'C123456' },
+        ts: "1672531200.123456", // 2023-01-01 00:00:00 UTC
+        user: "U123456",
+        text: "新年の目標について話し合いましょう",
+        channel: { id: "C123456" },
       },
       replies: [
         {
-          ts: '1672531260.123457', // 2023-01-01 00:01:00 UTC
-          user: 'U789012',
-          text: '私は英語の勉強を頑張りたいです',
-          thread_ts: '1672531200.123456',
-          channel: { id: 'C123456' },
+          ts: "1672531260.123457", // 2023-01-01 00:01:00 UTC
+          user: "U789012",
+          text: "私は英語の勉強を頑張りたいです",
+          thread_ts: "1672531200.123456",
+          channel: { id: "C123456" },
         },
         {
-          ts: '1672531320.123458', // 2023-01-01 00:02:00 UTC
-          user: 'U345678',
-          text: 'プログラミングスキルを向上させたいと思います',
-          thread_ts: '1672531200.123456',
-          channel: { id: 'C123456' },
+          ts: "1672531320.123458", // 2023-01-01 00:02:00 UTC
+          user: "U345678",
+          text: "プログラミングスキルを向上させたいと思います",
+          thread_ts: "1672531200.123456",
+          channel: { id: "C123456" },
         },
       ],
     },
     {
-      channel: 'C123456',
+      channel: "C123456",
       parent: {
-        ts: '1672617600.123459', // 2023-01-02 00:00:00 UTC
-        user: 'U654321',
-        text: '昨日の会議の議事録です',
-        channel: { id: 'C123456' },
+        ts: "1672617600.123459", // 2023-01-02 00:00:00 UTC
+        user: "U654321",
+        text: "昨日の会議の議事録です",
+        channel: { id: "C123456" },
       },
       replies: [
         {
-          ts: '1672617660.123460', // 2023-01-02 00:01:00 UTC
-          user: 'U111213',
-          text: 'ありがとうございます！',
-          thread_ts: '1672617600.123459',
-          channel: { id: 'C123456' },
+          ts: "1672617660.123460", // 2023-01-02 00:01:00 UTC
+          user: "U111213",
+          text: "ありがとうございます！",
+          thread_ts: "1672617600.123459",
+          channel: { id: "C123456" },
         },
       ],
     },
-  ]
+  ];
 
   const mockUserMap: Record<string, string> = {
-    U123456: '田中太郎',
-    U789012: '佐藤花子',
-    U345678: '山田次郎',
-    U654321: '鈴木一郎',
-    U111213: '高橋美咲',
-  }
+    U123456: "田中太郎",
+    U789012: "佐藤花子",
+    U345678: "山田次郎",
+    U654321: "鈴木一郎",
+    U111213: "高橋美咲",
+  };
 
   const mockPermalinkMap: Record<string, string> = {
-    '1672531200.123456': 'https://slack.com/archives/C123456/p1672531200123456',
-    '1672531260.123457': 'https://slack.com/archives/C123456/p1672531260123457',
-    '1672531320.123458': 'https://slack.com/archives/C123456/p1672531320123458',
-    '1672617600.123459': 'https://slack.com/archives/C123456/p1672617600123459',
-    '1672617660.123460': 'https://slack.com/archives/C123456/p1672617660123460',
-  }
+    "1672531200.123456": "https://slack.com/archives/C123456/p1672531200123456",
+    "1672531260.123457": "https://slack.com/archives/C123456/p1672531260123457",
+    "1672531320.123458": "https://slack.com/archives/C123456/p1672531320123458",
+    "1672617600.123459": "https://slack.com/archives/C123456/p1672617600123459",
+    "1672617660.123460": "https://slack.com/archives/C123456/p1672617660123460",
+  };
 
-  describe('基本機能', () => {
-    it('空の配列の場合は空文字列を返す', () => {
-      const result = generateSlackThreadsMarkdown([], mockUserMap, mockPermalinkMap)
-      expect(result).toBe('')
-    })
+  describe("基本機能", () => {
+    it("空の配列の場合は空文字列を返す", () => {
+      const result = generateSlackThreadsMarkdown(
+        [],
+        mockUserMap,
+        mockPermalinkMap
+      );
+      expect(result).toBe("");
+    });
 
-    it('nullまたはundefinedの場合は空文字列を返す', () => {
+    it("nullまたはundefinedの場合は空文字列を返す", () => {
       // @ts-expect-error nullまたはundefinedのテスト用
-      const resultNull = generateSlackThreadsMarkdown(null, mockUserMap, mockPermalinkMap)
+      const resultNull = generateSlackThreadsMarkdown(
+        null,
+        mockUserMap,
+        mockPermalinkMap
+      );
       // @ts-expect-error nullまたはundefinedのテスト用
-      const resultUndefined = generateSlackThreadsMarkdown(undefined, mockUserMap, mockPermalinkMap)
-      expect(resultNull).toBe('')
-      expect(resultUndefined).toBe('')
-    })
+      const resultUndefined = generateSlackThreadsMarkdown(
+        undefined,
+        mockUserMap,
+        mockPermalinkMap
+      );
+      expect(resultNull).toBe("");
+      expect(resultUndefined).toBe("");
+    });
 
-    it('スレッドリストから正しいMarkdownを生成する', () => {
-      const result = generateSlackThreadsMarkdown(mockThreads, mockUserMap, mockPermalinkMap, 'テストキーワード')
+    it("スレッドリストから正しいMarkdownを生成する", () => {
+      const result = generateSlackThreadsMarkdown(
+        mockThreads,
+        mockUserMap,
+        mockPermalinkMap,
+        "テストキーワード"
+      );
 
       // YAML Front Matterが含まれていることを確認
-      expect(result).toContain('---')
-      expect(result).toContain('source: "slack"')
-      expect(result).toContain('total_threads: 2')
-      expect(result).toContain('search_keyword: "テストキーワード"')
+      expect(result).toContain("---");
+      expect(result).toContain('source: "slack"');
+      expect(result).toContain("total_threads: 2");
+      expect(result).toContain('search_keyword: "テストキーワード"');
 
       // メインタイトルが含まれていることを確認
-      expect(result).toContain('# Slack Threads Collection')
+      expect(result).toContain("# Slack Threads Collection");
 
       // スレッド目次が含まれていることを確認
-      expect(result).toContain('## Threads Index')
+      expect(result).toContain("## Threads Index");
 
       // 各スレッドのコンテンツが含まれていることを確認
-      expect(result).toContain('## Threads Content')
-    })
+      expect(result).toContain("## Threads Content");
+    });
 
-    it('検索キーワードなしでもMarkdownを生成する', () => {
-      const result = generateSlackThreadsMarkdown(mockThreads, mockUserMap, mockPermalinkMap)
+    it("検索キーワードなしでもMarkdownを生成する", () => {
+      const result = generateSlackThreadsMarkdown(
+        mockThreads,
+        mockUserMap,
+        mockPermalinkMap
+      );
 
       // search_keywordが含まれていないことを確認
-      expect(result).not.toContain('search_keyword:')
-      expect(result).toContain('total_threads: 2')
-    })
-  })
+      expect(result).not.toContain("search_keyword:");
+      expect(result).toContain("total_threads: 2");
+    });
+  });
 
-  describe('メタデータ処理', () => {
-    it('複数チャンネルを正しく処理する', () => {
-      const multiChannelThreads = [{ ...mockThreads[0] }, { ...mockThreads[1], channel: 'C789012' }]
+  describe("メタデータ処理", () => {
+    it("複数チャンネルを正しく処理する", () => {
+      const multiChannelThreads = [
+        { ...mockThreads[0] },
+        { ...mockThreads[1], channel: "C789012" },
+      ];
 
-      const result = generateSlackThreadsMarkdown(multiChannelThreads, mockUserMap, mockPermalinkMap)
+      const result = generateSlackThreadsMarkdown(
+        multiChannelThreads,
+        mockUserMap,
+        mockPermalinkMap
+      );
 
-      expect(result).toContain('channels: ["C123456", "C789012"]')
-    })
+      expect(result).toContain('channels: ["C123456", "C789012"]');
+    });
 
-    it('参加者が10人以下の場合は全員リストアップする', () => {
-      const result = generateSlackThreadsMarkdown(mockThreads, mockUserMap, mockPermalinkMap)
+    it("参加者が10人以下の場合は全員リストアップする", () => {
+      const result = generateSlackThreadsMarkdown(
+        mockThreads,
+        mockUserMap,
+        mockPermalinkMap
+      );
 
       // 参加者が全員リストされていることを確認
-      expect(result).toContain('"田中太郎"')
-      expect(result).toContain('"佐藤花子"')
-      expect(result).toContain('"山田次郎"')
-      expect(result).toContain('"鈴木一郎"')
-      expect(result).toContain('"高橋美咲"')
-    })
+      expect(result).toContain('"田中太郎"');
+      expect(result).toContain('"佐藤花子"');
+      expect(result).toContain('"山田次郎"');
+      expect(result).toContain('"鈴木一郎"');
+      expect(result).toContain('"高橋美咲"');
+    });
 
-    it('参加者が10人を超える場合は制限する', () => {
-      const largeUserMap: Record<string, string> = {}
+    it("参加者が10人を超える場合は制限する", () => {
+      const largeUserMap: Record<string, string> = {};
       for (let i = 1; i <= 15; i++) {
-        largeUserMap[`U${i.toString().padStart(6, '0')}`] = `ユーザー${i}`
+        largeUserMap[`U${i.toString().padStart(6, "0")}`] = `ユーザー${i}`;
       }
 
       // 15人の異なるユーザーIDを確実に含むようにスレッドデータを構築
       const largeThreads: SlackThread[] = [
         {
-          channel: 'C123456',
+          channel: "C123456",
           parent: {
-            ts: '1672531200.123456',
-            user: 'U000001',
-            text: '新年の目標について話し合いましょう',
-            channel: { id: 'C123456' },
+            ts: "1672531200.123456",
+            user: "U000001",
+            text: "新年の目標について話し合いましょう",
+            channel: { id: "C123456" },
           },
           replies: [
             {
-              ts: '1672531260.123457',
-              user: 'U000002',
-              text: '私は英語の勉強を頑張りたいです',
-              thread_ts: '1672531200.123456',
-              channel: { id: 'C123456' },
+              ts: "1672531260.123457",
+              user: "U000002",
+              text: "私は英語の勉強を頑張りたいです",
+              thread_ts: "1672531200.123456",
+              channel: { id: "C123456" },
             },
             {
-              ts: '1672531320.123458',
-              user: 'U000003',
-              text: 'プログラミングスキルを向上させたいと思います',
-              thread_ts: '1672531200.123456',
-              channel: { id: 'C123456' },
+              ts: "1672531320.123458",
+              user: "U000003",
+              text: "プログラミングスキルを向上させたいと思います",
+              thread_ts: "1672531200.123456",
+              channel: { id: "C123456" },
             },
             {
-              ts: '1672531380.123459',
-              user: 'U000004',
-              text: '運動も大切ですね',
-              thread_ts: '1672531200.123456',
-              channel: { id: 'C123456' },
+              ts: "1672531380.123459",
+              user: "U000004",
+              text: "運動も大切ですね",
+              thread_ts: "1672531200.123456",
+              channel: { id: "C123456" },
             },
           ],
         },
         {
-          channel: 'C123456',
+          channel: "C123456",
           parent: {
-            ts: '1672617600.123460',
-            user: 'U000005',
-            text: '昨日の会議の議事録です',
-            channel: { id: 'C123456' },
+            ts: "1672617600.123460",
+            user: "U000005",
+            text: "昨日の会議の議事録です",
+            channel: { id: "C123456" },
           },
           replies: [
             {
-              ts: '1672617660.123461',
-              user: 'U000006',
-              text: 'ありがとうございます！',
-              thread_ts: '1672617600.123460',
-              channel: { id: 'C123456' },
+              ts: "1672617660.123461",
+              user: "U000006",
+              text: "ありがとうございます！",
+              thread_ts: "1672617600.123460",
+              channel: { id: "C123456" },
             },
             {
-              ts: '1672617720.123462',
-              user: 'U000007',
-              text: '参考になりました',
-              thread_ts: '1672617600.123460',
-              channel: { id: 'C123456' },
+              ts: "1672617720.123462",
+              user: "U000007",
+              text: "参考になりました",
+              thread_ts: "1672617600.123460",
+              channel: { id: "C123456" },
             },
             {
-              ts: '1672617780.123463',
-              user: 'U000008',
-              text: '次回もお願いします',
-              thread_ts: '1672617600.123460',
-              channel: { id: 'C123456' },
+              ts: "1672617780.123463",
+              user: "U000008",
+              text: "次回もお願いします",
+              thread_ts: "1672617600.123460",
+              channel: { id: "C123456" },
             },
             {
-              ts: '1672617840.123464',
-              user: 'U000009',
-              text: '了解しました',
-              thread_ts: '1672617600.123460',
-              channel: { id: 'C123456' },
+              ts: "1672617840.123464",
+              user: "U000009",
+              text: "了解しました",
+              thread_ts: "1672617600.123460",
+              channel: { id: "C123456" },
             },
             {
-              ts: '1672617900.123465',
-              user: 'U000010',
-              text: 'よろしくお願いします',
-              thread_ts: '1672617600.123460',
-              channel: { id: 'C123456' },
+              ts: "1672617900.123465",
+              user: "U000010",
+              text: "よろしくお願いします",
+              thread_ts: "1672617600.123460",
+              channel: { id: "C123456" },
             },
             {
-              ts: '1672617960.123466',
-              user: 'U000011',
-              text: '確認しました',
-              thread_ts: '1672617600.123460',
-              channel: { id: 'C123456' },
+              ts: "1672617960.123466",
+              user: "U000011",
+              text: "確認しました",
+              thread_ts: "1672617600.123460",
+              channel: { id: "C123456" },
             },
             {
-              ts: '1672618020.123467',
-              user: 'U000012',
-              text: '承知いたしました',
-              thread_ts: '1672617600.123460',
-              channel: { id: 'C123456' },
+              ts: "1672618020.123467",
+              user: "U000012",
+              text: "承知いたしました",
+              thread_ts: "1672617600.123460",
+              channel: { id: "C123456" },
             },
           ],
         },
-      ]
+      ];
 
-      const result = generateSlackThreadsMarkdown(largeThreads, largeUserMap, mockPermalinkMap)
+      const result = generateSlackThreadsMarkdown(
+        largeThreads,
+        largeUserMap,
+        mockPermalinkMap
+      );
 
-      expect(result).toContain('total_participants:')
+      expect(result).toContain("total_participants:");
       // 最初の10人のみがリストされることを確認
-      const participantsMatch = result.match(/participants: \[([^\]]+)\]/)
-      expect(participantsMatch).toBeTruthy()
+      const participantsMatch = result.match(/participants: \[([^\]]+)\]/);
+      expect(participantsMatch).toBeTruthy();
       if (participantsMatch) {
-        const participantsList = participantsMatch[1]
-        const participantCount = (participantsList.match(/"/g) || []).length / 2
-        expect(participantCount).toBe(10)
+        const participantsList = participantsMatch[1];
+        const participantCount =
+          (participantsList.match(/"/g) || []).length / 2;
+        expect(participantCount).toBe(10);
       }
-    })
+    });
 
-    it('日付範囲を正しく計算する', () => {
-      const result = generateSlackThreadsMarkdown(mockThreads, mockUserMap, mockPermalinkMap)
+    it("日付範囲を正しく計算する", () => {
+      const result = generateSlackThreadsMarkdown(
+        mockThreads,
+        mockUserMap,
+        mockPermalinkMap
+      );
 
-      expect(result).toContain('date_range: "2023-01-01 - 2023-01-02"')
-    })
+      expect(result).toContain('date_range: "2023-01-01 - 2023-01-02"');
+    });
 
-    it('同じ日付のスレッドのみの場合、日付範囲が単一日付になる', () => {
-      const singleDayThreads = [mockThreads[0]]
-      const result = generateSlackThreadsMarkdown(singleDayThreads, mockUserMap, mockPermalinkMap)
+    it("同じ日付のスレッドのみの場合、日付範囲が単一日付になる", () => {
+      const singleDayThreads = [mockThreads[0]];
+      const result = generateSlackThreadsMarkdown(
+        singleDayThreads,
+        mockUserMap,
+        mockPermalinkMap
+      );
 
-      expect(result).toContain('date_range: "2023-01-01 - 2023-01-01"')
-    })
-  })
+      expect(result).toContain('date_range: "2023-01-01 - 2023-01-01"');
+    });
+  });
 
-  describe('目次生成', () => {
-    it('スレッド目次が正しく生成される', () => {
-      const result = generateSlackThreadsMarkdown(mockThreads, mockUserMap, mockPermalinkMap)
+  describe("目次生成", () => {
+    it("スレッド目次が正しく生成される", () => {
+      const result = generateSlackThreadsMarkdown(
+        mockThreads,
+        mockUserMap,
+        mockPermalinkMap
+      );
 
-      expect(result).toContain('## Threads Index')
-      expect(result).toContain('1. [Thread 1](#thread-1) - 田中太郎 in C123456')
-      expect(result).toContain('2. [Thread 2](#thread-2) - 鈴木一郎 in C123456')
-    })
+      expect(result).toContain("## Threads Index");
+      expect(result).toContain(
+        "1. [Thread 1](#thread-1) - 田中太郎 in C123456"
+      );
+      expect(result).toContain(
+        "2. [Thread 2](#thread-2) - 鈴木一郎 in C123456"
+      );
+    });
 
-    it('長いテキストが省略される', () => {
+    it("長いテキストが省略される", () => {
       const longTextThread: SlackThread = {
-        channel: 'C123456',
+        channel: "C123456",
         parent: {
-          ts: '1672531200.123456',
-          user: 'U123456',
-          text: 'これは非常に長いテキストです。50文字を超える場合は省略されるはずです。テスト用の長い文章を書いています。',
-          channel: { id: 'C123456' },
+          ts: "1672531200.123456",
+          user: "U123456",
+          text: "これは非常に長いテキストです。50文字を超える場合は省略されるはずです。テスト用の長い文章を書いています。",
+          channel: { id: "C123456" },
         },
         replies: [],
-      }
+      };
 
-      const result = generateSlackThreadsMarkdown([longTextThread], mockUserMap, mockPermalinkMap)
+      const result = generateSlackThreadsMarkdown(
+        [longTextThread],
+        mockUserMap,
+        mockPermalinkMap
+      );
 
-      expect(result).toContain('...')
-    })
+      expect(result).toContain("...");
+    });
 
-    it('50文字以下のテキストは省略されない', () => {
+    it("50文字以下のテキストは省略されない", () => {
       const shortTextThread: SlackThread = {
-        channel: 'C123456',
+        channel: "C123456",
         parent: {
-          ts: '1672531200.123456',
-          user: 'U123456',
-          text: '短いテキスト',
-          channel: { id: 'C123456' },
+          ts: "1672531200.123456",
+          user: "U123456",
+          text: "短いテキスト",
+          channel: { id: "C123456" },
         },
         replies: [],
-      }
+      };
 
-      const result = generateSlackThreadsMarkdown([shortTextThread], mockUserMap, mockPermalinkMap)
+      const result = generateSlackThreadsMarkdown(
+        [shortTextThread],
+        mockUserMap,
+        mockPermalinkMap
+      );
 
-      expect(result).not.toContain('...')
-    })
-  })
+      expect(result).not.toContain("...");
+    });
+  });
 
-  describe('スレッド内容生成', () => {
-    it('スレッド内容が正しく生成される', () => {
-      const result = generateSlackThreadsMarkdown(mockThreads, mockUserMap, mockPermalinkMap)
+  describe("スレッド内容生成", () => {
+    it("スレッド内容が正しく生成される", () => {
+      const result = generateSlackThreadsMarkdown(
+        mockThreads,
+        mockUserMap,
+        mockPermalinkMap
+      );
 
       // 両方のスレッドの内容が含まれることを確認（新しい形式に合わせる）
-      expect(result).toContain('**Author**: 田中太郎')
-      expect(result).toContain('新年の目標について話し合いましょう')
-      expect(result).toContain('**Author**: 鈴木一郎')
-      expect(result).toContain('昨日の会議の議事録です')
-    })
+      expect(result).toContain("**Author**: 田中太郎");
+      expect(result).toContain("新年の目標について話し合いましょう");
+      expect(result).toContain("**Author**: 鈴木一郎");
+      expect(result).toContain("昨日の会議の議事録です");
+    });
 
-    it('各スレッドに適切なヘッダーとIDが付けられる', () => {
-      const result = generateSlackThreadsMarkdown(mockThreads, mockUserMap, mockPermalinkMap)
+    it("各スレッドに適切なヘッダーとIDが付けられる", () => {
+      const result = generateSlackThreadsMarkdown(
+        mockThreads,
+        mockUserMap,
+        mockPermalinkMap
+      );
 
-      expect(result).toContain('### Thread 1 {#thread-1}')
-      expect(result).toContain('### Thread 2 {#thread-2}')
-    })
-  })
+      expect(result).toContain("### Thread 1 {#thread-1}");
+      expect(result).toContain("### Thread 2 {#thread-2}");
+    });
+  });
 
-  describe('ユーザーマップ処理', () => {
-    it('ユーザーマップにないユーザーIDをそのまま使用する', () => {
+  describe("ユーザーマップ処理", () => {
+    it("ユーザーマップにないユーザーIDをそのまま使用する", () => {
       const incompleteUserMap = {
-        U123456: '田中太郎',
+        U123456: "田中太郎",
         // U789012は意図的に除外
-      }
+      };
 
-      const result = generateSlackThreadsMarkdown(mockThreads, incompleteUserMap, mockPermalinkMap)
+      const result = generateSlackThreadsMarkdown(
+        mockThreads,
+        incompleteUserMap,
+        mockPermalinkMap
+      );
 
       // ユーザー名がある場合は名前、ない場合はIDが使用される
-      expect(result).toContain('田中太郎')
-      expect(result).toContain('U789012') // ユーザーマップにないのでIDがそのまま使用される
-    })
+      expect(result).toContain("田中太郎");
+      expect(result).toContain("U789012"); // ユーザーマップにないのでIDがそのまま使用される
+    });
 
-    it('空のユーザーマップでも処理できる', () => {
-      const result = generateSlackThreadsMarkdown(mockThreads, {}, mockPermalinkMap)
+    it("空のユーザーマップでも処理できる", () => {
+      const result = generateSlackThreadsMarkdown(
+        mockThreads,
+        {},
+        mockPermalinkMap
+      );
 
       // ユーザーIDがそのまま使用される
-      expect(result).toContain('U123456')
-      expect(result).toContain('U654321')
-    })
-  })
+      expect(result).toContain("U123456");
+      expect(result).toContain("U654321");
+    });
+  });
 
-  describe('YAML Front Matter', () => {
-    it('すべての必要なメタデータが含まれる', () => {
-      const result = generateSlackThreadsMarkdown(mockThreads, mockUserMap, mockPermalinkMap, 'テストキーワード')
+  describe("YAML Front Matter", () => {
+    it("すべての必要なメタデータが含まれる", () => {
+      const result = generateSlackThreadsMarkdown(
+        mockThreads,
+        mockUserMap,
+        mockPermalinkMap,
+        "テストキーワード"
+      );
 
       // YAML Front Matterの開始と終了
-      expect(result.startsWith('---\n')).toBe(true)
-      expect(result).toContain('\n---\n')
+      expect(result.startsWith("---\n")).toBe(true);
+      expect(result).toContain("\n---\n");
 
       // 必須フィールド
-      expect(result).toContain('source: "slack"')
-      expect(result).toContain('total_threads: 2')
-      expect(result).toContain('total_messages: 5') // 親2 + 返信3
-      expect(result).toContain('search_keyword: "テストキーワード"')
-      expect(result).toContain('channels: ["C123456"]')
-      expect(result).toContain('date_range:')
-      expect(result).toContain('generated_at:')
-    })
-  })
+      expect(result).toContain('source: "slack"');
+      expect(result).toContain("total_threads: 2");
+      expect(result).toContain("total_messages: 5"); // 親2 + 返信3
+      expect(result).toContain('search_keyword: "テストキーワード"');
+      expect(result).toContain('channels: ["C123456"]');
+      expect(result).toContain("date_range:");
+      expect(result).toContain("generated_at:");
+    });
+  });
 
-  describe('エッジケース', () => {
-    it('返信のないスレッドを処理する', () => {
+  describe("エッジケース", () => {
+    it("返信のないスレッドを処理する", () => {
       const threadWithoutReplies: SlackThread = {
-        channel: 'C123456',
+        channel: "C123456",
         parent: {
-          ts: '1672531200.123456',
-          user: 'U123456',
-          text: '返信なしのスレッド',
-          channel: { id: 'C123456' },
+          ts: "1672531200.123456",
+          user: "U123456",
+          text: "返信なしのスレッド",
+          channel: { id: "C123456" },
         },
         replies: [],
-      }
+      };
 
-      const result = generateSlackThreadsMarkdown([threadWithoutReplies], mockUserMap, mockPermalinkMap)
+      const result = generateSlackThreadsMarkdown(
+        [threadWithoutReplies],
+        mockUserMap,
+        mockPermalinkMap
+      );
 
-      expect(result).toContain('total_threads: 1')
-      expect(result).toContain('total_messages: 1')
-      expect(result).toContain('返信なしのスレッド')
-    })
+      expect(result).toContain("total_threads: 1");
+      expect(result).toContain("total_messages: 1");
+      expect(result).toContain("返信なしのスレッド");
+    });
 
-    it('単一スレッドでも正しく処理する', () => {
-      const singleThread = [mockThreads[0]]
-      const result = generateSlackThreadsMarkdown(singleThread, mockUserMap, mockPermalinkMap)
+    it("単一スレッドでも正しく処理する", () => {
+      const singleThread = [mockThreads[0]];
+      const result = generateSlackThreadsMarkdown(
+        singleThread,
+        mockUserMap,
+        mockPermalinkMap
+      );
 
-      expect(result).toContain('total_threads: 1')
-      expect(result).toContain('### Thread 1 {#thread-1}')
-      expect(result).not.toContain('### Thread 2')
-    })
-  })
-})
+      expect(result).toContain("total_threads: 1");
+      expect(result).toContain("### Thread 1 {#thread-1}");
+      expect(result).not.toContain("### Thread 2");
+    });
+  });
+});

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -2,18 +2,22 @@
 // すべてのアダプターとHTTPクライアントを一箇所から提供
 
 // 型定義
-export type { HttpClient, MockResponse, RetryConfig } from './types'
+export type { HttpClient, MockResponse, RetryConfig } from "./types";
 
 // HTTPクライアントアダプター
-export { createFetchHttpClient } from './fetchHttpClient'
-export { createMockHttpClient, createSuccessResponse, createErrorResponse } from './mockHttpClient'
+export { createFetchHttpClient } from "./fetchHttpClient";
+export {
+  createMockHttpClient,
+  createSuccessResponse,
+  createErrorResponse,
+} from "./mockHttpClient";
 
 // APIアダプター
 export {
   createDocbaseAdapter,
   type DocbaseAdapter,
   type DocbaseSearchParams,
-} from '../features/docbase/adapters/docbaseAdapter'
+} from "../features/docbase/adapters/docbaseAdapter";
 export {
   createSlackAdapter,
   type SlackAdapter,
@@ -22,18 +26,18 @@ export {
   type SlackPermalinkParams,
   type SlackUserParams,
   type SlackSearchResponse,
-} from '../features/slack/adapters/slackAdapter'
+} from "../features/slack/adapters/slackAdapter";
 
 // 内部使用のためのインポート
-import { createDocbaseAdapter as _createDocbaseAdapter } from '../features/docbase/adapters/docbaseAdapter'
-import { createSlackAdapter as _createSlackAdapter } from '../features/slack/adapters/slackAdapter'
-import { createFetchHttpClient as _createFetchHttpClient } from './fetchHttpClient'
+import { createDocbaseAdapter as _createDocbaseAdapter } from "../features/docbase/adapters/docbaseAdapter";
+import { createSlackAdapter as _createSlackAdapter } from "../features/slack/adapters/slackAdapter";
+import { createFetchHttpClient as _createFetchHttpClient } from "./fetchHttpClient";
 
 // デフォルトインスタンス作成用のヘルパー関数
 export function createDefaultDocbaseAdapter() {
-  return _createDocbaseAdapter(_createFetchHttpClient())
+  return _createDocbaseAdapter(_createFetchHttpClient());
 }
 
 export function createDefaultSlackAdapter() {
-  return _createSlackAdapter(_createFetchHttpClient())
+  return _createSlackAdapter(_createFetchHttpClient());
 }

--- a/src/adapters/mockHttpClient.ts
+++ b/src/adapters/mockHttpClient.ts
@@ -1,9 +1,9 @@
 // テスト用のモックHTTPクライアントアダプター実装
 // 実際のAPIリクエストを行わず、事前に設定されたレスポンスを返す
 
-import { type Result, err, ok } from 'neverthrow'
-import type { ApiError } from '../types/error'
-import type { HttpClient, MockResponse } from './types'
+import { type Result, err, ok } from "neverthrow";
+import type { ApiError } from "../types/error";
+import type { HttpClient, MockResponse } from "./types";
 
 /**
  * テスト用のモックHTTPクライアントアダプターを作成
@@ -11,40 +11,45 @@ import type { HttpClient, MockResponse } from './types'
  * @returns HttpClient インターフェースの実装
  */
 export function createMockHttpClient(responses: MockResponse[]): HttpClient {
-  let requestCount = 0
+  let requestCount = 0;
 
   return {
-    async fetch<T>(url: string, options?: RequestInit): Promise<Result<T, ApiError>> {
-      requestCount++
+    async fetch<T>(
+      url: string,
+      options?: RequestInit
+    ): Promise<Result<T, ApiError>> {
+      requestCount++;
 
       // URLとメソッドでマッチするレスポンスを検索
-      const method = options?.method?.toUpperCase() || 'GET'
+      const method = options?.method?.toUpperCase() || "GET";
       const matchingResponse = responses.find(
-        (response) => response.url === url && (response.method?.toUpperCase() || 'GET') === method,
-      )
+        (response) =>
+          response.url === url &&
+          (response.method?.toUpperCase() || "GET") === method
+      );
 
       // マッチするレスポンスが見つからない場合
       if (!matchingResponse) {
         return err({
-          type: 'notFound',
+          type: "notFound",
           message: `No mock response configured for ${method} ${url}`,
-        })
+        });
       }
 
       // エラーレスポンスの場合
       if (matchingResponse.error) {
-        return err(matchingResponse.error)
+        return err(matchingResponse.error);
       }
 
       // 成功レスポンスの場合
       if (matchingResponse.status >= 200 && matchingResponse.status < 300) {
-        return ok(matchingResponse.data as T)
+        return ok(matchingResponse.data as T);
       }
 
       // HTTPエラーレスポンスの場合
-      return err(mapStatusToApiError(matchingResponse.status))
+      return err(mapStatusToApiError(matchingResponse.status));
     },
-  }
+  };
 }
 
 /**
@@ -53,40 +58,48 @@ export function createMockHttpClient(responses: MockResponse[]): HttpClient {
 function mapStatusToApiError(status: number): ApiError {
   switch (status) {
     case 401:
-      return { type: 'unauthorized', message: 'Mock unauthorized error' }
+      return { type: "unauthorized", message: "Mock unauthorized error" };
     case 403:
-      return { type: 'missing_scope', message: 'Mock forbidden error' }
+      return { type: "missing_scope", message: "Mock forbidden error" };
     case 404:
-      return { type: 'notFound', message: 'Mock not found error' }
+      return { type: "notFound", message: "Mock not found error" };
     case 429:
-      return { type: 'rate_limit', message: 'Mock rate limit error' }
+      return { type: "rate_limit", message: "Mock rate limit error" };
     case 400:
-      return { type: 'validation', message: 'Mock validation error' }
+      return { type: "validation", message: "Mock validation error" };
     default:
-      return { type: 'network', message: `Mock HTTP error: ${status}` }
+      return { type: "network", message: `Mock HTTP error: ${status}` };
   }
 }
 
 /**
  * テスト用のヘルパー関数: 成功レスポンスを簡単に作成
  */
-export function createSuccessResponse(url: string, data: unknown, method = 'GET'): MockResponse {
+export function createSuccessResponse(
+  url: string,
+  data: unknown,
+  method = "GET"
+): MockResponse {
   return {
     url,
     method,
     status: 200,
     data,
-  }
+  };
 }
 
 /**
  * テスト用のヘルパー関数: エラーレスポンスを簡単に作成
  */
-export function createErrorResponse(url: string, error: ApiError, method = 'GET'): MockResponse {
+export function createErrorResponse(
+  url: string,
+  error: ApiError,
+  method = "GET"
+): MockResponse {
   return {
     url,
     method,
     status: 500,
     error,
-  }
+  };
 }

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -1,8 +1,8 @@
 // アダプタパターンによる外部依存抽象化のための型定義
 // HTTPクライアントアダプター・APIアダプターの共通インターフェース
 
-import type { Result } from 'neverthrow'
-import type { ApiError } from '../types/error'
+import type { Result } from "neverthrow";
+import type { ApiError } from "../types/error";
 
 /**
  * HTTPクライアントアダプター
@@ -15,25 +15,25 @@ export interface HttpClient {
    * @param options fetchのオプション
    * @returns Promise<Result<T, ApiError>>
    */
-  fetch<T>(url: string, options?: RequestInit): Promise<Result<T, ApiError>>
+  fetch<T>(url: string, options?: RequestInit): Promise<Result<T, ApiError>>;
 }
 
 /**
  * モックレスポンスの定義（テスト用）
  */
 export interface MockResponse {
-  url: string
-  method?: string
-  status: number
-  data?: unknown
-  error?: ApiError
+  url: string;
+  method?: string;
+  status: number;
+  data?: unknown;
+  error?: ApiError;
 }
 
 /**
  * リトライ設定
  */
 export interface RetryConfig {
-  maxRetries: number
-  initialBackoffMs: number
-  retryableErrors: ApiError['type'][]
+  maxRetries: number;
+  initialBackoffMs: number;
+  retryableErrors: ApiError["type"][];
 }

--- a/src/app/docbase/page.tsx
+++ b/src/app/docbase/page.tsx
@@ -1,10 +1,10 @@
-'use client' // クライアントコンポーネントとしてマーク
+"use client"; // クライアントコンポーネントとしてマーク
 
-import { Toaster } from 'react-hot-toast' // Toasterをインポート
-import Footer from '../../components/Footer'
+import { Toaster } from "react-hot-toast"; // Toasterをインポート
+import Footer from "../../components/Footer";
 // import { SparklesCore } from "../../components/ui/sparkles"; // 架空のUIコンポーネントなのだ -> 一旦コメントアウト
-import Header from '../../components/Header'
-import { DocbaseSearchForm } from '../../features/docbase/components/DocbaseSearchForm' // パスを修正
+import Header from "../../components/Header";
+import { DocbaseSearchForm } from "../../features/docbase/components/DocbaseSearchForm"; // パスを修正
 
 export default function DocbasePage() {
   // コンポーネント名を DocbasePage に変更
@@ -26,17 +26,18 @@ export default function DocbasePage() {
       <Toaster
         position="top-center"
         toastOptions={{
-          className: '!border !border-gray-200 !bg-white !text-gray-700 !shadow-lg !rounded-md',
+          className:
+            "!border !border-gray-200 !bg-white !text-gray-700 !shadow-lg !rounded-md",
           success: {
             iconTheme: {
-              primary: '#3B82F6', // Docbase風ブルー
-              secondary: '#FFFFFF',
+              primary: "#3B82F6", // Docbase風ブルー
+              secondary: "#FFFFFF",
             },
           },
           error: {
             iconTheme: {
-              primary: '#EF4444', // 赤
-              secondary: '#FFFFFF',
+              primary: "#EF4444", // 赤
+              secondary: "#FFFFFF",
             },
           },
         }}
@@ -63,7 +64,11 @@ export default function DocbasePage() {
           <div className="flex flex-col items-center">
             <button
               type="button"
-              onClick={() => document.getElementById('main-tool-section')?.scrollIntoView({ behavior: 'smooth' })}
+              onClick={() =>
+                document
+                  .getElementById("main-tool-section")
+                  ?.scrollIntoView({ behavior: "smooth" })
+              }
               className="px-8 py-3 bg-docbase-primary hover:bg-docbase-primary-dark text-white font-semibold rounded-md shadow-md hover:shadow-lg transform hover:scale-105 transition-all duration-200 ease-in-out text-lg"
             >
               今すぐMarkdownを生成
@@ -77,29 +82,31 @@ export default function DocbasePage() {
         {/* 使い方説明セクション */}
         <section className="w-full mt-12">
           <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-background-light">
-            <h2 className="text-3xl md:text-4xl font-bold mb-20 text-center text-gray-800">利用はかんたん3ステップ</h2>
+            <h2 className="text-3xl md:text-4xl font-bold mb-20 text-center text-gray-800">
+              利用はかんたん3ステップ
+            </h2>
             <div className="grid md:grid-cols-3 gap-x-8 gap-y-10 relative">
               {[
                 {
-                  step: '1',
-                  title: '情報を入力',
+                  step: "1",
+                  title: "情報を入力",
                   description:
-                    'Docbaseドメイン、APIトークン、検索したいキーワードの3点を入力します。ドメインとトークンは保存可能です。',
-                  icon: '⌨️',
+                    "Docbaseドメイン、APIトークン、検索したいキーワードの3点を入力します。ドメインとトークンは保存可能です。",
+                  icon: "⌨️",
                 },
                 {
-                  step: '2',
-                  title: '検索して生成',
+                  step: "2",
+                  title: "検索して生成",
                   description:
-                    '「検索実行」ボタンを押すと、Docbaseから記事を取得し、NotebookLM用Markdownをプレビューします。',
-                  icon: '🔍',
+                    "「検索実行」ボタンを押すと、Docbaseから記事を取得し、NotebookLM用Markdownをプレビューします。",
+                  icon: "🔍",
                 },
                 {
-                  step: '3',
-                  title: 'ダウンロード',
+                  step: "3",
+                  title: "ダウンロード",
                   description:
-                    '生成されたMarkdown内容を確認し、「ダウンロード」ボタンでファイルとして保存。すぐにAIに学習させられます。',
-                  icon: '💾',
+                    "生成されたMarkdown内容を確認し、「ダウンロード」ボタンでファイルとして保存。すぐにAIに学習させられます。",
+                  icon: "💾",
                 },
               ].map((item, index) => (
                 <div key={item.step} className="text-center md:text-left">
@@ -109,8 +116,12 @@ export default function DocbasePage() {
                     </span>
                     <span className="text-3xl">{item.icon}</span>
                   </div>
-                  <h3 className="text-lg font-semibold mb-2 text-gray-800">{item.title}</h3>
-                  <p className="text-gray-600 text-sm leading-relaxed">{item.description}</p>
+                  <h3 className="text-lg font-semibold mb-2 text-gray-800">
+                    {item.title}
+                  </h3>
+                  <p className="text-gray-600 text-sm leading-relaxed">
+                    {item.description}
+                  </p>
                 </div>
               ))}
             </div>
@@ -121,9 +132,12 @@ export default function DocbasePage() {
         <section className="w-full mt-12">
           <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-background-light">
             <div className="text-center">
-              <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-gray-800">🔒 セキュリティについて</h2>
+              <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-gray-800">
+                🔒 セキュリティについて
+              </h2>
               <p className="text-gray-600 text-lg leading-relaxed max-w-3xl mx-auto">
-                入力されたDocbase APIトークンや取得された記事の内容は、お使いのブラウザ内でのみ処理されます。
+                入力されたDocbase
+                APIトークンや取得された記事の内容は、お使いのブラウザ内でのみ処理されます。
                 これらの情報が外部のサーバーに送信されたり、保存されたりすることは一切ありませんので、安心してご利用いただけます。
               </p>
             </div>
@@ -134,7 +148,9 @@ export default function DocbasePage() {
         <section id="main-tool-section" className="w-full my-12 bg-white">
           <div className="max-w-screen-lg mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-10 md:py-12 shadow-md rounded-lg border border-gray-200">
             <div className="px-0">
-              <h2 className="text-4xl font-bold mb-6 text-center text-gray-800">DocBase 記事検索・収集</h2>
+              <h2 className="text-4xl font-bold mb-6 text-center text-gray-800">
+                DocBase 記事検索・収集
+              </h2>
               <DocbaseSearchForm />
             </div>
           </div>
@@ -142,5 +158,5 @@ export default function DocbasePage() {
       </div>
       <Footer />
     </main>
-  )
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,34 +1,36 @@
-import type { Metadata } from 'next'
-import { Geist_Mono, Noto_Sans_JP } from 'next/font/google'
-import './globals.css'
-import { ErrorBoundaryProvider } from '@/components/ErrorBoundaryProvider'
+import type { Metadata } from "next";
+import { Geist_Mono, Noto_Sans_JP } from "next/font/google";
+import "./globals.css";
+import { ErrorBoundaryProvider } from "@/components/ErrorBoundaryProvider";
 // import Header from '@/components/Header'
 // import Footer from '@/components/Footer'
 
 const notoSansJP = Noto_Sans_JP({
-  variable: '--font-noto-sans-jp',
-  subsets: ['latin'],
-  weight: ['400', '500', '700'],
-})
+  variable: "--font-noto-sans-jp",
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+});
 
 const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-})
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
 
 export const metadata: Metadata = {
-  title: 'NotebookLM Collector',
-  description: 'Collect DocBase articles for NotebookLM',
-}
+  title: "NotebookLM Collector",
+  description: "Collect DocBase articles for NotebookLM",
+};
 
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode
+  children: React.ReactNode;
 }>) {
   return (
     <html lang="ja">
-      <body className={`${notoSansJP.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}>
+      <body
+        className={`${notoSansJP.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}
+      >
         <ErrorBoundaryProvider>
           {/* <Header /> */}
           <main className="flex-grow">{children}</main>
@@ -36,5 +38,5 @@ export default function RootLayout({
         </ErrorBoundaryProvider>
       </body>
     </html>
-  )
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
-'use client' // クライアントコンポーネントとしてマーク
+"use client"; // クライアントコンポーネントとしてマーク
 
-import Link from 'next/link'
-import Footer from '../components/Footer'
-import Header from '../components/Header'
+import Link from "next/link";
+import Footer from "../components/Footer";
+import Header from "../components/Header";
 
 export default function HomePage() {
   return (
@@ -20,23 +20,33 @@ export default function HomePage() {
             href="/docbase"
             className="block p-8 bg-white rounded-lg shadow-lg hover:shadow-xl transition-shadow border border-gray-200"
           >
-            <h2 className="text-3xl font-semibold mb-3 text-docbase-primary">Docbase連携</h2>
-            <p className="text-gray-700 mb-2">Docbaseの記事を検索・収集し、Markdownを生成します。</p>
+            <h2 className="text-3xl font-semibold mb-3 text-docbase-primary">
+              Docbase連携
+            </h2>
+            <p className="text-gray-700 mb-2">
+              Docbaseの記事を検索・収集し、Markdownを生成します。
+            </p>
             <p className="text-sm text-gray-500">最大500件まで収集可能</p>
           </Link>
           <Link
             href="/slack"
             className="block p-8 bg-white rounded-lg shadow-lg hover:shadow-xl transition-shadow border border-gray-200"
           >
-            <h2 className="text-3xl font-semibold mb-3 text-indigo-600">Slack連携</h2>
-            <p className="text-gray-700 mb-2">Slackのスレッドを検索・収集し、NotebookLM用Markdownを生成します。</p>
+            <h2 className="text-3xl font-semibold mb-3 text-indigo-600">
+              Slack連携
+            </h2>
+            <p className="text-gray-700 mb-2">
+              Slackのスレッドを検索・収集し、NotebookLM用Markdownを生成します。
+            </p>
             <p className="text-sm text-gray-500">最大300件まで収集可能</p>
           </Link>
         </div>
         {/* セキュリティ説明セクション */}
         <div className="w-full max-w-4xl">
           <div className="px-6 py-8 rounded-xl border border-gray-200 bg-gray-50">
-            <h2 className="text-2xl font-bold mb-4 text-center text-gray-800">🔒 セキュリティについて</h2>
+            <h2 className="text-2xl font-bold mb-4 text-center text-gray-800">
+              🔒 セキュリティについて
+            </h2>
             <p className="text-gray-600 text-center leading-relaxed">
               入力されたAPIトークンや取得されたデータは、お使いのブラウザ内でのみ処理されます。
               <br />
@@ -47,5 +57,5 @@ export default function HomePage() {
       </div>
       <Footer />
     </main>
-  )
+  );
 }

--- a/src/app/slack/page.tsx
+++ b/src/app/slack/page.tsx
@@ -1,13 +1,13 @@
-'use client'
+"use client";
 
-import { useSlackForm } from '@/features/slack/hooks/useSlackForm'
-import { Toaster } from 'react-hot-toast'
-import Footer from '../../components/Footer'
-import Header from '../../components/Header'
-import { SlackSearchForm } from '../../features/slack/components/SlackSearchForm'
+import { useSlackForm } from "@/features/slack/hooks/useSlackForm";
+import { Toaster } from "react-hot-toast";
+import Footer from "../../components/Footer";
+import Header from "../../components/Header";
+import { SlackSearchForm } from "../../features/slack/components/SlackSearchForm";
 
 export default function SlackPage() {
-  const slackForm = useSlackForm()
+  const slackForm = useSlackForm();
 
   return (
     <main className="flex min-h-screen flex-col text-gray-800 selection:bg-blue-100 font-sans">
@@ -15,17 +15,18 @@ export default function SlackPage() {
       <Toaster
         position="top-center"
         toastOptions={{
-          className: '!border !border-gray-200 !bg-white !text-gray-700 !shadow-lg !rounded-md',
+          className:
+            "!border !border-gray-200 !bg-white !text-gray-700 !shadow-lg !rounded-md",
           success: {
             iconTheme: {
-              primary: '#36C5F0', // Slackブルー
-              secondary: '#FFFFFF',
+              primary: "#36C5F0", // Slackブルー
+              secondary: "#FFFFFF",
             },
           },
           error: {
             iconTheme: {
-              primary: '#EF4444',
-              secondary: '#FFFFFF',
+              primary: "#EF4444",
+              secondary: "#FFFFFF",
             },
           },
         }}
@@ -49,7 +50,11 @@ export default function SlackPage() {
           <div className="flex flex-col items-center">
             <button
               type="button"
-              onClick={() => document.getElementById('main-tool-section')?.scrollIntoView({ behavior: 'smooth' })}
+              onClick={() =>
+                document
+                  .getElementById("main-tool-section")
+                  ?.scrollIntoView({ behavior: "smooth" })
+              }
               className="px-8 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-md shadow-md hover:shadow-lg transform hover:scale-105 transition-all duration-200 ease-in-out text-lg"
             >
               今すぐMarkdownを生成
@@ -63,27 +68,31 @@ export default function SlackPage() {
         {/* 使い方説明セクション */}
         <section className="w-full mt-12">
           <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-gray-50">
-            <h2 className="text-3xl md:text-4xl font-bold mb-20 text-center text-gray-800">利用はかんたん3ステップ</h2>
+            <h2 className="text-3xl md:text-4xl font-bold mb-20 text-center text-gray-800">
+              利用はかんたん3ステップ
+            </h2>
             <div className="grid md:grid-cols-3 gap-x-8 gap-y-10 relative">
               {[
                 {
-                  step: '1',
-                  title: '情報を入力',
-                  description: 'Slackトークン、検索キーワード、期間などを入力します。トークンは保存可能です。',
-                  icon: '⌨️',
-                },
-                {
-                  step: '2',
-                  title: '検索して生成',
+                  step: "1",
+                  title: "情報を入力",
                   description:
-                    '「検索実行」ボタンでSlackからメッセージを取得し、NotebookLM用Markdownをプレビューします。',
-                  icon: '🔍',
+                    "Slackトークン、検索キーワード、期間などを入力します。トークンは保存可能です。",
+                  icon: "⌨️",
                 },
                 {
-                  step: '3',
-                  title: 'ダウンロード',
-                  description: '生成されたMarkdownを「ダウンロード」ボタンで保存。すぐにAIに学習させられます。',
-                  icon: '💾',
+                  step: "2",
+                  title: "検索して生成",
+                  description:
+                    "「検索実行」ボタンでSlackからメッセージを取得し、NotebookLM用Markdownをプレビューします。",
+                  icon: "🔍",
+                },
+                {
+                  step: "3",
+                  title: "ダウンロード",
+                  description:
+                    "生成されたMarkdownを「ダウンロード」ボタンで保存。すぐにAIに学習させられます。",
+                  icon: "💾",
                 },
               ].map((item) => (
                 <div key={item.step} className="text-center md:text-left">
@@ -93,8 +102,12 @@ export default function SlackPage() {
                     </span>
                     <span className="text-3xl">{item.icon}</span>
                   </div>
-                  <h3 className="text-lg font-semibold mb-2 text-gray-800">{item.title}</h3>
-                  <p className="text-gray-600 text-sm leading-relaxed">{item.description}</p>
+                  <h3 className="text-lg font-semibold mb-2 text-gray-800">
+                    {item.title}
+                  </h3>
+                  <p className="text-gray-600 text-sm leading-relaxed">
+                    {item.description}
+                  </p>
                 </div>
               ))}
             </div>
@@ -105,9 +118,12 @@ export default function SlackPage() {
         <section className="w-full mt-12">
           <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-gray-50">
             <div className="text-center">
-              <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-gray-800">🔒 セキュリティについて</h2>
+              <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-gray-800">
+                🔒 セキュリティについて
+              </h2>
               <p className="text-gray-600 text-lg leading-relaxed max-w-3xl mx-auto">
-                入力されたSlack APIトークンや取得したメッセージ内容は、お使いのブラウザ内でのみ処理されます。
+                入力されたSlack
+                APIトークンや取得したメッセージ内容は、お使いのブラウザ内でのみ処理されます。
                 これらの情報が外部サーバーに送信されたり、保存されたりすることは一切ありませんので、安心してご利用いただけます。
               </p>
             </div>
@@ -118,7 +134,9 @@ export default function SlackPage() {
         <section id="main-tool-section" className="w-full my-12 bg-white">
           <div className="max-w-screen-lg mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-10 md:py-12 shadow-md rounded-lg border border-gray-200">
             <div className="px-0">
-              <h2 className="text-4xl font-bold mb-6 text-center text-gray-800">Slack メッセージ検索・収集</h2>
+              <h2 className="text-4xl font-bold mb-6 text-center text-gray-800">
+                Slack メッセージ検索・収集
+              </h2>
               <SlackSearchForm form={slackForm} />
             </div>
           </div>
@@ -126,5 +144,5 @@ export default function SlackPage() {
       </div>
       <Footer />
     </main>
-  )
+  );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -6,36 +6,42 @@
  * アプリ全体のクラッシュを防ぎ、適切なエラーハンドリングを提供する。
  */
 
-'use client'
+"use client";
 
-import type React from 'react'
-import { Component, type ReactNode } from 'react'
-import type { ErrorInfo } from 'react'
-import { logError } from '../utils/errorStorage'
-import { ErrorFallback } from './ErrorFallback'
+import type React from "react";
+import { Component, type ReactNode } from "react";
+import type { ErrorInfo } from "react";
+import { logError } from "../utils/errorStorage";
+import { ErrorFallback } from "./ErrorFallback";
 
 interface ErrorBoundaryProps {
-  children: ReactNode
-  fallback?: React.ComponentType<{ error: Error | null; resetError: () => void }>
-  onError?: (error: Error, errorInfo: ErrorInfo) => void
+  children: ReactNode;
+  fallback?: React.ComponentType<{
+    error: Error | null;
+    resetError: () => void;
+  }>;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
 }
 
 interface ErrorBoundaryState {
-  hasError: boolean
-  error: Error | null
-  errorInfo: ErrorInfo | null
-  errorId: string | null
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  errorId: string | null;
 }
 
-export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
   constructor(props: ErrorBoundaryProps) {
-    super(props)
+    super(props);
     this.state = {
       hasError: false,
       error: null,
       errorInfo: null,
       errorId: null,
-    }
+    };
   }
 
   static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
@@ -43,35 +49,36 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return {
       hasError: true,
       error,
-      errorId: Date.now().toString(36) + Math.random().toString(36).substr(2, 9),
-    }
+      errorId:
+        Date.now().toString(36) + Math.random().toString(36).substr(2, 9),
+    };
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     // エラー情報を state に保存
     this.setState({
       errorInfo,
-    })
+    });
 
     // エラーログを記録
     const errorLog = logError(error, errorInfo, {
       url: window.location.href,
       userAgent: navigator.userAgent,
       timestamp: new Date().toISOString(),
-    })
+    });
 
     // 開発環境でのデバッグ情報
-    if (process.env.NODE_ENV === 'development') {
-      console.group('🚨 Error Boundary Caught Error')
-      console.error('Error:', error)
-      console.error('Error Info:', errorInfo)
-      console.error('Component Stack:', errorInfo.componentStack)
-      console.error('Error Log ID:', errorLog.id)
-      console.groupEnd()
+    if (process.env.NODE_ENV === "development") {
+      console.group("🚨 Error Boundary Caught Error");
+      console.error("Error:", error);
+      console.error("Error Info:", errorInfo);
+      console.error("Component Stack:", errorInfo.componentStack);
+      console.error("Error Log ID:", errorLog.id);
+      console.groupEnd();
     }
 
     // プロップスで渡されたエラーハンドラを実行
-    this.props.onError?.(error, errorInfo)
+    this.props.onError?.(error, errorInfo);
   }
 
   resetError = () => {
@@ -80,15 +87,20 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       error: null,
       errorInfo: null,
       errorId: null,
-    })
-  }
+    });
+  };
 
   render() {
     if (this.state.hasError) {
       // カスタムフォールバックコンポーネントがある場合はそれを使用
       if (this.props.fallback) {
-        const FallbackComponent = this.props.fallback
-        return <FallbackComponent error={this.state.error} resetError={this.resetError} />
+        const FallbackComponent = this.props.fallback;
+        return (
+          <FallbackComponent
+            error={this.state.error}
+            resetError={this.resetError}
+          />
+        );
       }
 
       // デフォルトのエラーフォールバックを表示
@@ -99,9 +111,9 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           errorId={this.state.errorId}
           onReset={this.resetError}
         />
-      )
+      );
     }
 
-    return this.props.children
+    return this.props.children;
   }
 }

--- a/src/components/ErrorBoundaryProvider.tsx
+++ b/src/components/ErrorBoundaryProvider.tsx
@@ -5,26 +5,28 @@
  * Client Componentとして動作し、Server Componentとの橋渡しを行う
  */
 
-'use client'
+"use client";
 
-import type { ReactNode } from 'react'
-import { ErrorBoundary } from './ErrorBoundary'
+import type { ReactNode } from "react";
+import { ErrorBoundary } from "./ErrorBoundary";
 
 interface ErrorBoundaryProviderProps {
-  children: ReactNode
+  children: ReactNode;
 }
 
-export function ErrorBoundaryProvider({ children }: ErrorBoundaryProviderProps) {
+export function ErrorBoundaryProvider({
+  children,
+}: ErrorBoundaryProviderProps) {
   return (
     <ErrorBoundary
       onError={(error, errorInfo) => {
         // クライアントサイドでのエラーログ
-        if (typeof window !== 'undefined') {
-          console.error('Application-level error caught:', error, errorInfo)
+        if (typeof window !== "undefined") {
+          console.error("Application-level error caught:", error, errorInfo);
         }
       }}
     >
       {children}
     </ErrorBoundary>
-  )
+  );
 }

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -5,55 +5,60 @@
  * ユーザーフレンドリーな形で表示し、復旧オプションを提供する。
  */
 
-'use client'
+"use client";
 
-import React, { useState } from 'react'
-import type { ErrorInfo } from 'react'
+import React, { useState } from "react";
+import type { ErrorInfo } from "react";
 
 interface ErrorFallbackProps {
-  error: Error | null
-  errorInfo: ErrorInfo | null
-  errorId: string | null
-  onReset: () => void
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  errorId: string | null;
+  onReset: () => void;
 }
 
-export function ErrorFallback({ error, errorInfo, errorId, onReset }: ErrorFallbackProps) {
-  const [showDetails, setShowDetails] = useState(false)
-  const isDevelopment = process.env.NODE_ENV === 'development'
+export function ErrorFallback({
+  error,
+  errorInfo,
+  errorId,
+  onReset,
+}: ErrorFallbackProps) {
+  const [showDetails, setShowDetails] = useState(false);
+  const isDevelopment = process.env.NODE_ENV === "development";
 
   const handleReload = () => {
-    window.location.reload()
-  }
+    window.location.reload();
+  };
 
   const handleGoHome = () => {
-    window.location.href = '/'
-  }
+    window.location.href = "/";
+  };
 
   const handleClearStorage = () => {
     try {
-      localStorage.clear()
-      sessionStorage.clear()
-      onReset()
+      localStorage.clear();
+      sessionStorage.clear();
+      onReset();
     } catch (err) {
-      console.error('Failed to clear storage:', err)
-      handleReload()
+      console.error("Failed to clear storage:", err);
+      handleReload();
     }
-  }
+  };
 
   const createGitHubIssueUrl = () => {
-    const title = `[Error Report] ${error?.name || 'Unexpected Error'}`
+    const title = `[Error Report] ${error?.name || "Unexpected Error"}`;
     const body = `
 ## エラー情報
 
 **エラーID**: ${errorId}
-**発生時刻**: ${new Date().toLocaleString('ja-JP')}
+**発生時刻**: ${new Date().toLocaleString("ja-JP")}
 **URL**: ${window.location.href}
 **ブラウザ**: ${navigator.userAgent}
 
 ## エラー詳細
 
 \`\`\`
-${error?.stack || error?.message || 'Unknown error'}
+${error?.stack || error?.message || "Unknown error"}
 \`\`\`
 
 ## 再現手順
@@ -69,11 +74,11 @@ ${error?.stack || error?.message || 'Unknown error'}
 ## 追加情報
 
 [その他、参考になる情報があれば記載してください]
-`.trim()
+`.trim();
 
-    const repoUrl = 'https://github.com/sotaroNishioka/notebooklm-collector'
-    return `${repoUrl}/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`
-  }
+    const repoUrl = "https://github.com/sotaroNishioka/notebooklm-collector";
+    return `${repoUrl}/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
@@ -100,7 +105,9 @@ ${error?.stack || error?.message || 'Unknown error'}
 
           {/* エラーメッセージ */}
           <div className="text-center">
-            <h1 className="text-lg font-medium text-gray-900 mb-2">申し訳ございません</h1>
+            <h1 className="text-lg font-medium text-gray-900 mb-2">
+              申し訳ございません
+            </h1>
             <p className="text-sm text-gray-600 mb-6">
               予期しないエラーが発生しました。以下の方法で解決を試してください。
             </p>
@@ -148,7 +155,7 @@ ${error?.stack || error?.message || 'Unknown error'}
               onClick={() => setShowDetails(!showDetails)}
               className="w-full text-sm text-gray-500 hover:text-gray-700 focus:outline-none focus:underline transition-colors"
             >
-              {showDetails ? '詳細を非表示' : 'エラー詳細を表示'}
+              {showDetails ? "詳細を非表示" : "エラー詳細を表示"}
             </button>
 
             {showDetails && (
@@ -160,21 +167,29 @@ ${error?.stack || error?.message || 'Unknown error'}
                     </div>
                   )}
                   <div>
-                    <span className="font-medium">エラー名:</span> {error?.name || 'Unknown'}
+                    <span className="font-medium">エラー名:</span>{" "}
+                    {error?.name || "Unknown"}
                   </div>
                   <div>
-                    <span className="font-medium">メッセージ:</span> {error?.message || 'No error message'}
+                    <span className="font-medium">メッセージ:</span>{" "}
+                    {error?.message || "No error message"}
                   </div>
                   {isDevelopment && error?.stack && (
                     <div>
                       <span className="font-medium">スタックトレース:</span>
-                      <pre className="mt-1 text-xs whitespace-pre-wrap break-all">{error.stack}</pre>
+                      <pre className="mt-1 text-xs whitespace-pre-wrap break-all">
+                        {error.stack}
+                      </pre>
                     </div>
                   )}
                   {isDevelopment && errorInfo?.componentStack && (
                     <div>
-                      <span className="font-medium">コンポーネントスタック:</span>
-                      <pre className="mt-1 text-xs whitespace-pre-wrap break-all">{errorInfo.componentStack}</pre>
+                      <span className="font-medium">
+                        コンポーネントスタック:
+                      </span>
+                      <pre className="mt-1 text-xs whitespace-pre-wrap break-all">
+                        {errorInfo.componentStack}
+                      </pre>
                     </div>
                   )}
                 </div>
@@ -184,7 +199,9 @@ ${error?.stack || error?.message || 'Unknown error'}
 
           {/* フィードバック */}
           <div className="mt-6 text-center">
-            <p className="text-xs text-gray-500 mb-2">問題が解決しない場合は、以下のリンクからお報告ください</p>
+            <p className="text-xs text-gray-500 mb-2">
+              問題が解決しない場合は、以下のリンクからお報告ください
+            </p>
             <a
               href={createGitHubIssueUrl()}
               target="_blank"
@@ -197,5 +214,5 @@ ${error?.stack || error?.message || 'Unknown error'}
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,14 +1,17 @@
-import React from 'react'
+import React from "react";
 
 const Footer = () => {
   return (
     <footer className="w-full mt-12 border-t border-gray-200">
       <div className="max-w-screen-lg mx-auto px-4 sm:px-6 lg:px-8 py-10 text-center text-gray-500 text-xs">
-        <p>&copy; {new Date().getFullYear()} NotebookLM Collector. All rights reserved.</p>
+        <p>
+          &copy; {new Date().getFullYear()} NotebookLM Collector. All rights
+          reserved.
+        </p>
         {/* <p className="mt-1">A tool by Your Name/Company</p> */}
       </div>
     </footer>
-  )
-}
+  );
+};
 
-export default Footer
+export default Footer;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,20 +1,20 @@
-'use client' // 必要に応じて
+"use client"; // 必要に応じて
 
 // Reactの明示的なインポートは不要になる場合があるが、JSXを使うためにはスコープにReactが必要。
 // ただし、Next.js 13以降のApp Routerや新しいJSX Transformでは不要なことも。
 // 一旦残しておくが、もし不要ならリンターが教えてくれるはず。
-import type React from 'react' // 'import type' に変更
+import type React from "react"; // 'import type' に変更
 
 interface HeaderProps {
   // インターフェース名を HeaderProps に
-  title: string
+  title: string;
 }
 
 const Header: React.FC<HeaderProps> = ({ title }) => {
   // 型を HeaderProps に
   return (
     <header className="w-full py-6 shadow-md">
-      {' '}
+      {" "}
       {/* DocbaseHeader から shadow-md を持ってきたのだ */}
       <div className="max-w-screen-lg mx-auto flex justify-between items-center px-4 sm:px-6 lg:px-8">
         <div className="flex items-center">
@@ -24,7 +24,7 @@ const Header: React.FC<HeaderProps> = ({ title }) => {
         {/* <a href="#" className="px-4 py-2 text-sm font-medium text-blue-600 border border-blue-600 rounded-md hover:bg-blue-50 transition-colors">ログイン(仮)</a> */}
       </div>
     </header>
-  )
-}
+  );
+};
 
-export default Header
+export default Header;

--- a/src/features/docbase/adapters/docbaseAdapter.ts
+++ b/src/features/docbase/adapters/docbaseAdapter.ts
@@ -22,7 +22,6 @@ export interface DocbaseSearchParams {
     titleFilter?: string;
     startDate?: string;
     endDate?: string;
-    group?: string;
   };
 }
 
@@ -124,7 +123,7 @@ function buildSearchQuery(
         !advancedFilters.titleFilter?.trim() &&
         !advancedFilters.startDate?.trim() &&
         !advancedFilters.endDate?.trim() &&
-        !advancedFilters.group?.trim()))
+        !advancedFilters.endDate?.trim()))
   ) {
     return "";
   }
@@ -132,7 +131,7 @@ function buildSearchQuery(
   let query = keyword.trim() ? `"${keyword.trim()}"` : "";
 
   if (advancedFilters) {
-    const { tags, author, titleFilter, startDate, endDate, group } =
+    const { tags, author, titleFilter, startDate, endDate } =
       advancedFilters;
 
     // タグ検索
@@ -164,10 +163,6 @@ function buildSearchQuery(
       query += ` created_at:*~${endDate.trim()}`;
     }
 
-    // グループ検索
-    if (group?.trim()) {
-      query += ` group:${group.trim()}`;
-    }
   }
 
   return query.trim();

--- a/src/features/docbase/adapters/docbaseAdapter.ts
+++ b/src/features/docbase/adapters/docbaseAdapter.ts
@@ -131,8 +131,7 @@ function buildSearchQuery(
   let query = keyword.trim() ? `"${keyword.trim()}"` : "";
 
   if (advancedFilters) {
-    const { tags, author, titleFilter, startDate, endDate } =
-      advancedFilters;
+    const { tags, author, titleFilter, startDate, endDate } = advancedFilters;
 
     // タグ検索
     if (tags?.trim()) {
@@ -162,7 +161,6 @@ function buildSearchQuery(
     } else if (endDate?.trim()) {
       query += ` created_at:*~${endDate.trim()}`;
     }
-
   }
 
   return query.trim();

--- a/src/features/docbase/adapters/docbaseAdapter.ts
+++ b/src/features/docbase/adapters/docbaseAdapter.ts
@@ -1,26 +1,29 @@
 // Docbase APIアダプター実装
 // HTTPクライアントアダプターを使用してDocbase APIにアクセスし、Result型で結果を返す
 
-import { type Result, err, ok } from 'neverthrow'
-import type { HttpClient } from '../../../adapters/types'
-import type { ApiError } from '../../../types/error'
-import type { DocbasePostListItem, DocbasePostsResponse } from '../types/docbase'
+import { type Result, err, ok } from "neverthrow";
+import type { HttpClient } from "../../../adapters/types";
+import type { ApiError } from "../../../types/error";
+import type {
+  DocbasePostListItem,
+  DocbasePostsResponse,
+} from "../types/docbase";
 
 /**
  * Docbase検索パラメータ
  */
 export interface DocbaseSearchParams {
-  domain: string
-  token: string
-  keyword: string
+  domain: string;
+  token: string;
+  keyword: string;
   advancedFilters?: {
-    tags?: string
-    author?: string
-    titleFilter?: string
-    startDate?: string
-    endDate?: string
-    group?: string
-  }
+    tags?: string;
+    author?: string;
+    titleFilter?: string;
+    startDate?: string;
+    endDate?: string;
+    group?: string;
+  };
 }
 
 /**
@@ -32,7 +35,9 @@ export interface DocbaseAdapter {
    * @param params 検索パラメータ
    * @returns Promise<Result<DocbasePostListItem[], ApiError>>
    */
-  searchPosts(params: DocbaseSearchParams): Promise<Result<DocbasePostListItem[], ApiError>>
+  searchPosts(
+    params: DocbaseSearchParams
+  ): Promise<Result<DocbasePostListItem[], ApiError>>;
 }
 
 /**
@@ -41,22 +46,24 @@ export interface DocbaseAdapter {
  * @returns DocbaseAdapter の実装
  */
 export function createDocbaseAdapter(httpClient: HttpClient): DocbaseAdapter {
-  const API_BASE_URL = 'https://api.docbase.io/teams'
-  const MAX_PAGES = 5
-  const POSTS_PER_PAGE = 100
+  const API_BASE_URL = "https://api.docbase.io/teams";
+  const MAX_PAGES = 5;
+  const POSTS_PER_PAGE = 100;
 
   return {
-    async searchPosts(params: DocbaseSearchParams): Promise<Result<DocbasePostListItem[], ApiError>> {
-      const { domain, token, keyword, advancedFilters } = params
+    async searchPosts(
+      params: DocbaseSearchParams
+    ): Promise<Result<DocbasePostListItem[], ApiError>> {
+      const { domain, token, keyword, advancedFilters } = params;
 
       // 検索クエリの構築
-      const query = buildSearchQuery(keyword, advancedFilters)
+      const query = buildSearchQuery(keyword, advancedFilters);
       if (!query) {
-        return ok([]) // クエリが空の場合は空配列を返す
+        return ok([]); // クエリが空の場合は空配列を返す
       }
 
-      const allPosts: DocbasePostListItem[] = []
-      let currentPage = 1
+      const allPosts: DocbasePostListItem[] = [];
+      let currentPage = 1;
 
       // ページネーション処理
       while (currentPage <= MAX_PAGES) {
@@ -64,47 +71,50 @@ export function createDocbaseAdapter(httpClient: HttpClient): DocbaseAdapter {
           q: query,
           page: currentPage.toString(),
           per_page: POSTS_PER_PAGE.toString(),
-        })
+        });
 
-        const url = `${API_BASE_URL}/${domain}/posts?${searchParams.toString()}`
+        const url = `${API_BASE_URL}/${domain}/posts?${searchParams.toString()}`;
 
         const result = await httpClient.fetch<DocbasePostsResponse>(url, {
           headers: {
-            'X-DocBaseToken': token,
-            'Content-Type': 'application/json',
+            "X-DocBaseToken": token,
+            "Content-Type": "application/json",
           },
-        })
+        });
 
         if (result.isErr()) {
           // HTTPクライアントからのエラーをそのまま返す
-          return err(result.error)
+          return err(result.error);
         }
 
-        const data = result.value
+        const data = result.value;
         if (data.posts && data.posts.length > 0) {
-          allPosts.push(...data.posts)
+          allPosts.push(...data.posts);
 
           // 取得した件数がper_page未満なら最終ページ
           if (data.posts.length < POSTS_PER_PAGE) {
-            break
+            break;
           }
         } else {
           // 投稿が空なら終了
-          break
+          break;
         }
 
-        currentPage++
+        currentPage++;
       }
 
-      return ok(allPosts)
+      return ok(allPosts);
     },
-  }
+  };
 }
 
 /**
  * 検索クエリを構築する内部ヘルパー関数
  */
-function buildSearchQuery(keyword: string, advancedFilters?: DocbaseSearchParams['advancedFilters']): string {
+function buildSearchQuery(
+  keyword: string,
+  advancedFilters?: DocbaseSearchParams["advancedFilters"]
+): string {
   // キーワードと詳細検索条件の両方が空の場合は空文字を返す
   if (
     !keyword.trim() &&
@@ -116,48 +126,49 @@ function buildSearchQuery(keyword: string, advancedFilters?: DocbaseSearchParams
         !advancedFilters.endDate?.trim() &&
         !advancedFilters.group?.trim()))
   ) {
-    return ''
+    return "";
   }
 
-  let query = keyword.trim() ? `"${keyword.trim()}"` : ''
+  let query = keyword.trim() ? `"${keyword.trim()}"` : "";
 
   if (advancedFilters) {
-    const { tags, author, titleFilter, startDate, endDate, group } = advancedFilters
+    const { tags, author, titleFilter, startDate, endDate, group } =
+      advancedFilters;
 
     // タグ検索
     if (tags?.trim()) {
       for (const tag of tags
-        .split(',')
+        .split(",")
         .map((t) => t.trim())
         .filter((t) => t)) {
-        query += ` tag:${tag}`
+        query += ` tag:${tag}`;
       }
     }
 
     // 投稿者検索
     if (author?.trim()) {
-      query += ` author:${author.trim()}`
+      query += ` author:${author.trim()}`;
     }
 
     // タイトル検索
     if (titleFilter?.trim()) {
-      query += ` title:${titleFilter.trim()}`
+      query += ` title:${titleFilter.trim()}`;
     }
 
     // 期間検索
     if (startDate?.trim() && endDate?.trim()) {
-      query += ` created_at:${startDate.trim()}~${endDate.trim()}`
+      query += ` created_at:${startDate.trim()}~${endDate.trim()}`;
     } else if (startDate?.trim()) {
-      query += ` created_at:${startDate.trim()}~*`
+      query += ` created_at:${startDate.trim()}~*`;
     } else if (endDate?.trim()) {
-      query += ` created_at:*~${endDate.trim()}`
+      query += ` created_at:*~${endDate.trim()}`;
     }
 
     // グループ検索
     if (group?.trim()) {
-      query += ` group:${group.trim()}`
+      query += ` group:${group.trim()}`;
     }
   }
 
-  return query.trim()
+  return query.trim();
 }

--- a/src/features/docbase/adapters/docbaseClient.ts
+++ b/src/features/docbase/adapters/docbaseClient.ts
@@ -1,12 +1,15 @@
-import type { Result } from 'neverthrow'
-import { createFetchHttpClient } from '../../../adapters/fetchHttpClient'
-import type { ApiError } from '../../../types/error'
-import type { DocbasePostListItem } from '../types/docbase'
-import type { AdvancedFilters } from '../types/forms'
-import { type DocbaseSearchParams, createDocbaseAdapter } from './docbaseAdapter'
+import type { Result } from "neverthrow";
+import { createFetchHttpClient } from "../../../adapters/fetchHttpClient";
+import type { ApiError } from "../../../types/error";
+import type { DocbasePostListItem } from "../types/docbase";
+import type { AdvancedFilters } from "../types/forms";
+import {
+  type DocbaseSearchParams,
+  createDocbaseAdapter,
+} from "./docbaseAdapter";
 
 // デフォルトのDocbaseアダプターインスタンス
-const defaultAdapter = createDocbaseAdapter(createFetchHttpClient())
+const defaultAdapter = createDocbaseAdapter(createFetchHttpClient());
 
 /**
  * Docbase APIから投稿リストを取得する関数（アダプターパターンを使用）
@@ -22,12 +25,12 @@ export const fetchDocbasePosts = async (
   domain: string,
   token: string,
   keyword: string,
-  advancedFilters?: AdvancedFilters,
+  advancedFilters?: AdvancedFilters
 ): Promise<Result<DocbasePostListItem[], ApiError>> => {
   return defaultAdapter.searchPosts({
     domain,
     token,
     keyword,
     advancedFilters,
-  })
-}
+  });
+};

--- a/src/features/docbase/components/DocbaseDomainInput.tsx
+++ b/src/features/docbase/components/DocbaseDomainInput.tsx
@@ -1,13 +1,13 @@
-'use client'
+"use client";
 
-import type { FC } from 'react'
+import type { FC } from "react";
 
 type DocbaseDomainInputProps = {
-  domain: string
-  onDomainChange: (domain: string) => void
-  error?: string
-  disabled?: boolean
-}
+  domain: string;
+  onDomainChange: (domain: string) => void;
+  error?: string;
+  disabled?: boolean;
+};
 
 /**
  * Docbaseドメイン入力コンポーネント
@@ -16,10 +16,18 @@ type DocbaseDomainInputProps = {
  * @param error エラーメッセージ
  * @param disabled 非活性状態にするかどうか
  */
-export const DocbaseDomainInput: FC<DocbaseDomainInputProps> = ({ domain, onDomainChange, error, disabled }) => {
+export const DocbaseDomainInput: FC<DocbaseDomainInputProps> = ({
+  domain,
+  onDomainChange,
+  error,
+  disabled,
+}) => {
   return (
     <div className="mb-4">
-      <label htmlFor="docbase-domain" className="block text-base font-medium text-docbase-text mb-1">
+      <label
+        htmlFor="docbase-domain"
+        className="block text-base font-medium text-docbase-text mb-1"
+      >
         Docbaseドメイン
       </label>
       <input
@@ -29,8 +37,8 @@ export const DocbaseDomainInput: FC<DocbaseDomainInputProps> = ({ domain, onDoma
         onChange={(e) => onDomainChange(e.target.value)}
         placeholder="example"
         disabled={disabled}
-        className={`block w-full px-4 py-3 border ${error ? 'border-red-500' : 'border-gray-400'} rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500' : 'focus:ring-docbase-primary focus:border-docbase-primary'} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
-        aria-describedby={error ? 'docbase-domain-error' : undefined}
+        className={`block w-full px-4 py-3 border ${error ? "border-red-500" : "border-gray-400"} rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 ${error ? "focus:ring-red-500 focus:border-red-500" : "focus:ring-docbase-primary focus:border-docbase-primary"} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
+        aria-describedby={error ? "docbase-domain-error" : undefined}
       />
       {error && (
         <p id="docbase-domain-error" className="mt-1 text-xs text-red-600">
@@ -38,5 +46,5 @@ export const DocbaseDomainInput: FC<DocbaseDomainInputProps> = ({ domain, onDoma
         </p>
       )}
     </div>
-  )
-}
+  );
+};

--- a/src/features/docbase/components/DocbaseMarkdownPreview.stories.tsx
+++ b/src/features/docbase/components/DocbaseMarkdownPreview.stories.tsx
@@ -1,49 +1,50 @@
-import { action } from '@storybook/addon-actions'
-import type { Meta, StoryObj } from '@storybook/react'
-import { DocbaseMarkdownPreview } from './DocbaseMarkdownPreview'
+import { action } from "@storybook/addon-actions";
+import type { Meta, StoryObj } from "@storybook/react";
+import { DocbaseMarkdownPreview } from "./DocbaseMarkdownPreview";
 
 const meta: Meta<typeof DocbaseMarkdownPreview> = {
-  title: 'Features/Docbase/Components/DocbaseMarkdownPreview',
+  title: "Features/Docbase/Components/DocbaseMarkdownPreview",
   component: DocbaseMarkdownPreview,
   parameters: {
-    layout: 'padded',
+    layout: "padded",
     docs: {
       description: {
-        component: 'Docbase用Markdownプレビューコンポーネント。Docbaseの記事プレビューに特化したMarkdownレンダリング。',
+        component:
+          "Docbase用Markdownプレビューコンポーネント。Docbaseの記事プレビューに特化したMarkdownレンダリング。",
       },
     },
   },
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   argTypes: {
     markdown: {
-      control: 'text',
-      description: '表示するMarkdown文字列',
+      control: "text",
+      description: "表示するMarkdown文字列",
     },
     title: {
-      control: 'text',
-      description: 'プレビューのタイトル',
+      control: "text",
+      description: "プレビューのタイトル",
     },
     onDownload: {
-      action: 'downloaded',
-      description: 'ダウンロードハンドラー',
+      action: "downloaded",
+      description: "ダウンロードハンドラー",
     },
     downloadFileName: {
-      control: 'text',
-      description: 'ダウンロードファイル名',
+      control: "text",
+      description: "ダウンロードファイル名",
     },
     className: {
-      control: 'text',
-      description: '追加のCSSクラス',
+      control: "text",
+      description: "追加のCSSクラス",
     },
     emptyMessage: {
-      control: 'text',
-      description: '空の時のメッセージ',
+      control: "text",
+      description: "空の時のメッセージ",
     },
   },
-}
+};
 
-export default meta
-type Story = StoryObj<typeof meta>
+export default meta;
+type Story = StoryObj<typeof meta>;
 
 // 基本的な使用例
 export const Default: Story = {
@@ -83,38 +84,39 @@ function fetchDocbasePosts(domain: string, token: string): Promise<DocbasePost[]
 > これは引用ブロックです。Docbaseの記事でよく使用される重要な情報を強調します。
 
 [関連記事へのリンク](https://example.docbase.io/posts/123)`,
-    title: 'Docbase記事プレビュー',
-    onDownload: action('download-clicked'),
-    downloadFileName: 'docbase-article.md',
+    title: "Docbase記事プレビュー",
+    onDownload: action("download-clicked"),
+    downloadFileName: "docbase-article.md",
   },
-}
+};
 
 // 空状態
 export const Empty: Story = {
   args: {
-    markdown: '',
-    title: 'Docbase記事プレビュー',
-    emptyMessage: 'Docbase記事を検索すると、ここにプレビューが表示されます。',
+    markdown: "",
+    title: "Docbase記事プレビュー",
+    emptyMessage: "Docbase記事を検索すると、ここにプレビューが表示されます。",
   },
-}
+};
 
 // カスタム空メッセージ
 export const CustomEmptyMessage: Story = {
   args: {
-    markdown: '',
-    title: 'Docbase検索結果',
-    emptyMessage: '検索条件に該当する記事が見つかりませんでした。検索キーワードを変更してお試しください。',
+    markdown: "",
+    title: "Docbase検索結果",
+    emptyMessage:
+      "検索条件に該当する記事が見つかりませんでした。検索キーワードを変更してお試しください。",
   },
-}
+};
 
 // ローディング状態（空状態をローディングメッセージで代用）
 export const Loading: Story = {
   args: {
-    markdown: '',
-    title: 'Docbase記事を読み込み中...',
-    emptyMessage: '📄 Docbaseから記事を取得しています...',
+    markdown: "",
+    title: "Docbase記事を読み込み中...",
+    emptyMessage: "📄 Docbaseから記事を取得しています...",
   },
-}
+};
 
 // 短文コンテンツ
 export const ShortContent: Story = {
@@ -130,11 +132,11 @@ export const ShortContent: Story = {
 - [ ] API仕様書の更新
 - [x] デザインレビューの実施
 - [ ] テストケースの追加`,
-    title: 'ミーティング議事録',
-    onDownload: action('download-clicked'),
-    downloadFileName: 'meeting-minutes.md',
+    title: "ミーティング議事録",
+    onDownload: action("download-clicked"),
+    downloadFileName: "meeting-minutes.md",
   },
-}
+};
 
 // 長文コンテンツ（Docbase記事らしい内容）
 export const LongContent: Story = {
@@ -336,11 +338,11 @@ GET /api/v1/posts?tag=API&author=user123&created_after=2023-01-01
 
 このガイドラインに従うことで、一貫性があり使いやすいAPIを提供できます。
 詳細な実装については、各エンドポイントの仕様書を参照してください。`,
-    title: 'API設計ガイドライン',
-    onDownload: action('download-clicked'),
-    downloadFileName: 'api-guidelines.md',
+    title: "API設計ガイドライン",
+    onDownload: action("download-clicked"),
+    downloadFileName: "api-guidelines.md",
   },
-}
+};
 
 // コードブロック中心のコンテンツ
 export const CodeHeavyContent: Story = {
@@ -484,11 +486,11 @@ export const docbaseConfig = {
   apiToken: process.env.DOCBASE_API_TOKEN!,
 } as const
 \`\`\``,
-    title: 'Docbase API実装例',
-    onDownload: action('download-clicked'),
-    downloadFileName: 'docbase-implementation.md',
+    title: "Docbase API実装例",
+    onDownload: action("download-clicked"),
+    downloadFileName: "docbase-implementation.md",
   },
-}
+};
 
 // ダウンロード機能なし
 export const NoDownload: Story = {
@@ -501,10 +503,10 @@ export const NoDownload: Story = {
 - Docbase記事の基本情報
 - タグ情報
 - 作成日時`,
-    title: 'シンプルプレビュー',
+    title: "シンプルプレビュー",
     // onDownloadを指定しない
   },
-}
+};
 
 // タイトルなし
 export const NoTitle: Story = {
@@ -515,9 +517,9 @@ export const NoTitle: Story = {
 
 Docbaseから取得した記事のプレビュー状態を確認できます。`,
     // titleを指定しない
-    onDownload: action('download-clicked'),
+    onDownload: action("download-clicked"),
   },
-}
+};
 
 // カスタムクラス適用
 export const CustomStyling: Story = {
@@ -530,8 +532,8 @@ export const CustomStyling: Story = {
 - 背景色の変更
 - 余白の調整
 - Docbase専用のスタイリング`,
-    title: 'カスタムスタイル',
-    className: 'bg-blue-50 p-8 rounded-xl',
-    onDownload: action('download-clicked'),
+    title: "カスタムスタイル",
+    className: "bg-blue-50 p-8 rounded-xl",
+    onDownload: action("download-clicked"),
   },
-}
+};

--- a/src/features/docbase/components/DocbaseMarkdownPreview.tsx
+++ b/src/features/docbase/components/DocbaseMarkdownPreview.tsx
@@ -1,19 +1,21 @@
-'use client'
+"use client";
 
-import type { FC, ReactNode } from 'react'
-import ReactMarkdown, { type ExtraProps as ReactMarkdownExtraProps } from 'react-markdown'
-import remarkGfm from 'remark-gfm'
+import type { FC, ReactNode } from "react";
+import ReactMarkdown, {
+  type ExtraProps as ReactMarkdownExtraProps,
+} from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 // react-markdownのカスタムコンポーネントのprops型を定義
 // BiomeのnoExplicitAnyを抑制するために、型をanyにしてコメントで説明を追加します
 
 interface DocbaseMarkdownPreviewProps {
-  markdown: string
-  title?: string
-  onDownload?: () => void
-  downloadFileName?: string
-  className?: string
-  emptyMessage?: string
+  markdown: string;
+  title?: string;
+  onDownload?: () => void;
+  downloadFileName?: string;
+  className?: string;
+  emptyMessage?: string;
 }
 
 /**
@@ -28,11 +30,11 @@ interface DocbaseMarkdownPreviewProps {
  */
 export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
   markdown,
-  title = 'プレビュー',
+  title = "プレビュー",
   onDownload,
-  downloadFileName = 'markdown.md',
-  className = '',
-  emptyMessage = 'ここにMarkdownプレビューが表示されます。',
+  downloadFileName = "markdown.md",
+  className = "",
+  emptyMessage = "ここにMarkdownプレビューが表示されます。",
 }) => {
   if (!markdown) {
     return (
@@ -41,7 +43,7 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
           <p className="text-gray-500">{emptyMessage}</p>
         </div>
       </div>
-    )
+    );
   }
 
   return (
@@ -67,34 +69,48 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
             components={{
               // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
               h2: ({ node, children, ...props }: any) => (
-                <h2 className="text-3xl font-bold mt-8 mb-4 pb-2 border-b-2 border-blue-600 text-gray-800" {...props}>
+                <h2
+                  className="text-3xl font-bold mt-8 mb-4 pb-2 border-b-2 border-blue-600 text-gray-800"
+                  {...props}
+                >
                   {children}
                 </h2>
               ),
               // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
               h3: ({ node, children, ...props }: any) => (
-                <h3 className="text-2xl font-bold mt-6 mb-3 text-gray-800" {...props}>
+                <h3
+                  className="text-2xl font-bold mt-6 mb-3 text-gray-800"
+                  {...props}
+                >
                   {children}
                 </h3>
               ),
               // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
               h4: ({ node, children, ...props }: any) => (
-                <h4 className="text-xl font-bold mt-4 mb-2 text-gray-700" {...props}>
+                <h4
+                  className="text-xl font-bold mt-4 mb-2 text-gray-700"
+                  {...props}
+                >
                   {children}
                 </h4>
               ),
               // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
               blockquote: ({ node, children, ...props }: any) => (
-                <blockquote className="my-4 pl-4 border-l-4 border-gray-300 text-gray-600 bg-gray-100 py-2" {...props}>
+                <blockquote
+                  className="my-4 pl-4 border-l-4 border-gray-300 text-gray-600 bg-gray-100 py-2"
+                  {...props}
+                >
                   {children}
                 </blockquote>
               ),
               // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
               code: ({ node, inline, className, children, ...props }: any) => {
-                const match = /language-(\w+)/.exec(className || '')
+                const match = /language-(\w+)/.exec(className || "");
                 return !inline && match ? (
                   <div className="my-4 bg-gray-800 rounded-md overflow-hidden shadow">
-                    <div className="px-4 py-2 text-sm text-gray-300 bg-gray-700">{match[1]}</div>
+                    <div className="px-4 py-2 text-sm text-gray-300 bg-gray-700">
+                      {match[1]}
+                    </div>
                     <pre className="p-4 text-sm leading-relaxed overflow-x-auto text-gray-100">
                       <code {...props} className={className}>
                         {children}
@@ -104,15 +120,21 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
                 ) : (
                   <code
                     {...props}
-                    className={className || 'px-1 py-0.5 bg-gray-200 text-gray-800 rounded-sm text-sm font-mono'}
+                    className={
+                      className ||
+                      "px-1 py-0.5 bg-gray-200 text-gray-800 rounded-sm text-sm font-mono"
+                    }
                   >
                     {children}
                   </code>
-                )
+                );
               },
               // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
               a: ({ node, children, ...props }: any) => (
-                <a className="text-blue-600 hover:underline hover:text-blue-800" {...props}>
+                <a
+                  className="text-blue-600 hover:underline hover:text-blue-800"
+                  {...props}
+                >
                   {children}
                 </a>
               ),
@@ -123,5 +145,5 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
         </div>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/src/features/docbase/components/DocbaseMarkdownPreview.tsx
+++ b/src/features/docbase/components/DocbaseMarkdownPreview.tsx
@@ -62,24 +62,60 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
           )}
         </div>
       )}
-      <div className="border rounded-lg p-6 bg-gray-50">
-        <div className="prose max-w-none prose-neutral prose-sm sm:prose-base lg:prose-lg xl:prose-xl">
+      <div className="border border-gray-200 rounded-xl p-8 bg-white shadow-sm">
+        <div className="prose max-w-none prose-neutral prose-sm sm:prose-base lg:prose-lg xl:prose-xl docbase-preview">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{
               // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
-              h2: ({ node, children, ...props }: any) => (
-                <h2
-                  className="text-3xl font-bold mt-8 mb-4 pb-2 border-b-2 border-blue-600 text-gray-800"
+              h1: ({ node, children, ...props }: any) => (
+                <h1
+                  className="text-xl font-semibold mt-6 mb-4 text-slate-800 bg-slate-50 px-4 py-3 rounded-lg border-l-4 border-slate-400"
                   {...props}
                 >
                   {children}
-                </h2>
+                </h1>
               ),
+              // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+              h2: ({ node, children, ...props }: any) => {
+                // プレビューの記事タイトル（DocbaseタイトルのH2）か記事内のH2かを判定
+                const childrenText = Array.isArray(children)
+                  ? children.join("")
+                  : children;
+                const isDocbaseTitle = markdown.includes(
+                  `## ${childrenText}\n\n**作成日**:`
+                );
+
+                if (isDocbaseTitle) {
+                  // Docbaseの記事タイトル
+                  const isFirstTitle =
+                    markdown.indexOf(`## ${childrenText}`) ===
+                    markdown.indexOf("##");
+                  return (
+                    <h2
+                      className={`text-2xl font-bold mb-8 text-slate-800 bg-gradient-to-r from-slate-50 via-blue-50 to-slate-50 px-6 py-4 rounded-xl border border-slate-200 shadow-sm hover:shadow-md transition-shadow duration-200 ${
+                        isFirstTitle ? "mt-0" : "mt-16"
+                      }`}
+                      {...props}
+                    >
+                      {children}
+                    </h2>
+                  );
+                }
+                // 記事内のH2タイトル
+                return (
+                  <h2
+                    className="text-lg font-semibold mt-6 mb-3 text-slate-700 bg-slate-50 px-4 py-2 rounded-lg border-l-4 border-slate-300"
+                    {...props}
+                  >
+                    {children}
+                  </h2>
+                );
+              },
               // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
               h3: ({ node, children, ...props }: any) => (
                 <h3
-                  className="text-2xl font-bold mt-6 mb-3 text-gray-800"
+                  className="text-base font-semibold mt-4 mb-2 text-slate-700 bg-slate-50 px-3 py-2 rounded-lg border-l-3 border-slate-300"
                   {...props}
                 >
                   {children}
@@ -88,7 +124,7 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
               // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
               h4: ({ node, children, ...props }: any) => (
                 <h4
-                  className="text-xl font-bold mt-4 mb-2 text-gray-700"
+                  className="text-sm font-medium mt-3 mb-2 text-slate-600 bg-slate-50 px-3 py-1 rounded border-l-2 border-slate-300"
                   {...props}
                 >
                   {children}
@@ -97,7 +133,7 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
               // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
               blockquote: ({ node, children, ...props }: any) => (
                 <blockquote
-                  className="my-4 pl-4 border-l-4 border-gray-300 text-gray-600 bg-gray-100 py-2"
+                  className="my-6 pl-6 border-l-4 border-blue-300 text-slate-700 bg-blue-50 py-4 rounded-r-lg italic"
                   {...props}
                 >
                   {children}
@@ -107,11 +143,11 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
               code: ({ node, inline, className, children, ...props }: any) => {
                 const match = /language-(\w+)/.exec(className || "");
                 return !inline && match ? (
-                  <div className="my-4 bg-gray-800 rounded-md overflow-hidden shadow">
-                    <div className="px-4 py-2 text-sm text-gray-300 bg-gray-700">
+                  <div className="my-6 bg-slate-900 rounded-xl overflow-hidden shadow-lg">
+                    <div className="px-4 py-2 text-sm text-slate-300 bg-slate-800 font-medium">
                       {match[1]}
                     </div>
-                    <pre className="p-4 text-sm leading-relaxed overflow-x-auto text-gray-100">
+                    <pre className="p-6 text-sm leading-relaxed overflow-x-auto text-slate-100">
                       <code {...props} className={className}>
                         {children}
                       </code>
@@ -122,7 +158,7 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
                     {...props}
                     className={
                       className ||
-                      "px-1 py-0.5 bg-gray-200 text-gray-800 rounded-sm text-sm font-mono"
+                      "px-2 py-1 bg-slate-100 text-slate-800 rounded text-sm font-mono border border-slate-200"
                     }
                   >
                     {children}
@@ -138,6 +174,47 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
                   {children}
                 </a>
               ),
+              // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+              hr: ({ node, ...props }: any) => (
+                <hr className="my-16 border-slate-200" {...props} />
+              ),
+              // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+              p: ({ node, children, ...props }: any) => {
+                // メタデータを含むpタグか、通常の本文pタグかを判定
+                const containsMetadata =
+                  Array.isArray(children) &&
+                  children.some(
+                    (child) =>
+                      typeof child === "object" && child?.type === "strong"
+                  );
+
+                return (
+                  <p
+                    className={`leading-relaxed text-slate-700 ${containsMetadata ? "mb-2 text-sm" : "mt-6 mb-4"}`}
+                    {...props}
+                  >
+                    {children}
+                  </p>
+                );
+              },
+              // biome-ignore lint/suspicious/noExplicitAny: カスタムコンポーネントの型解決が複雑なため一時的にanyを使用
+              strong: ({ node, children, ...props }: any) => {
+                // メタデータラベル（作成日:、作成者:など）の場合、その後に余白を追加
+                const isMetadataLabel =
+                  typeof children === "string" && children.includes(":");
+                return (
+                  <strong
+                    className={
+                      isMetadataLabel
+                        ? "font-semibold text-slate-600"
+                        : "font-semibold text-slate-800"
+                    }
+                    {...props}
+                  >
+                    {children}
+                  </strong>
+                );
+              },
             }}
           >
             {markdown}

--- a/src/features/docbase/components/DocbaseSearchForm.tsx
+++ b/src/features/docbase/components/DocbaseSearchForm.tsx
@@ -36,7 +36,6 @@ export const DocbaseSearchForm = () => {
   const [titleFilter, setTitleFilter] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
-  const [group, setGroup] = useState("");
 
   const { posts, isLoading, error, searchPosts, canRetry, retrySearch } =
     useDocbaseSearch();
@@ -53,7 +52,6 @@ export const DocbaseSearchForm = () => {
       titleFilter,
       startDate,
       endDate,
-      group,
     };
     await searchPosts(domain, token, keyword, advancedFilters);
   };
@@ -230,23 +228,6 @@ export const DocbaseSearchForm = () => {
                     disabled={isLoading || isDownloading}
                   />
                 </div>
-              </div>
-              <div>
-                <label
-                  htmlFor="group"
-                  className="block text-sm font-medium text-docbase-text mb-1"
-                >
-                  グループ名
-                </label>
-                <input
-                  id="group"
-                  type="text"
-                  value={group}
-                  onChange={(e) => setGroup(e.target.value)}
-                  placeholder="例: 開発チーム"
-                  className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
-                  disabled={isLoading || isDownloading}
-                />
               </div>
             </div>
           )}

--- a/src/features/docbase/components/DocbaseSearchForm.tsx
+++ b/src/features/docbase/components/DocbaseSearchForm.tsx
@@ -371,8 +371,6 @@ export const DocbaseSearchForm = () => {
           <div className="mt-6 pt-5 border-t border-gray-200">
             <DocbaseMarkdownPreview
               markdown={markdownContent}
-              title="Markdownプレビュー"
-              onDownload={handleDownloadClick}
               emptyMessage="Docbase記事の検索結果がここに表示されます。"
             />
             {posts && posts.length > 10 && (

--- a/src/features/docbase/components/DocbaseSearchForm.tsx
+++ b/src/features/docbase/components/DocbaseSearchForm.tsx
@@ -1,42 +1,52 @@
-'use client'
+"use client";
 
-import React, { useState, type FormEvent, useEffect, useRef } from 'react'
-import { useDownload } from '../../../hooks/useDownload'
-import useLocalStorage from '../../../hooks/useLocalStorage'
-import type { ApiError } from '../../../types/error'
-import { useDocbaseSearch } from '../hooks/useDocbaseSearch'
-import { generateDocbaseMarkdown, generateDocbaseMarkdownForPreview } from '../utils/docbaseMarkdownGenerator'
-import { DocbaseDomainInput } from './DocbaseDomainInput'
-import { DocbaseMarkdownPreview } from './DocbaseMarkdownPreview'
-import { DocbaseTokenInput } from './DocbaseTokenInput'
+import React, { useState, type FormEvent, useEffect, useRef } from "react";
+import { useDownload } from "../../../hooks/useDownload";
+import useLocalStorage from "../../../hooks/useLocalStorage";
+import type { ApiError } from "../../../types/error";
+import { useDocbaseSearch } from "../hooks/useDocbaseSearch";
+import {
+  generateDocbaseMarkdown,
+  generateDocbaseMarkdownForPreview,
+} from "../utils/docbaseMarkdownGenerator";
+import { DocbaseDomainInput } from "./DocbaseDomainInput";
+import { DocbaseMarkdownPreview } from "./DocbaseMarkdownPreview";
+import { DocbaseTokenInput } from "./DocbaseTokenInput";
 
-const LOCAL_STORAGE_DOMAIN_KEY = 'docbaseDomain'
-const LOCAL_STORAGE_TOKEN_KEY = 'docbaseToken'
+const LOCAL_STORAGE_DOMAIN_KEY = "docbaseDomain";
+const LOCAL_STORAGE_TOKEN_KEY = "docbaseToken";
 
 /**
  * 検索フォームコンポーネント
  */
 export const DocbaseSearchForm = () => {
-  const [keyword, setKeyword] = useState('')
-  const [domain, setDomain] = useLocalStorage<string>(LOCAL_STORAGE_DOMAIN_KEY, '')
-  const [token, setToken] = useLocalStorage<string>(LOCAL_STORAGE_TOKEN_KEY, '')
-  const [markdownContent, setMarkdownContent] = useState('')
-  const [showAdvancedSearch, setShowAdvancedSearch] = useState(false)
-  const [tags, setTags] = useState('')
-  const [author, setAuthor] = useState('')
-  const [titleFilter, setTitleFilter] = useState('')
-  const [startDate, setStartDate] = useState('')
-  const [endDate, setEndDate] = useState('')
-  const [group, setGroup] = useState('')
+  const [keyword, setKeyword] = useState("");
+  const [domain, setDomain] = useLocalStorage<string>(
+    LOCAL_STORAGE_DOMAIN_KEY,
+    ""
+  );
+  const [token, setToken] = useLocalStorage<string>(
+    LOCAL_STORAGE_TOKEN_KEY,
+    ""
+  );
+  const [markdownContent, setMarkdownContent] = useState("");
+  const [showAdvancedSearch, setShowAdvancedSearch] = useState(false);
+  const [tags, setTags] = useState("");
+  const [author, setAuthor] = useState("");
+  const [titleFilter, setTitleFilter] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [group, setGroup] = useState("");
 
-  const { posts, isLoading, error, searchPosts, canRetry, retrySearch } = useDocbaseSearch()
-  const { isDownloading, handleDownload } = useDownload()
+  const { posts, isLoading, error, searchPosts, canRetry, retrySearch } =
+    useDocbaseSearch();
+  const { isDownloading, handleDownload } = useDownload();
 
-  const tokenInputRef = useRef<HTMLInputElement>(null)
+  const tokenInputRef = useRef<HTMLInputElement>(null);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setMarkdownContent('')
+    event.preventDefault();
+    setMarkdownContent("");
     const advancedFilters = {
       tags,
       author,
@@ -44,56 +54,59 @@ export const DocbaseSearchForm = () => {
       startDate,
       endDate,
       group,
-    }
-    await searchPosts(domain, token, keyword, advancedFilters)
-  }
+    };
+    await searchPosts(domain, token, keyword, advancedFilters);
+  };
 
   useEffect(() => {
     if (posts && posts.length > 0) {
-      const md = generateDocbaseMarkdownForPreview(posts.slice(0, 10), keyword)
-      setMarkdownContent(md)
+      const md = generateDocbaseMarkdownForPreview(posts.slice(0, 10), keyword);
+      setMarkdownContent(md);
     } else {
-      setMarkdownContent('')
+      setMarkdownContent("");
     }
-  }, [posts, keyword])
+  }, [posts, keyword]);
 
   useEffect(() => {
-    if (error?.type === 'unauthorized') {
-      tokenInputRef.current?.focus()
+    if (error?.type === "unauthorized") {
+      tokenInputRef.current?.focus();
     }
-  }, [error])
+  }, [error]);
 
   const handleDownloadClick = () => {
-    const postsExist = posts && posts.length > 0
+    const postsExist = posts && posts.length > 0;
     if (postsExist) {
       // ダウンロード時は全件のMarkdownを生成
-      const fullMarkdown = generateDocbaseMarkdown(posts, keyword)
-      handleDownload(fullMarkdown, keyword, postsExist, 'docbase')
+      const fullMarkdown = generateDocbaseMarkdown(posts, keyword);
+      handleDownload(fullMarkdown, keyword, postsExist, "docbase");
     } else {
-      handleDownload(markdownContent, keyword, postsExist, 'docbase')
+      handleDownload(markdownContent, keyword, postsExist, "docbase");
     }
-  }
+  };
 
   const renderErrorCause = (currentError: ApiError | null) => {
-    if (!currentError) return null
+    if (!currentError) return null;
 
-    if (currentError.type === 'network' || currentError.type === 'unknown') {
+    if (currentError.type === "network" || currentError.type === "unknown") {
       if (currentError.cause) {
         if (currentError.cause instanceof Error) {
-          return <p className="text-sm">詳細: {currentError.cause.message}</p>
+          return <p className="text-sm">詳細: {currentError.cause.message}</p>;
         }
-        return <p className="text-sm">詳細: {String(currentError.cause)}</p>
+        return <p className="text-sm">詳細: {String(currentError.cause)}</p>;
       }
     }
-    return null
-  }
+    return null;
+  };
 
   return (
     <div className="max-w-3xl mx-auto">
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className="space-y-4">
           <div>
-            <label htmlFor="keyword" className="block text-base font-medium text-docbase-text mb-1">
+            <label
+              htmlFor="keyword"
+              className="block text-base font-medium text-docbase-text mb-1"
+            >
               検索キーワード
             </label>
             <input
@@ -107,8 +120,16 @@ export const DocbaseSearchForm = () => {
               required
             />
           </div>
-          <DocbaseDomainInput domain={domain} onDomainChange={setDomain} disabled={isLoading || isDownloading} />
-          <DocbaseTokenInput token={token} onTokenChange={setToken} disabled={isLoading || isDownloading} />
+          <DocbaseDomainInput
+            domain={domain}
+            onDomainChange={setDomain}
+            disabled={isLoading || isDownloading}
+          />
+          <DocbaseTokenInput
+            token={token}
+            onTokenChange={setToken}
+            disabled={isLoading || isDownloading}
+          />
         </div>
 
         {/* 詳細検索の開閉ボタンと入力フィールドを追加 */}
@@ -118,13 +139,18 @@ export const DocbaseSearchForm = () => {
             onClick={() => setShowAdvancedSearch(!showAdvancedSearch)}
             className="text-sm text-docbase-primary hover:text-docbase-primary-dark focus:outline-none"
           >
-            {showAdvancedSearch ? '詳細な条件を閉じる ▲' : 'もっと詳細な条件を追加する ▼'}
+            {showAdvancedSearch
+              ? "詳細な条件を閉じる ▲"
+              : "もっと詳細な条件を追加する ▼"}
           </button>
 
           {showAdvancedSearch && (
             <div className="space-y-4 p-4 border border-gray-300 rounded-md bg-gray-50">
               <div>
-                <label htmlFor="tags" className="block text-sm font-medium text-docbase-text mb-1">
+                <label
+                  htmlFor="tags"
+                  className="block text-sm font-medium text-docbase-text mb-1"
+                >
                   タグ (カンマ区切り)
                 </label>
                 <input
@@ -138,7 +164,10 @@ export const DocbaseSearchForm = () => {
                 />
               </div>
               <div>
-                <label htmlFor="author" className="block text-sm font-medium text-docbase-text mb-1">
+                <label
+                  htmlFor="author"
+                  className="block text-sm font-medium text-docbase-text mb-1"
+                >
                   投稿者 (ユーザーID)
                 </label>
                 <input
@@ -152,7 +181,10 @@ export const DocbaseSearchForm = () => {
                 />
               </div>
               <div>
-                <label htmlFor="titleFilter" className="block text-sm font-medium text-docbase-text mb-1">
+                <label
+                  htmlFor="titleFilter"
+                  className="block text-sm font-medium text-docbase-text mb-1"
+                >
                   タイトルに含むキーワード
                 </label>
                 <input
@@ -167,7 +199,10 @@ export const DocbaseSearchForm = () => {
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
-                  <label htmlFor="startDate" className="block text-sm font-medium text-docbase-text mb-1">
+                  <label
+                    htmlFor="startDate"
+                    className="block text-sm font-medium text-docbase-text mb-1"
+                  >
                     投稿期間 (開始日)
                   </label>
                   <input
@@ -180,7 +215,10 @@ export const DocbaseSearchForm = () => {
                   />
                 </div>
                 <div>
-                  <label htmlFor="endDate" className="block text-sm font-medium text-docbase-text mb-1">
+                  <label
+                    htmlFor="endDate"
+                    className="block text-sm font-medium text-docbase-text mb-1"
+                  >
                     投稿期間 (終了日)
                   </label>
                   <input
@@ -194,7 +232,10 @@ export const DocbaseSearchForm = () => {
                 </div>
               </div>
               <div>
-                <label htmlFor="group" className="block text-sm font-medium text-docbase-text mb-1">
+                <label
+                  htmlFor="group"
+                  className="block text-sm font-medium text-docbase-text mb-1"
+                >
                   グループ名
                 </label>
                 <input
@@ -215,7 +256,9 @@ export const DocbaseSearchForm = () => {
           <button
             type="submit"
             className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-transparent shadow-sm text-sm font-medium rounded-sm text-white bg-docbase-primary hover:bg-docbase-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
-            disabled={isLoading || isDownloading || !domain || !token || !keyword}
+            disabled={
+              isLoading || isDownloading || !domain || !token || !keyword
+            }
           >
             {isLoading ? (
               <>
@@ -226,7 +269,14 @@ export const DocbaseSearchForm = () => {
                   viewBox="0 0 24 24"
                 >
                   <title>検索処理ローディング</title>
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
                   <path
                     className="opacity-75"
                     fill="currentColor"
@@ -236,7 +286,7 @@ export const DocbaseSearchForm = () => {
                 検索中...
               </>
             ) : (
-              '検索実行'
+              "検索実行"
             )}
           </button>
           <button
@@ -254,7 +304,14 @@ export const DocbaseSearchForm = () => {
                   viewBox="0 0 24 24"
                 >
                   <title>ダウンロード処理ローディング</title>
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
                   <path
                     className="opacity-75"
                     fill="currentColor"
@@ -264,7 +321,7 @@ export const DocbaseSearchForm = () => {
                 生成中...
               </>
             ) : (
-              'Markdownダウンロード'
+              "Markdownダウンロード"
             )}
           </button>
         </div>
@@ -302,7 +359,11 @@ export const DocbaseSearchForm = () => {
               <p className="font-medium">エラーが発生しました:</p>
             </div>
             <p className="ml-7 mt-0.5 text-red-600">{error.message}</p>
-            {renderErrorCause(error) && <div className="ml-7 mt-1 text-xs text-red-500">{renderErrorCause(error)}</div>}
+            {renderErrorCause(error) && (
+              <div className="ml-7 mt-1 text-xs text-red-500">
+                {renderErrorCause(error)}
+              </div>
+            )}
           </div>
         )}
 
@@ -320,13 +381,15 @@ export const DocbaseSearchForm = () => {
               </p>
             )}
             {posts && posts.length > 0 && (
-              <p className="mt-2 text-sm text-docbase-text-sub">取得件数: {posts.length}件</p>
+              <p className="mt-2 text-sm text-docbase-text-sub">
+                取得件数: {posts.length}件
+              </p>
             )}
           </div>
         )}
       </form>
     </div>
-  )
-}
+  );
+};
 
 // Named exportのみ使用

--- a/src/features/docbase/components/DocbaseSearchForm.tsx
+++ b/src/features/docbase/components/DocbaseSearchForm.tsx
@@ -5,7 +5,7 @@ import { useDownload } from '../../../hooks/useDownload'
 import useLocalStorage from '../../../hooks/useLocalStorage'
 import type { ApiError } from '../../../types/error'
 import { useDocbaseSearch } from '../hooks/useDocbaseSearch'
-import { generateDocbaseMarkdown } from '../utils/docbaseMarkdownGenerator'
+import { generateDocbaseMarkdown, generateDocbaseMarkdownForPreview } from '../utils/docbaseMarkdownGenerator'
 import { DocbaseDomainInput } from './DocbaseDomainInput'
 import { DocbaseMarkdownPreview } from './DocbaseMarkdownPreview'
 import { DocbaseTokenInput } from './DocbaseTokenInput'
@@ -50,7 +50,7 @@ export const DocbaseSearchForm = () => {
 
   useEffect(() => {
     if (posts && posts.length > 0) {
-      const md = generateDocbaseMarkdown(posts.slice(0, 10), keyword)
+      const md = generateDocbaseMarkdownForPreview(posts.slice(0, 10), keyword)
       setMarkdownContent(md)
     } else {
       setMarkdownContent('')

--- a/src/features/docbase/components/DocbaseTokenInput.tsx
+++ b/src/features/docbase/components/DocbaseTokenInput.tsx
@@ -1,16 +1,16 @@
-import React, { type FC, forwardRef, useImperativeHandle, useRef } from 'react'
+import React, { type FC, forwardRef, useImperativeHandle, useRef } from "react";
 
 type DocbaseTokenInputProps = {
-  token: string
-  onTokenChange: (token: string) => void
-  error?: string
-  disabled?: boolean
-}
+  token: string;
+  onTokenChange: (token: string) => void;
+  error?: string;
+  disabled?: boolean;
+};
 
 // focusメソッドを持つRefの型を定義
 export type DocbaseTokenInputRef = {
-  focus: () => void
-}
+  focus: () => void;
+};
 
 /**
  * Docbaseアクセストークン入力コンポーネント
@@ -19,39 +19,43 @@ export type DocbaseTokenInputRef = {
  * @param error エラーメッセージ
  * @param disabled 非活性状態にするかどうか
  */
-export const DocbaseTokenInput = forwardRef<DocbaseTokenInputRef, DocbaseTokenInputProps>(
-  ({ token, onTokenChange, error, disabled }, ref) => {
-    const inputRef = useRef<HTMLInputElement>(null) // input要素への参照を作成
+export const DocbaseTokenInput = forwardRef<
+  DocbaseTokenInputRef,
+  DocbaseTokenInputProps
+>(({ token, onTokenChange, error, disabled }, ref) => {
+  const inputRef = useRef<HTMLInputElement>(null); // input要素への参照を作成
 
-    // 親コンポーネントから呼び出せるメソッドを定義
-    useImperativeHandle(ref, () => ({
-      focus: () => {
-        inputRef.current?.focus()
-      },
-    }))
+  // 親コンポーネントから呼び出せるメソッドを定義
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      inputRef.current?.focus();
+    },
+  }));
 
-    return (
-      <div className="mb-4">
-        <label htmlFor="docbase-token" className="block text-base font-medium text-docbase-text mb-1">
-          Docbase APIトークン
-        </label>
-        <input
-          type="password"
-          id="docbase-token"
-          ref={inputRef} // input要素にrefを渡す
-          value={token}
-          onChange={(e) => onTokenChange(e.target.value)}
-          placeholder="APIトークンを入力"
-          disabled={disabled}
-          className={`block w-full px-4 py-3 border ${error ? 'border-red-500' : 'border-gray-400'} rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500' : 'focus:ring-docbase-primary focus:border-docbase-primary'} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
-          aria-describedby={error ? 'docbase-token-error' : undefined}
-        />
-        {error && (
-          <p id="docbase-token-error" className="mt-1 text-xs text-red-600">
-            {error}
-          </p>
-        )}
-      </div>
-    )
-  },
-)
+  return (
+    <div className="mb-4">
+      <label
+        htmlFor="docbase-token"
+        className="block text-base font-medium text-docbase-text mb-1"
+      >
+        Docbase APIトークン
+      </label>
+      <input
+        type="password"
+        id="docbase-token"
+        ref={inputRef} // input要素にrefを渡す
+        value={token}
+        onChange={(e) => onTokenChange(e.target.value)}
+        placeholder="APIトークンを入力"
+        disabled={disabled}
+        className={`block w-full px-4 py-3 border ${error ? "border-red-500" : "border-gray-400"} rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 ${error ? "focus:ring-red-500 focus:border-red-500" : "focus:ring-docbase-primary focus:border-docbase-primary"} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
+        aria-describedby={error ? "docbase-token-error" : undefined}
+      />
+      {error && (
+        <p id="docbase-token-error" className="mt-1 text-xs text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+});

--- a/src/features/docbase/hooks/useDocbaseSearch.ts
+++ b/src/features/docbase/hooks/useDocbaseSearch.ts
@@ -1,105 +1,129 @@
-import type { Result } from 'neverthrow' // Resultを型としてインポート (typeキーワードを明示)
-import { useCallback, useState } from 'react'
-import toast from 'react-hot-toast' // react-hot-toastをインポート
-import { createFetchHttpClient } from '../../../adapters/fetchHttpClient'
-import type { ApiError } from '../../../types/error'
-import { getErrorActionSuggestion, getUserFriendlyErrorMessage } from '../../../utils/errorMessage'
-import { type DocbaseAdapter, createDocbaseAdapter } from '../adapters/docbaseAdapter'
-import type { DocbasePostListItem } from '../types/docbase'
+import type { Result } from "neverthrow"; // Resultを型としてインポート (typeキーワードを明示)
+import { useCallback, useState } from "react";
+import toast from "react-hot-toast"; // react-hot-toastをインポート
+import { createFetchHttpClient } from "../../../adapters/fetchHttpClient";
+import type { ApiError } from "../../../types/error";
+import {
+  getErrorActionSuggestion,
+  getUserFriendlyErrorMessage,
+} from "../../../utils/errorMessage";
+import {
+  type DocbaseAdapter,
+  createDocbaseAdapter,
+} from "../adapters/docbaseAdapter";
+import type { DocbasePostListItem } from "../types/docbase";
 
 // 詳細検索条件の型定義（forms.tsからインポートして再エクスポート）
-import type { AdvancedFilters } from '../types/forms'
-export type { AdvancedFilters }
+import type { AdvancedFilters } from "../types/forms";
+export type { AdvancedFilters };
 
 interface UseDocbaseSearchResult {
-  posts: DocbasePostListItem[]
-  isLoading: boolean
-  error: ApiError | null
+  posts: DocbasePostListItem[];
+  isLoading: boolean;
+  error: ApiError | null;
   searchPosts: (
     domain: string,
     token: string,
     keyword: string,
-    advancedFilters?: AdvancedFilters, // advancedFilters をオプションで追加
-  ) => Promise<void>
-  canRetry: boolean // 再試行可能かどうかのフラグ
-  retrySearch: () => void // 再試行用の関数
-  getUserFriendlyError: () => string | null // ユーザーフレンドリーエラーメッセージ
-  getErrorSuggestion: () => string | null // エラーアクション提案
+    advancedFilters?: AdvancedFilters // advancedFilters をオプションで追加
+  ) => Promise<void>;
+  canRetry: boolean; // 再試行可能かどうかのフラグ
+  retrySearch: () => void; // 再試行用の関数
+  getUserFriendlyError: () => string | null; // ユーザーフレンドリーエラーメッセージ
+  getErrorSuggestion: () => string | null; // エラーアクション提案
 }
 
 interface UseDocbaseSearchOptions {
-  adapter?: DocbaseAdapter // アダプターを注入可能にする（テスト用）
+  adapter?: DocbaseAdapter; // アダプターを注入可能にする（テスト用）
 }
 
 /**
  * Docbaseの投稿を検索するためのカスタムフック
  */
-export const useDocbaseSearch = (options?: UseDocbaseSearchOptions): UseDocbaseSearchResult => {
+export const useDocbaseSearch = (
+  options?: UseDocbaseSearchOptions
+): UseDocbaseSearchResult => {
   // アダプターの初期化（注入されていない場合はデフォルトを使用）
-  const adapter = options?.adapter || createDocbaseAdapter(createFetchHttpClient())
-  const [posts, setPosts] = useState<DocbasePostListItem[]>([])
-  const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [error, setError] = useState<ApiError | null>(null)
+  const adapter =
+    options?.adapter || createDocbaseAdapter(createFetchHttpClient());
+  const [posts, setPosts] = useState<DocbasePostListItem[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<ApiError | null>(null);
   const [lastSearchParams, setLastSearchParams] = useState<{
-    domain: string
-    token: string
-    keyword: string
-    advancedFilters?: AdvancedFilters // advancedFilters を追加
-  } | null>(null)
-  const [canRetry, setCanRetry] = useState<boolean>(false)
+    domain: string;
+    token: string;
+    keyword: string;
+    advancedFilters?: AdvancedFilters; // advancedFilters を追加
+  } | null>(null);
+  const [canRetry, setCanRetry] = useState<boolean>(false);
 
   const executeSearch = useCallback(
-    async (domain: string, token: string, keyword: string, advancedFilters?: AdvancedFilters) => {
-      setIsLoading(true)
-      setError(null)
-      setCanRetry(false)
-      setLastSearchParams({ domain, token, keyword, advancedFilters }) // 最後に検索したパラメータを保存
+    async (
+      domain: string,
+      token: string,
+      keyword: string,
+      advancedFilters?: AdvancedFilters
+    ) => {
+      setIsLoading(true);
+      setError(null);
+      setCanRetry(false);
+      setLastSearchParams({ domain, token, keyword, advancedFilters }); // 最後に検索したパラメータを保存
 
-      const result: Result<DocbasePostListItem[], ApiError> = await adapter.searchPosts({
-        domain,
-        token,
-        keyword,
-        advancedFilters, // advancedFilters を渡す
-      })
+      const result: Result<DocbasePostListItem[], ApiError> =
+        await adapter.searchPosts({
+          domain,
+          token,
+          keyword,
+          advancedFilters, // advancedFilters を渡す
+        });
 
       if (result.isOk()) {
-        setPosts(result.value)
-        if (result.value.length === 0 && keyword.trim() !== '') {
-          toast.success('検索結果が見つかりませんでした。')
+        setPosts(result.value);
+        if (result.value.length === 0 && keyword.trim() !== "") {
+          toast.success("検索結果が見つかりませんでした。");
         }
       } else {
-        const apiError = result.error
-        setError(apiError)
-        setPosts([])
+        const apiError = result.error;
+        setError(apiError);
+        setPosts([]);
         // ユーザーフレンドリーなエラーメッセージでトースト通知
-        const friendlyMessage = getUserFriendlyErrorMessage(apiError)
-        toast.error(friendlyMessage)
+        const friendlyMessage = getUserFriendlyErrorMessage(apiError);
+        toast.error(friendlyMessage);
 
         // リトライ可能なエラーの場合は手動再試行を許可
-        if (apiError.type === 'rate_limit' || apiError.type === 'network' || apiError.type === 'unknown') {
-          setCanRetry(true)
+        if (
+          apiError.type === "rate_limit" ||
+          apiError.type === "network" ||
+          apiError.type === "unknown"
+        ) {
+          setCanRetry(true);
         }
       }
-      setIsLoading(false)
+      setIsLoading(false);
     },
-    [adapter],
-  )
+    [adapter]
+  );
 
   const searchPosts = useCallback(
-    async (domain: string, token: string, keyword: string, advancedFilters?: AdvancedFilters) => {
+    async (
+      domain: string,
+      token: string,
+      keyword: string,
+      advancedFilters?: AdvancedFilters
+    ) => {
       if (!keyword.trim() && !domain.trim() && !token.trim()) {
         // 全て空なら何もしない
-        setPosts([])
-        setError(null)
-        setCanRetry(false)
-        return
+        setPosts([]);
+        setError(null);
+        setCanRetry(false);
+        return;
       }
       if (!domain.trim() || !token.trim()) {
-        toast.error('Docbaseドメインとトークンを入力してください。')
-        setPosts([])
-        setError(null)
-        setCanRetry(false)
-        return
+        toast.error("Docbaseドメインとトークンを入力してください。");
+        setPosts([]);
+        setError(null);
+        setCanRetry(false);
+        return;
       }
       if (
         !keyword.trim() &&
@@ -109,44 +133,46 @@ export const useDocbaseSearch = (options?: UseDocbaseSearchOptions): UseDocbaseS
         !advancedFilters?.startDate?.trim() &&
         !advancedFilters?.endDate?.trim()
       ) {
-        toast.success('キーワードまたは詳細検索条件を入力して検索してください。') // 検索前にキーワードが空ならメッセージ表示
-        setPosts([])
-        setError(null)
-        setCanRetry(false)
-        return
+        toast.success(
+          "キーワードまたは詳細検索条件を入力して検索してください。"
+        ); // 検索前にキーワードが空ならメッセージ表示
+        setPosts([]);
+        setError(null);
+        setCanRetry(false);
+        return;
       }
-      await executeSearch(domain, token, keyword, advancedFilters) // advancedFilters を渡す
+      await executeSearch(domain, token, keyword, advancedFilters); // advancedFilters を渡す
     },
-    [executeSearch],
-  )
+    [executeSearch]
+  );
 
   const retrySearch = useCallback(() => {
     if (lastSearchParams) {
-      toast.dismiss() // 既存のエラートーストを消す
+      toast.dismiss(); // 既存のエラートーストを消す
       executeSearch(
         lastSearchParams.domain,
         lastSearchParams.token,
         lastSearchParams.keyword,
-        lastSearchParams.advancedFilters, // advancedFilters を渡す
-      )
+        lastSearchParams.advancedFilters // advancedFilters を渡す
+      );
     }
-  }, [lastSearchParams, executeSearch])
+  }, [lastSearchParams, executeSearch]);
 
   /**
    * ユーザーフレンドリーなエラーメッセージを取得
    */
   const getUserFriendlyError = useCallback((): string | null => {
-    if (!error) return null
-    return getUserFriendlyErrorMessage(error)
-  }, [error])
+    if (!error) return null;
+    return getUserFriendlyErrorMessage(error);
+  }, [error]);
 
   /**
    * エラーに対するアクション提案を取得
    */
   const getErrorSuggestion = useCallback((): string | null => {
-    if (!error) return null
-    return getErrorActionSuggestion(error)
-  }, [error])
+    if (!error) return null;
+    return getErrorActionSuggestion(error);
+  }, [error]);
 
   return {
     posts,
@@ -157,5 +183,5 @@ export const useDocbaseSearch = (options?: UseDocbaseSearchOptions): UseDocbaseS
     retrySearch,
     getUserFriendlyError,
     getErrorSuggestion,
-  }
-}
+  };
+};

--- a/src/features/docbase/types/docbase.ts
+++ b/src/features/docbase/types/docbase.ts
@@ -2,39 +2,39 @@
  * Docbaseユーザー情報の型定義
  */
 export type DocbaseUser = {
-  id: number
-  name: string
-  profile_image_url: string
-}
+  id: number;
+  name: string;
+  profile_image_url: string;
+};
 
 /**
  * Docbaseタグ情報の型定義
  */
 export type DocbaseTag = {
-  name: string
-}
+  name: string;
+};
 
 /**
  * Docbaseグループ情報の型定義
  */
 export type DocbaseGroup = {
-  id: number
-  name: string
-}
+  id: number;
+  name: string;
+};
 
 /**
  * Docbaseの投稿情報を表す型定義
  */
 export type DocbasePostListItem = {
-  id: number
-  title: string
-  body: string
-  created_at: string // ISO-8601形式の文字列
-  url: string
-  user: DocbaseUser
-  tags: DocbaseTag[]
-  groups: DocbaseGroup[]
-  scope: string
+  id: number;
+  title: string;
+  body: string;
+  created_at: string; // ISO-8601形式の文字列
+  url: string;
+  user: DocbaseUser;
+  tags: DocbaseTag[];
+  groups: DocbaseGroup[];
+  scope: string;
   // APIレスポンスには他にも多くのフィールドがあるが、今回は必要なもののみ定義
   // 必要に応じて追加する
   // comments: [ ... ],
@@ -42,16 +42,16 @@ export type DocbasePostListItem = {
   // archieved: boolean,
   // sharing_url: string | null,
   // organization: { ... }
-}
+};
 
 /**
  * Docbase APIの投稿リスト取得レスポンスの型定義
  */
 export type DocbasePostsResponse = {
-  posts: DocbasePostListItem[]
+  posts: DocbasePostListItem[];
   meta: {
-    previous_page: string | null
-    next_page: string | null
-    total: number
-  }
-}
+    previous_page: string | null;
+    next_page: string | null;
+    total: number;
+  };
+};

--- a/src/features/docbase/types/docbase.ts
+++ b/src/features/docbase/types/docbase.ts
@@ -14,13 +14,6 @@ export type DocbaseTag = {
   name: string;
 };
 
-/**
- * Docbaseグループ情報の型定義
- */
-export type DocbaseGroup = {
-  id: number;
-  name: string;
-};
 
 /**
  * Docbaseの投稿情報を表す型定義
@@ -33,7 +26,6 @@ export type DocbasePostListItem = {
   url: string;
   user: DocbaseUser;
   tags: DocbaseTag[];
-  groups: DocbaseGroup[];
   scope: string;
   // APIレスポンスには他にも多くのフィールドがあるが、今回は必要なもののみ定義
   // 必要に応じて追加する

--- a/src/features/docbase/types/docbase.ts
+++ b/src/features/docbase/types/docbase.ts
@@ -14,7 +14,6 @@ export type DocbaseTag = {
   name: string;
 };
 
-
 /**
  * Docbaseの投稿情報を表す型定義
  */

--- a/src/features/docbase/types/forms.ts
+++ b/src/features/docbase/types/forms.ts
@@ -4,18 +4,18 @@
 
 // 詳細検索条件の型定義
 export interface AdvancedFilters {
-  tags: string
-  author: string
-  titleFilter: string
-  startDate: string
-  endDate: string
-  group: string
+  tags: string;
+  author: string;
+  titleFilter: string;
+  startDate: string;
+  endDate: string;
+  group: string;
 }
 
 // フォーム入力値の型定義
 export interface DocbaseFormValues {
-  keyword: string
-  domain: string
-  token: string
-  advancedFilters: AdvancedFilters
+  keyword: string;
+  domain: string;
+  token: string;
+  advancedFilters: AdvancedFilters;
 }

--- a/src/features/docbase/types/forms.ts
+++ b/src/features/docbase/types/forms.ts
@@ -9,7 +9,6 @@ export interface AdvancedFilters {
   titleFilter: string;
   startDate: string;
   endDate: string;
-  group: string;
 }
 
 // フォーム入力値の型定義

--- a/src/features/docbase/utils/docbaseMarkdownGenerator.ts
+++ b/src/features/docbase/utils/docbaseMarkdownGenerator.ts
@@ -171,6 +171,6 @@ export const generateDocbaseMarkdownForPreview = (
 
         return articleMd;
       })
-      .join("---\n\n")
+      .join("---\n\n\n")
   );
 };

--- a/src/features/docbase/utils/docbaseMarkdownGenerator.ts
+++ b/src/features/docbase/utils/docbaseMarkdownGenerator.ts
@@ -94,11 +94,6 @@ export const generateDocbaseMarkdown = (
             .map((tag) => tag.name)
             .join(", ")}\n`;
         }
-        if (post.groups.length > 0) {
-          articleMd += `**Groups**: ${post.groups
-            .map((group) => group.name)
-            .join(", ")}\n`;
-        }
         articleMd += `**URL**: [View Original](${post.url})\n\n`;
 
         // HTMLコメントで記事コンテンツの境界を明確化
@@ -152,11 +147,6 @@ export const generateDocbaseMarkdownForPreview = (
         if (post.tags.length > 0) {
           articleMd += `**タグ**: ${post.tags
             .map((tag) => tag.name)
-            .join(", ")}  \n`;
-        }
-        if (post.groups.length > 0) {
-          articleMd += `**グループ**: ${post.groups
-            .map((group) => group.name)
             .join(", ")}  \n`;
         }
         articleMd += "\n";

--- a/src/features/docbase/utils/docbaseMarkdownGenerator.ts
+++ b/src/features/docbase/utils/docbaseMarkdownGenerator.ts
@@ -98,3 +98,65 @@ export const generateDocbaseMarkdown = (posts: DocbasePostListItem[], searchKeyw
       .join('---\n\n')
   ) // 各記事の間を水平線で区切る
 }
+
+/**
+ * Docbaseの投稿リストからプレビュー用Markdown文字列を生成する関数
+ * パット見で記事内容を確認できることを目的とした簡潔な表示
+ * @param posts DocbasePostListItemの配列（プレビューでは最初の10件のみ）
+ * @param searchKeyword 検索キーワード（ヘッダー表示用）
+ * @returns プレビュー最適化Markdown文字列
+ */
+export const generateDocbaseMarkdownForPreview = (posts: DocbasePostListItem[], searchKeyword?: string): string => {
+  if (!posts || posts.length === 0) {
+    return ''
+  }
+
+  // プレビュー用の簡潔なヘッダー
+  let markdown = '# Docbase 記事プレビュー\n\n'
+  
+  if (searchKeyword) {
+    markdown += `**検索キーワード**: ${searchKeyword}\n\n`
+  }
+  
+  markdown += `**記事数**: ${posts.length}件\n\n`
+  markdown += '---\n\n'
+
+  // 各記事のプレビュー表示
+  return (
+    markdown +
+    posts
+      .map((post, index) => {
+        // 簡潔な日付フォーマット（例：2024/03/15）
+        const date = new Date(post.created_at)
+        const simpleDate = date.toLocaleDateString('ja-JP', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+        })
+
+        // 記事タイトル
+        let articleMd = `## ${post.title}\n\n`
+
+        // メタデータを記事タイトル直下に表示
+        articleMd += `**作成日**: ${simpleDate}  \n`
+        articleMd += `**作成者**: ${post.user.name}  \n`
+        if (post.tags.length > 0) {
+          articleMd += `**タグ**: ${post.tags.map((tag) => tag.name).join(', ')}  \n`
+        }
+        if (post.groups.length > 0) {
+          articleMd += `**グループ**: ${post.groups.map((group) => group.name).join(', ')}  \n`
+        }
+        articleMd += '\n'
+
+        // 記事内容を150文字程度で切り詰め
+        const truncatedBody = post.body.length > 150 
+          ? `${post.body.substring(0, 150)}...` 
+          : post.body
+        
+        articleMd += `${truncatedBody}\n\n`
+
+        return articleMd
+      })
+      .join('---\n\n')
+  )
+}

--- a/src/features/docbase/utils/docbaseMarkdownGenerator.ts
+++ b/src/features/docbase/utils/docbaseMarkdownGenerator.ts
@@ -112,12 +112,12 @@ export const generateDocbaseMarkdownForPreview = (posts: DocbasePostListItem[], 
   }
 
   // プレビュー用の簡潔なヘッダー
-  let markdown = '# Docbase 記事プレビュー\n\n'
-  
+  let markdown = ''
+
   if (searchKeyword) {
     markdown += `**検索キーワード**: ${searchKeyword}\n\n`
   }
-  
+
   markdown += `**記事数**: ${posts.length}件\n\n`
   markdown += '---\n\n'
 
@@ -149,10 +149,8 @@ export const generateDocbaseMarkdownForPreview = (posts: DocbasePostListItem[], 
         articleMd += '\n'
 
         // 記事内容を150文字程度で切り詰め
-        const truncatedBody = post.body.length > 150 
-          ? `${post.body.substring(0, 150)}...` 
-          : post.body
-        
+        const truncatedBody = post.body.length > 150 ? `${post.body.substring(0, 150)}...` : post.body
+
         articleMd += `${truncatedBody}\n\n`
 
         return articleMd

--- a/src/features/docbase/utils/docbaseMarkdownGenerator.ts
+++ b/src/features/docbase/utils/docbaseMarkdownGenerator.ts
@@ -1,4 +1,4 @@
-import type { DocbasePostListItem } from '../types/docbase'
+import type { DocbasePostListItem } from "../types/docbase";
 
 /**
  * Docbaseの投稿リストからLLM最適化Markdown文字列を生成する関数
@@ -7,97 +7,110 @@ import type { DocbasePostListItem } from '../types/docbase'
  * @param searchKeyword 検索キーワード（メタデータとして記録）
  * @returns LLM最適化Markdown文字列
  */
-export const generateDocbaseMarkdown = (posts: DocbasePostListItem[], searchKeyword?: string): string => {
+export const generateDocbaseMarkdown = (
+  posts: DocbasePostListItem[],
+  searchKeyword?: string
+): string => {
   if (!posts || posts.length === 0) {
-    return '' // 投稿がない場合は空文字列を返す
+    return ""; // 投稿がない場合は空文字列を返す
   }
 
   // 全体のメタデータ作成
-  const dates = posts.map((post) => new Date(post.created_at))
-  const minDate = new Date(Math.min(...dates.map((d) => d.getTime())))
-  const maxDate = new Date(Math.max(...dates.map((d) => d.getTime())))
+  const dates = posts.map((post) => new Date(post.created_at));
+  const minDate = new Date(Math.min(...dates.map((d) => d.getTime())));
+  const maxDate = new Date(Math.max(...dates.map((d) => d.getTime())));
 
   // YAML Front Matter形式で全体メタデータ
-  let markdown = '---\n'
-  markdown += `source: "docbase"\n`
-  markdown += `total_articles: ${posts.length}\n`
+  let markdown = "---\n";
+  markdown += `source: "docbase"\n`;
+  markdown += `total_articles: ${posts.length}\n`;
   if (searchKeyword) {
-    markdown += `search_keyword: "${searchKeyword}"\n`
+    markdown += `search_keyword: "${searchKeyword}"\n`;
   }
-  markdown += `date_range: "${minDate.toISOString().split('T')[0]} - ${maxDate.toISOString().split('T')[0]}"\n`
-  markdown += `generated_at: "${new Date().toISOString()}"\n`
-  markdown += '---\n\n'
+  markdown += `date_range: "${minDate.toISOString().split("T")[0]} - ${
+    maxDate.toISOString().split("T")[0]
+  }"\n`;
+  markdown += `generated_at: "${new Date().toISOString()}"\n`;
+  markdown += "---\n\n";
 
   // LLM理解しやすいタイトル
   const dateRange =
-    minDate.toLocaleDateString('ja-JP') === maxDate.toLocaleDateString('ja-JP')
-      ? minDate.toLocaleDateString('ja-JP')
-      : `${minDate.toLocaleDateString('ja-JP')} - ${maxDate.toLocaleDateString('ja-JP')}`
+    minDate.toLocaleDateString("ja-JP") === maxDate.toLocaleDateString("ja-JP")
+      ? minDate.toLocaleDateString("ja-JP")
+      : `${minDate.toLocaleDateString("ja-JP")} - ${maxDate.toLocaleDateString(
+          "ja-JP"
+        )}`;
 
-  markdown += '# Docbase Articles Collection\n\n'
+  markdown += "# Docbase Articles Collection\n\n";
 
-  markdown += '## Collection Overview\n'
-  markdown += `- **Total Articles**: ${posts.length}\n`
+  markdown += "## Collection Overview\n";
+  markdown += `- **Total Articles**: ${posts.length}\n`;
   if (searchKeyword) {
-    markdown += `- **Search Keyword**: "${searchKeyword}"\n`
+    markdown += `- **Search Keyword**: "${searchKeyword}"\n`;
   }
-  markdown += `- **Date Range**: ${dateRange}\n`
-  markdown += '- **Source**: Docbase Knowledge Base\n\n'
+  markdown += `- **Date Range**: ${dateRange}\n`;
+  markdown += "- **Source**: Docbase Knowledge Base\n\n";
 
   // 目次
-  markdown += '## Articles Index\n\n'
+  markdown += "## Articles Index\n\n";
   posts.forEach((post, index) => {
-    const date = new Date(post.created_at)
-    const formattedDate = date.toLocaleDateString('ja-JP')
-    markdown += `${index + 1}. [${post.title}](#article-${index + 1}) - ${formattedDate}\n`
-  })
-  markdown += '\n---\n\n'
+    const date = new Date(post.created_at);
+    const formattedDate = date.toLocaleDateString("ja-JP");
+    markdown += `${index + 1}. [${post.title}](#article-${
+      index + 1
+    }) - ${formattedDate}\n`;
+  });
+  markdown += "\n---\n\n";
 
   // 各記事の詳細
-  markdown += '## Articles Content\n\n'
+  markdown += "## Articles Content\n\n";
 
   return (
     markdown +
     posts
       .map((post, index) => {
         // 日付フォーマット
-        const date = new Date(post.created_at)
-        const isoDate = date.toISOString()
-        const displayDateWithTime = date.toLocaleDateString('ja-JP', {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-          weekday: 'long',
-          hour: '2-digit',
-          minute: '2-digit',
-          timeZone: 'Asia/Tokyo',
-        })
+        const date = new Date(post.created_at);
+        const isoDate = date.toISOString();
+        const displayDateWithTime = date.toLocaleDateString("ja-JP", {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          weekday: "long",
+          hour: "2-digit",
+          minute: "2-digit",
+          timeZone: "Asia/Tokyo",
+        });
 
         // 記事のメタデータをシンプルな形式で表示
-        let articleMd = `### Article ${index + 1}: ${post.title}\n\n`
+        let articleMd = `### Article ${index + 1}: ${post.title}\n\n`;
 
         // メタデータを改行区切りで表示
-        articleMd += `**Created**: ${displayDateWithTime}\n`
-        articleMd += `**Author**: ${post.user.name}\n`
-        articleMd += `**ID**: ${post.id}\n`
+        articleMd += `**Created**: ${displayDateWithTime}\n`;
+        articleMd += `**Author**: ${post.user.name}\n`;
+        articleMd += `**ID**: ${post.id}\n`;
         if (post.tags.length > 0) {
-          articleMd += `**Tags**: ${post.tags.map((tag) => tag.name).join(', ')}\n`
+          articleMd += `**Tags**: ${post.tags
+            .map((tag) => tag.name)
+            .join(", ")}\n`;
         }
         if (post.groups.length > 0) {
-          articleMd += `**Groups**: ${post.groups.map((group) => group.name).join(', ')}\n`
+          articleMd += `**Groups**: ${post.groups
+            .map((group) => group.name)
+            .join(", ")}\n`;
         }
-        articleMd += `**URL**: [View Original](${post.url})\n\n`
+        articleMd += `**URL**: [View Original](${post.url})\n\n`;
 
         // HTMLコメントで記事コンテンツの境界を明確化
-        articleMd += '<!-- DOCBASE_CONTENT_START -->\n'
-        articleMd += `${post.body}\n`
-        articleMd += '<!-- DOCBASE_CONTENT_END -->\n\n'
+        articleMd += "<!-- DOCBASE_CONTENT_START -->\n";
+        articleMd += `${post.body}\n`;
+        articleMd += "<!-- DOCBASE_CONTENT_END -->\n\n";
 
-        return articleMd
+        return articleMd;
       })
-      .join('---\n\n')
-  ) // 各記事の間を水平線で区切る
-}
+      .join("---\n\n")
+  ); // 各記事の間を水平線で区切る
+};
 
 /**
  * Docbaseの投稿リストからプレビュー用Markdown文字列を生成する関数
@@ -106,20 +119,16 @@ export const generateDocbaseMarkdown = (posts: DocbasePostListItem[], searchKeyw
  * @param searchKeyword 検索キーワード（ヘッダー表示用）
  * @returns プレビュー最適化Markdown文字列
  */
-export const generateDocbaseMarkdownForPreview = (posts: DocbasePostListItem[], searchKeyword?: string): string => {
+export const generateDocbaseMarkdownForPreview = (
+  posts: DocbasePostListItem[],
+  searchKeyword?: string
+): string => {
   if (!posts || posts.length === 0) {
-    return ''
+    return "";
   }
 
   // プレビュー用の簡潔なヘッダー
-  let markdown = ''
-
-  if (searchKeyword) {
-    markdown += `**検索キーワード**: ${searchKeyword}\n\n`
-  }
-
-  markdown += `**記事数**: ${posts.length}件\n\n`
-  markdown += '---\n\n'
+  const markdown = "";
 
   // 各記事のプレビュー表示
   return (
@@ -127,34 +136,41 @@ export const generateDocbaseMarkdownForPreview = (posts: DocbasePostListItem[], 
     posts
       .map((post, index) => {
         // 簡潔な日付フォーマット（例：2024/03/15）
-        const date = new Date(post.created_at)
-        const simpleDate = date.toLocaleDateString('ja-JP', {
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-        })
+        const date = new Date(post.created_at);
+        const simpleDate = date.toLocaleDateString("ja-JP", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+        });
 
         // 記事タイトル
-        let articleMd = `## ${post.title}\n\n`
+        let articleMd = `## ${post.title}\n\n`;
 
         // メタデータを記事タイトル直下に表示
-        articleMd += `**作成日**: ${simpleDate}  \n`
-        articleMd += `**作成者**: ${post.user.name}  \n`
+        articleMd += `**作成日**: ${simpleDate}  \n`;
+        articleMd += `**作成者**: ${post.user.name}  \n`;
         if (post.tags.length > 0) {
-          articleMd += `**タグ**: ${post.tags.map((tag) => tag.name).join(', ')}  \n`
+          articleMd += `**タグ**: ${post.tags
+            .map((tag) => tag.name)
+            .join(", ")}  \n`;
         }
         if (post.groups.length > 0) {
-          articleMd += `**グループ**: ${post.groups.map((group) => group.name).join(', ')}  \n`
+          articleMd += `**グループ**: ${post.groups
+            .map((group) => group.name)
+            .join(", ")}  \n`;
         }
-        articleMd += '\n'
+        articleMd += "\n";
 
         // 記事内容を150文字程度で切り詰め
-        const truncatedBody = post.body.length > 150 ? `${post.body.substring(0, 150)}...` : post.body
+        const truncatedBody =
+          post.body.length > 150
+            ? `${post.body.substring(0, 150)}...`
+            : post.body;
 
-        articleMd += `${truncatedBody}\n\n`
+        articleMd += `${truncatedBody}\n\n`;
 
-        return articleMd
+        return articleMd;
       })
-      .join('---\n\n')
-  )
-}
+      .join("---\n\n")
+  );
+};

--- a/src/features/slack/adapters/slackAdapter.ts
+++ b/src/features/slack/adapters/slackAdapter.ts
@@ -1,58 +1,58 @@
 // Slack APIアダプター実装
 // HTTPクライアントアダプターを使用してSlack APIにアクセスし、Result型で結果を返す
 
-import { type Result, err, ok } from 'neverthrow'
-import type { HttpClient } from '../../../adapters/types'
-import type { ApiError } from '../../../types/error'
-import type { SlackMessage, SlackThread, SlackUser } from '../types/slack'
+import { type Result, err, ok } from "neverthrow";
+import type { HttpClient } from "../../../adapters/types";
+import type { ApiError } from "../../../types/error";
+import type { SlackMessage, SlackThread, SlackUser } from "../types/slack";
 
 /**
  * Slack検索パラメータ
  */
 export interface SlackSearchParams {
-  token: string
-  query: string
-  count?: number
-  page?: number
+  token: string;
+  query: string;
+  count?: number;
+  page?: number;
 }
 
 /**
  * Slackスレッド取得パラメータ
  */
 export interface SlackThreadParams {
-  token: string
-  channel: string
-  threadTs: string
+  token: string;
+  channel: string;
+  threadTs: string;
 }
 
 /**
  * Slackパーマリンク取得パラメータ
  */
 export interface SlackPermalinkParams {
-  token: string
-  channel: string
-  messageTs: string
+  token: string;
+  channel: string;
+  messageTs: string;
 }
 
 /**
  * Slackユーザー情報取得パラメータ
  */
 export interface SlackUserParams {
-  token: string
-  userId: string
+  token: string;
+  userId: string;
 }
 
 /**
  * Slack検索成功レスポンス
  */
 export interface SlackSearchResponse {
-  messages: SlackMessage[]
+  messages: SlackMessage[];
   pagination: {
-    currentPage: number
-    totalPages: number
-    totalResults: number
-    perPage: number
-  }
+    currentPage: number;
+    totalPages: number;
+    totalResults: number;
+    perPage: number;
+  };
 }
 
 /**
@@ -64,28 +64,32 @@ export interface SlackAdapter {
    * @param params 検索パラメータ
    * @returns Promise<Result<SlackSearchResponse, ApiError>>
    */
-  searchMessages(params: SlackSearchParams): Promise<Result<SlackSearchResponse, ApiError>>
+  searchMessages(
+    params: SlackSearchParams
+  ): Promise<Result<SlackSearchResponse, ApiError>>;
 
   /**
    * スレッド全体（親＋返信）を取得する
    * @param params スレッド取得パラメータ
    * @returns Promise<Result<SlackThread, ApiError>>
    */
-  getThreadMessages(params: SlackThreadParams): Promise<Result<SlackThread, ApiError>>
+  getThreadMessages(
+    params: SlackThreadParams
+  ): Promise<Result<SlackThread, ApiError>>;
 
   /**
    * メッセージのパーマリンクを取得する
    * @param params パーマリンク取得パラメータ
    * @returns Promise<Result<string, ApiError>>
    */
-  getPermalink(params: SlackPermalinkParams): Promise<Result<string, ApiError>>
+  getPermalink(params: SlackPermalinkParams): Promise<Result<string, ApiError>>;
 
   /**
    * ユーザー情報を取得する
    * @param params ユーザー情報取得パラメータ
    * @returns Promise<Result<SlackUser, ApiError>>
    */
-  getUserInfo(params: SlackUserParams): Promise<Result<SlackUser, ApiError>>
+  getUserInfo(params: SlackUserParams): Promise<Result<SlackUser, ApiError>>;
 
   /**
    * メッセージリストからスレッドを構築する
@@ -93,7 +97,10 @@ export interface SlackAdapter {
    * @param token APIトークン
    * @returns Promise<Result<SlackThread[], ApiError>>
    */
-  buildThreadsFromMessages(messages: SlackMessage[], token: string): Promise<Result<SlackThread[], ApiError>>
+  buildThreadsFromMessages(
+    messages: SlackMessage[],
+    token: string
+  ): Promise<Result<SlackThread[], ApiError>>;
 
   /**
    * スレッドリストからユーザーマップを取得する
@@ -101,7 +108,10 @@ export interface SlackAdapter {
    * @param token APIトークン
    * @returns Promise<Result<Record<string, string>, ApiError>>
    */
-  fetchUserMaps(threads: SlackThread[], token: string): Promise<Result<Record<string, string>, ApiError>>
+  fetchUserMaps(
+    threads: SlackThread[],
+    token: string
+  ): Promise<Result<Record<string, string>, ApiError>>;
 
   /**
    * スレッドリストからパーマリンクマップを生成する
@@ -109,7 +119,10 @@ export interface SlackAdapter {
    * @param token APIトークン
    * @returns Promise<Result<Record<string, string>, ApiError>>
    */
-  generatePermalinkMaps(threads: SlackThread[], token: string): Promise<Result<Record<string, string>, ApiError>>
+  generatePermalinkMaps(
+    threads: SlackThread[],
+    token: string
+  ): Promise<Result<Record<string, string>, ApiError>>;
 
   /**
    * スレッドリストからMarkdownを生成する
@@ -123,8 +136,8 @@ export interface SlackAdapter {
     threads: SlackThread[],
     userMaps: Record<string, string>,
     permalinkMaps: Record<string, string>,
-    searchQuery: string,
-  ): Promise<Result<string, ApiError>>
+    searchQuery: string
+  ): Promise<Result<string, ApiError>>;
 }
 
 /**
@@ -133,17 +146,19 @@ export interface SlackAdapter {
  * @returns SlackAdapter の実装
  */
 export function createSlackAdapter(httpClient: HttpClient): SlackAdapter {
-  const API_BASE_URL = 'https://slack.com/api'
+  const API_BASE_URL = "https://slack.com/api";
 
   return {
-    async searchMessages(params: SlackSearchParams): Promise<Result<SlackSearchResponse, ApiError>> {
-      const { token, query, count = 20, page = 1 } = params
+    async searchMessages(
+      params: SlackSearchParams
+    ): Promise<Result<SlackSearchResponse, ApiError>> {
+      const { token, query, count = 20, page = 1 } = params;
 
       if (!token || !query) {
         return err({
-          type: 'validation',
-          message: 'トークンと検索クエリは必須です。',
-        })
+          type: "validation",
+          message: "トークンと検索クエリは必須です。",
+        });
       }
 
       const formParams = new URLSearchParams({
@@ -151,153 +166,171 @@ export function createSlackAdapter(httpClient: HttpClient): SlackAdapter {
         query,
         count: count.toString(),
         page: page.toString(),
-      })
+      });
 
-      const result = await httpClient.fetch<SlackApiResponse>(`${API_BASE_URL}/search.messages`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: formParams.toString(),
-      })
+      const result = await httpClient.fetch<SlackApiResponse>(
+        `${API_BASE_URL}/search.messages`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: formParams.toString(),
+        }
+      );
 
       if (result.isErr()) {
-        return err(result.error)
+        return err(result.error);
       }
 
-      const data = result.value
+      const data = result.value;
 
       // Slack API特有のエラーチェック
       if (!data.ok) {
-        const errorCode = data.error || 'unknown_error'
-        return err(mapSlackErrorToApiError(errorCode))
+        const errorCode = data.error || "unknown_error";
+        return err(mapSlackErrorToApiError(errorCode));
       }
 
       // メッセージとページネーション情報の抽出
-      const messages = extractMessagesFromResponse(data)
-      const pagination = extractPaginationFromResponse(data, count)
+      const messages = extractMessagesFromResponse(data);
+      const pagination = extractPaginationFromResponse(data, count);
 
-      return ok({ messages, pagination })
+      return ok({ messages, pagination });
     },
 
-    async getThreadMessages(params: SlackThreadParams): Promise<Result<SlackThread, ApiError>> {
-      const { token, channel, threadTs } = params
+    async getThreadMessages(
+      params: SlackThreadParams
+    ): Promise<Result<SlackThread, ApiError>> {
+      const { token, channel, threadTs } = params;
 
       const formParams = new URLSearchParams({
         token,
         channel,
         ts: threadTs,
-      })
+      });
 
-      const result = await httpClient.fetch<SlackApiResponse>(`${API_BASE_URL}/conversations.replies`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: formParams.toString(),
-      })
+      const result = await httpClient.fetch<SlackApiResponse>(
+        `${API_BASE_URL}/conversations.replies`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: formParams.toString(),
+        }
+      );
 
       if (result.isErr()) {
-        return err(result.error)
+        return err(result.error);
       }
 
-      const data = result.value
+      const data = result.value;
 
       if (!data.ok) {
-        const errorCode = data.error || 'unknown_error'
-        return err(mapSlackErrorToApiError(errorCode))
+        const errorCode = data.error || "unknown_error";
+        return err(mapSlackErrorToApiError(errorCode));
       }
 
       // メッセージリストを抽出
-      const messages = extractThreadMessagesFromResponse(data, channel)
+      const messages = extractThreadMessagesFromResponse(data, channel);
       if (messages.length === 0) {
         return err({
-          type: 'notFound',
-          message: 'スレッドメッセージが見つかりません。',
-        })
+          type: "notFound",
+          message: "スレッドメッセージが見つかりません。",
+        });
       }
 
-      const parent = messages[0]
-      const replies = messages.slice(1)
+      const parent = messages[0];
+      const replies = messages.slice(1);
 
-      return ok({ channel, parent, replies })
+      return ok({ channel, parent, replies });
     },
 
-    async getPermalink(params: SlackPermalinkParams): Promise<Result<string, ApiError>> {
-      const { token, channel, messageTs } = params
+    async getPermalink(
+      params: SlackPermalinkParams
+    ): Promise<Result<string, ApiError>> {
+      const { token, channel, messageTs } = params;
 
       const url = `${API_BASE_URL}/chat.getPermalink?channel=${encodeURIComponent(
-        channel,
-      )}&message_ts=${encodeURIComponent(messageTs)}`
+        channel
+      )}&message_ts=${encodeURIComponent(messageTs)}`;
 
       const result = await httpClient.fetch<SlackApiResponse>(url, {
         headers: {
           Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/x-www-form-urlencoded',
+          "Content-Type": "application/x-www-form-urlencoded",
         },
-      })
+      });
 
       if (result.isErr()) {
-        return err(result.error)
+        return err(result.error);
       }
 
-      const data = result.value
+      const data = result.value;
 
       if (!data.ok) {
-        const errorCode = data.error || 'unknown_error'
-        return err(mapSlackErrorToApiError(errorCode))
+        const errorCode = data.error || "unknown_error";
+        return err(mapSlackErrorToApiError(errorCode));
       }
 
-      return ok(data.permalink as string)
+      return ok(data.permalink as string);
     },
 
-    async getUserInfo(params: SlackUserParams): Promise<Result<SlackUser, ApiError>> {
-      const { token, userId } = params
+    async getUserInfo(
+      params: SlackUserParams
+    ): Promise<Result<SlackUser, ApiError>> {
+      const { token, userId } = params;
 
       const formParams = new URLSearchParams({
         token,
         user: userId,
-      })
+      });
 
-      const result = await httpClient.fetch<SlackApiResponse>(`${API_BASE_URL}/users.info`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: formParams.toString(),
-      })
+      const result = await httpClient.fetch<SlackApiResponse>(
+        `${API_BASE_URL}/users.info`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: formParams.toString(),
+        }
+      );
 
       if (result.isErr()) {
-        return err(result.error)
+        return err(result.error);
       }
 
-      const data = result.value
+      const data = result.value;
 
       if (!data.ok) {
-        const errorCode = data.error || 'unknown_error'
-        return err(mapSlackErrorToApiError(errorCode))
+        const errorCode = data.error || "unknown_error";
+        return err(mapSlackErrorToApiError(errorCode));
       }
 
       const user: SlackUser = {
-        id: data.user?.id || '',
-        name: data.user?.name || '',
+        id: data.user?.id || "",
+        name: data.user?.name || "",
         real_name: data.user?.real_name,
-      }
+      };
 
-      return ok(user)
+      return ok(user);
     },
 
-    async buildThreadsFromMessages(messages: SlackMessage[], token: string): Promise<Result<SlackThread[], ApiError>> {
-      const threadMap = new Map<string, SlackThread>()
+    async buildThreadsFromMessages(
+      messages: SlackMessage[],
+      token: string
+    ): Promise<Result<SlackThread[], ApiError>> {
+      const threadMap = new Map<string, SlackThread>();
 
       for (const message of messages) {
-        const threadTs = message.thread_ts || message.ts
+        const threadTs = message.thread_ts || message.ts;
 
         if (threadMap.has(threadTs)) {
           // 既存スレッドに返信を追加
-          const thread = threadMap.get(threadTs)
+          const thread = threadMap.get(threadTs);
           if (thread && message.thread_ts) {
-            thread.replies.push(message)
+            thread.replies.push(message);
           }
         } else {
           // 新しいスレッドを作成
@@ -307,10 +340,10 @@ export function createSlackAdapter(httpClient: HttpClient): SlackAdapter {
               token,
               channel: message.channel.id,
               threadTs: message.thread_ts,
-            })
+            });
 
             if (parentResult.isOk()) {
-              threadMap.set(threadTs, parentResult.value)
+              threadMap.set(threadTs, parentResult.value);
             }
           } else {
             // これは親メッセージ
@@ -318,45 +351,48 @@ export function createSlackAdapter(httpClient: HttpClient): SlackAdapter {
               channel: message.channel.id,
               parent: message,
               replies: [],
-            })
+            });
           }
         }
       }
 
-      return ok(Array.from(threadMap.values()))
+      return ok(Array.from(threadMap.values()));
     },
 
-    async fetchUserMaps(threads: SlackThread[], token: string): Promise<Result<Record<string, string>, ApiError>> {
-      const userMaps: Record<string, string> = {}
-      const userIds = new Set<string>()
+    async fetchUserMaps(
+      threads: SlackThread[],
+      token: string
+    ): Promise<Result<Record<string, string>, ApiError>> {
+      const userMaps: Record<string, string> = {};
+      const userIds = new Set<string>();
 
       // すべてのスレッドからユーザーIDを収集
       for (const thread of threads) {
-        userIds.add(thread.parent.user)
+        userIds.add(thread.parent.user);
         for (const reply of thread.replies) {
-          userIds.add(reply.user)
+          userIds.add(reply.user);
         }
       }
 
       // 各ユーザー情報を取得
       for (const userId of userIds) {
-        const userResult = await this.getUserInfo({ token, userId })
+        const userResult = await this.getUserInfo({ token, userId });
         if (userResult.isOk()) {
-          const user = userResult.value
-          userMaps[userId] = user.real_name || user.name || userId
+          const user = userResult.value;
+          userMaps[userId] = user.real_name || user.name || userId;
         } else {
-          userMaps[userId] = userId
+          userMaps[userId] = userId;
         }
       }
 
-      return ok(userMaps)
+      return ok(userMaps);
     },
 
     async generatePermalinkMaps(
       threads: SlackThread[],
-      token: string,
+      token: string
     ): Promise<Result<Record<string, string>, ApiError>> {
-      const permalinkMaps: Record<string, string> = {}
+      const permalinkMaps: Record<string, string> = {};
 
       for (const thread of threads) {
         // 親メッセージのパーマリンク
@@ -364,10 +400,10 @@ export function createSlackAdapter(httpClient: HttpClient): SlackAdapter {
           token,
           channel: thread.channel,
           messageTs: thread.parent.ts,
-        })
+        });
 
         if (parentPermalinkResult.isOk()) {
-          permalinkMaps[thread.parent.ts] = parentPermalinkResult.value
+          permalinkMaps[thread.parent.ts] = parentPermalinkResult.value;
         }
 
         // 返信メッセージのパーマリンク
@@ -376,22 +412,22 @@ export function createSlackAdapter(httpClient: HttpClient): SlackAdapter {
             token,
             channel: thread.channel,
             messageTs: reply.ts,
-          })
+          });
 
           if (replyPermalinkResult.isOk()) {
-            permalinkMaps[reply.ts] = replyPermalinkResult.value
+            permalinkMaps[reply.ts] = replyPermalinkResult.value;
           }
         }
       }
 
-      return ok(permalinkMaps)
+      return ok(permalinkMaps);
     },
 
     async generateMarkdown(
       threads: SlackThread[],
       userMaps: Record<string, string>,
       permalinkMaps: Record<string, string>,
-      searchQuery: string,
+      searchQuery: string
     ): Promise<Result<string, ApiError>> {
       try {
         const frontMatter = `---
@@ -407,65 +443,68 @@ generated_at: "${new Date().toISOString()}"
 
 **検索クエリ:** ${searchQuery}  
 **スレッド数:** ${threads.length}  
-**生成日時:** ${new Date().toLocaleString('ja-JP')}
+**生成日時:** ${new Date().toLocaleString("ja-JP")}
 
-`
+`;
 
         const threadMarkdowns = threads.map((thread, index) => {
-          const parentUser = userMaps[thread.parent.user] || thread.parent.user
-          const parentPermalink = permalinkMaps[thread.parent.ts] || ''
+          const parentUser = userMaps[thread.parent.user] || thread.parent.user;
+          const parentPermalink = permalinkMaps[thread.parent.ts] || "";
 
-          let markdown = `## ${index + 1}. ${parentUser}の投稿\n\n`
-          markdown += `**投稿者:** ${parentUser}  \n`
-          markdown += `**チャンネル:** #${thread.parent.channel.name || thread.channel}  \n`
+          let markdown = `## ${index + 1}. ${parentUser}の投稿\n\n`;
+          markdown += `**投稿者:** ${parentUser}  \n`;
+          markdown += `**チャンネル:** #${thread.parent.channel.name || thread.channel}  \n`;
           if (parentPermalink) {
-            markdown += `**リンク:** ${parentPermalink}  \n`
+            markdown += `**リンク:** ${parentPermalink}  \n`;
           }
-          markdown += `\n${thread.parent.text}\n\n`
+          markdown += `\n${thread.parent.text}\n\n`;
 
           if (thread.replies.length > 0) {
-            markdown += `### 返信 (${thread.replies.length}件)\n\n`
+            markdown += `### 返信 (${thread.replies.length}件)\n\n`;
             thread.replies.forEach((reply, replyIndex) => {
-              const replyUser = userMaps[reply.user] || reply.user
-              const replyPermalink = permalinkMaps[reply.ts] || ''
+              const replyUser = userMaps[reply.user] || reply.user;
+              const replyPermalink = permalinkMaps[reply.ts] || "";
 
-              markdown += `**${replyIndex + 1}. ${replyUser}**`
+              markdown += `**${replyIndex + 1}. ${replyUser}**`;
               if (replyPermalink) {
-                markdown += ` ([リンク](${replyPermalink}))`
+                markdown += ` ([リンク](${replyPermalink}))`;
               }
-              markdown += `  \n${reply.text}\n\n`
-            })
+              markdown += `  \n${reply.text}\n\n`;
+            });
           }
 
-          return markdown
-        })
+          return markdown;
+        });
 
-        const fullMarkdown = frontMatter + threadMarkdowns.join('---\n\n')
-        return ok(fullMarkdown)
+        const fullMarkdown = frontMatter + threadMarkdowns.join("---\n\n");
+        return ok(fullMarkdown);
       } catch (error) {
         return err({
-          type: 'unknown',
-          message: error instanceof Error ? error.message : 'Markdown生成に失敗しました',
-        })
+          type: "unknown",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Markdown生成に失敗しました",
+        });
       }
     },
-  }
+  };
 }
 
 /**
  * Slack APIレスポンスの基本型
  */
 interface SlackApiResponse {
-  ok: boolean
-  error?: string
-  messages?: unknown
+  ok: boolean;
+  error?: string;
+  messages?: unknown;
   user?: {
-    id: string
-    name: string
-    real_name?: string
-  }
-  permalink?: string
-  [key: string]: unknown
+    id: string;
+    name: string;
+    real_name?: string;
+  };
+  permalink?: string;
+  [key: string]: unknown;
 }
 
 /**
@@ -473,37 +512,37 @@ interface SlackApiResponse {
  */
 function mapSlackErrorToApiError(errorCode: string): ApiError {
   switch (errorCode) {
-    case 'invalid_auth':
-    case 'not_authed':
-    case 'token_revoked':
-    case 'account_inactive':
+    case "invalid_auth":
+    case "not_authed":
+    case "token_revoked":
+    case "account_inactive":
       return {
-        type: 'unauthorized',
+        type: "unauthorized",
         message: `Slack認証エラー: ${errorCode}`,
-      }
-    case 'missing_scope':
+      };
+    case "missing_scope":
       return {
-        type: 'missing_scope',
+        type: "missing_scope",
         message: `必要なスコープがありません: ${errorCode}`,
-      }
-    case 'channel_not_found':
-    case 'thread_not_found':
-    case 'message_not_found':
-    case 'user_not_found':
+      };
+    case "channel_not_found":
+    case "thread_not_found":
+    case "message_not_found":
+    case "user_not_found":
       return {
-        type: 'notFound',
-        message: 'リソースが見つかりません。',
-      }
-    case 'rate_limited':
+        type: "notFound",
+        message: "リソースが見つかりません。",
+      };
+    case "rate_limited":
       return {
-        type: 'rate_limit',
-        message: 'APIレート制限に達しました。',
-      }
+        type: "rate_limit",
+        message: "APIレート制限に達しました。",
+      };
     default:
       return {
-        type: 'slack_api',
+        type: "slack_api",
         message: `Slack APIエラー: ${errorCode}`,
-      }
+      };
   }
 }
 
@@ -511,72 +550,102 @@ function mapSlackErrorToApiError(errorCode: string): ApiError {
  * 検索レスポンスからメッセージを抽出
  */
 function extractMessagesFromResponse(data: SlackApiResponse): SlackMessage[] {
-  const messages: SlackMessage[] = []
+  const messages: SlackMessage[] = [];
 
-  if (data.messages && typeof data.messages === 'object' && data.messages !== null) {
-    const msgObj = data.messages as Record<string, unknown>
-    if ('matches' in msgObj && Array.isArray(msgObj.matches)) {
+  if (
+    data.messages &&
+    typeof data.messages === "object" &&
+    data.messages !== null
+  ) {
+    const msgObj = data.messages as Record<string, unknown>;
+    if ("matches" in msgObj && Array.isArray(msgObj.matches)) {
       return msgObj.matches.map((m: unknown) => {
-        const msg = m as Record<string, unknown>
+        const msg = m as Record<string, unknown>;
         return {
-          ts: typeof msg.ts === 'string' ? msg.ts : '',
-          user: typeof msg.user === 'string' ? msg.user : '',
-          text: typeof msg.text === 'string' ? msg.text : '',
-          thread_ts: typeof msg.thread_ts === 'string' ? msg.thread_ts : undefined,
+          ts: typeof msg.ts === "string" ? msg.ts : "",
+          user: typeof msg.user === "string" ? msg.user : "",
+          text: typeof msg.text === "string" ? msg.text : "",
+          thread_ts:
+            typeof msg.thread_ts === "string" ? msg.thread_ts : undefined,
           channel:
-            msg.channel && typeof msg.channel === 'object' && msg.channel !== null && 'id' in msg.channel
+            msg.channel &&
+            typeof msg.channel === "object" &&
+            msg.channel !== null &&
+            "id" in msg.channel
               ? {
                   id: (msg.channel as { id: string }).id,
                   name: (msg.channel as { name?: string }).name,
                 }
-              : { id: '', name: undefined },
-          permalink: typeof msg.permalink === 'string' ? msg.permalink : undefined,
-        }
-      })
+              : { id: "", name: undefined },
+          permalink:
+            typeof msg.permalink === "string" ? msg.permalink : undefined,
+        };
+      });
     }
   }
 
-  return messages
+  return messages;
 }
 
 /**
  * 検索レスポンスからページネーション情報を抽出
  */
 function extractPaginationFromResponse(data: SlackApiResponse, count: number) {
-  let paginationData: Record<string, unknown> | undefined
+  let paginationData: Record<string, unknown> | undefined;
 
-  if (data.messages && typeof data.messages === 'object' && data.messages !== null) {
-    const msgObj = data.messages as Record<string, unknown>
-    if ('pagination' in msgObj && typeof msgObj.pagination === 'object' && msgObj.pagination !== null) {
-      paginationData = msgObj.pagination as Record<string, unknown>
+  if (
+    data.messages &&
+    typeof data.messages === "object" &&
+    data.messages !== null
+  ) {
+    const msgObj = data.messages as Record<string, unknown>;
+    if (
+      "pagination" in msgObj &&
+      typeof msgObj.pagination === "object" &&
+      msgObj.pagination !== null
+    ) {
+      paginationData = msgObj.pagination as Record<string, unknown>;
     }
   }
 
   return {
-    currentPage: typeof paginationData?.page === 'number' ? paginationData.page : 1,
-    totalPages: typeof paginationData?.page_count === 'number' ? paginationData.page_count : 1,
-    totalResults: typeof paginationData?.total_count === 'number' ? paginationData.total_count : 0,
-    perPage: typeof paginationData?.per_page === 'number' ? paginationData.per_page : count,
-  }
+    currentPage:
+      typeof paginationData?.page === "number" ? paginationData.page : 1,
+    totalPages:
+      typeof paginationData?.page_count === "number"
+        ? paginationData.page_count
+        : 1,
+    totalResults:
+      typeof paginationData?.total_count === "number"
+        ? paginationData.total_count
+        : 0,
+    perPage:
+      typeof paginationData?.per_page === "number"
+        ? paginationData.per_page
+        : count,
+  };
 }
 
 /**
  * スレッドレスポンスからメッセージを抽出
  */
-function extractThreadMessagesFromResponse(data: SlackApiResponse, channel: string): SlackMessage[] {
+function extractThreadMessagesFromResponse(
+  data: SlackApiResponse,
+  channel: string
+): SlackMessage[] {
   if (!Array.isArray(data.messages)) {
-    return []
+    return [];
   }
 
   return data.messages.map((m: unknown) => {
-    const msg = m as Record<string, unknown>
+    const msg = m as Record<string, unknown>;
     return {
-      ts: typeof msg.ts === 'string' ? msg.ts : '',
-      user: typeof msg.user === 'string' ? msg.user : '',
-      text: typeof msg.text === 'string' ? msg.text : '',
-      thread_ts: typeof msg.thread_ts === 'string' ? msg.thread_ts : undefined,
+      ts: typeof msg.ts === "string" ? msg.ts : "",
+      user: typeof msg.user === "string" ? msg.user : "",
+      text: typeof msg.text === "string" ? msg.text : "",
+      thread_ts: typeof msg.thread_ts === "string" ? msg.thread_ts : undefined,
       channel: { id: channel },
       permalink: undefined,
-    }
-  })
+    };
+  });
 }

--- a/src/features/slack/components/SlackAdvancedFilters.tsx
+++ b/src/features/slack/components/SlackAdvancedFilters.tsx
@@ -5,20 +5,20 @@
  * - 各フィルター条件の入力フィールド
  */
 
-'use client'
+"use client";
 
-import type { SlackAdvancedFiltersProps } from '@/features/slack/types/forms'
+import type { SlackAdvancedFiltersProps } from "@/features/slack/types/forms";
 
 export function SlackAdvancedFilters({
   showAdvanced,
   onToggleAdvanced,
-  channel = '',
+  channel = "",
   onChannelChange = () => {},
-  author = '',
+  author = "",
   onAuthorChange = () => {},
-  startDate = '',
+  startDate = "",
   onStartDateChange = () => {},
-  endDate = '',
+  endDate = "",
   onEndDateChange = () => {},
   disabled = false,
   children,
@@ -30,7 +30,7 @@ export function SlackAdvancedFilters({
         onClick={onToggleAdvanced}
         className="text-sm text-blue-600 hover:text-blue-800 focus:outline-none"
       >
-        {showAdvanced ? '詳細な条件を閉じる ▲' : 'もっと詳細な条件を追加する ▼'}
+        {showAdvanced ? "詳細な条件を閉じる ▲" : "もっと詳細な条件を追加する ▼"}
       </button>
       {showAdvanced && (
         <div className="space-y-4 p-4 border border-gray-300 rounded-md bg-gray-50">
@@ -39,7 +39,10 @@ export function SlackAdvancedFilters({
           ) : (
             <>
               <div>
-                <label htmlFor="channel" className="block text-sm font-medium text-gray-700 mb-1">
+                <label
+                  htmlFor="channel"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
                   チャンネル (例: #general)
                 </label>
                 <input
@@ -53,7 +56,10 @@ export function SlackAdvancedFilters({
                 />
               </div>
               <div>
-                <label htmlFor="author" className="block text-sm font-medium text-gray-700 mb-1">
+                <label
+                  htmlFor="author"
+                  className="block text-sm font-medium text-gray-700 mb-1"
+                >
                   投稿者 (例: @user)
                 </label>
                 <input
@@ -68,7 +74,10 @@ export function SlackAdvancedFilters({
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
-                  <label htmlFor="startDate" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label
+                    htmlFor="startDate"
+                    className="block text-sm font-medium text-gray-700 mb-1"
+                  >
                     投稿期間 (開始日)
                   </label>
                   <input
@@ -81,7 +90,10 @@ export function SlackAdvancedFilters({
                   />
                 </div>
                 <div>
-                  <label htmlFor="endDate" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label
+                    htmlFor="endDate"
+                    className="block text-sm font-medium text-gray-700 mb-1"
+                  >
                     投稿期間 (終了日)
                   </label>
                   <input
@@ -99,5 +111,5 @@ export function SlackAdvancedFilters({
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/src/features/slack/components/SlackAuthorInput.tsx
+++ b/src/features/slack/components/SlackAuthorInput.tsx
@@ -1,10 +1,18 @@
-import type { SlackAuthorInputProps } from '@/features/slack/types/forms'
-import type { FC } from 'react'
+import type { SlackAuthorInputProps } from "@/features/slack/types/forms";
+import type { FC } from "react";
 
-export const SlackAuthorInput: FC<SlackAuthorInputProps> = ({ author, onAuthorChange, error, disabled }) => {
+export const SlackAuthorInput: FC<SlackAuthorInputProps> = ({
+  author,
+  onAuthorChange,
+  error,
+  disabled,
+}) => {
   return (
     <div className="mb-4">
-      <label htmlFor="slack-author" className="block text-base font-medium text-gray-700 mb-1">
+      <label
+        htmlFor="slack-author"
+        className="block text-base font-medium text-gray-700 mb-1"
+      >
         投稿者 (例: @user)
       </label>
       <input
@@ -14,8 +22,8 @@ export const SlackAuthorInput: FC<SlackAuthorInputProps> = ({ author, onAuthorCh
         onChange={(e) => onAuthorChange(e.target.value)}
         placeholder="@user"
         disabled={disabled}
-        className={`block w-full px-4 py-3 border ${error ? 'border-red-500' : 'border-gray-400'} rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500' : 'focus:ring-blue-400 focus:border-blue-400'} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
-        aria-describedby={error ? 'slack-author-error' : undefined}
+        className={`block w-full px-4 py-3 border ${error ? "border-red-500" : "border-gray-400"} rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 ${error ? "focus:ring-red-500 focus:border-red-500" : "focus:ring-blue-400 focus:border-blue-400"} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
+        aria-describedby={error ? "slack-author-error" : undefined}
       />
       {error && (
         <p id="slack-author-error" className="mt-1 text-xs text-red-600">
@@ -23,5 +31,5 @@ export const SlackAuthorInput: FC<SlackAuthorInputProps> = ({ author, onAuthorCh
         </p>
       )}
     </div>
-  )
-}
+  );
+};

--- a/src/features/slack/components/SlackChannelInput.tsx
+++ b/src/features/slack/components/SlackChannelInput.tsx
@@ -1,10 +1,18 @@
-import type { SlackChannelInputProps } from '@/features/slack/types/forms'
-import type { FC } from 'react'
+import type { SlackChannelInputProps } from "@/features/slack/types/forms";
+import type { FC } from "react";
 
-export const SlackChannelInput: FC<SlackChannelInputProps> = ({ channel, onChannelChange, error, disabled }) => {
+export const SlackChannelInput: FC<SlackChannelInputProps> = ({
+  channel,
+  onChannelChange,
+  error,
+  disabled,
+}) => {
   return (
     <div className="mb-4">
-      <label htmlFor="slack-channel" className="block text-base font-medium text-gray-700 mb-1">
+      <label
+        htmlFor="slack-channel"
+        className="block text-base font-medium text-gray-700 mb-1"
+      >
         チャンネル (例: #general)
       </label>
       <input
@@ -14,8 +22,8 @@ export const SlackChannelInput: FC<SlackChannelInputProps> = ({ channel, onChann
         onChange={(e) => onChannelChange(e.target.value)}
         placeholder="#general"
         disabled={disabled}
-        className={`block w-full px-4 py-3 border ${error ? 'border-red-500' : 'border-gray-400'} rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500' : 'focus:ring-blue-400 focus:border-blue-400'} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
-        aria-describedby={error ? 'slack-channel-error' : undefined}
+        className={`block w-full px-4 py-3 border ${error ? "border-red-500" : "border-gray-400"} rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 ${error ? "focus:ring-red-500 focus:border-red-500" : "focus:ring-blue-400 focus:border-blue-400"} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
+        aria-describedby={error ? "slack-channel-error" : undefined}
       />
       {error && (
         <p id="slack-channel-error" className="mt-1 text-xs text-red-600">
@@ -23,5 +31,5 @@ export const SlackChannelInput: FC<SlackChannelInputProps> = ({ channel, onChann
         </p>
       )}
     </div>
-  )
-}
+  );
+};

--- a/src/features/slack/components/SlackSearchForm.tsx
+++ b/src/features/slack/components/SlackSearchForm.tsx
@@ -5,17 +5,17 @@
  * - 検索実行とローディング状態の管理
  */
 
-'use client'
+"use client";
 
-import type { UseSlackFormResult } from '../types/forms'
-import { SlackAdvancedFilters } from './SlackAdvancedFilters'
-import { SlackAuthorInput } from './SlackAuthorInput'
-import { SlackChannelInput } from './SlackChannelInput'
-import { SlackSearchInput } from './SlackSearchInput'
-import { SlackTokenInput } from './SlackTokenInput'
+import type { UseSlackFormResult } from "../types/forms";
+import { SlackAdvancedFilters } from "./SlackAdvancedFilters";
+import { SlackAuthorInput } from "./SlackAuthorInput";
+import { SlackChannelInput } from "./SlackChannelInput";
+import { SlackSearchInput } from "./SlackSearchInput";
+import { SlackTokenInput } from "./SlackTokenInput";
 
 interface SlackSearchFormProps {
-  form: UseSlackFormResult
+  form: UseSlackFormResult;
 }
 
 export function SlackSearchForm({ form }: SlackSearchFormProps) {
@@ -32,15 +32,27 @@ export function SlackSearchForm({ form }: SlackSearchFormProps) {
       />
 
       {/* 詳細フィルター */}
-      <SlackAdvancedFilters showAdvanced={form.showAdvanced} onToggleAdvanced={form.onToggleAdvanced}>
+      <SlackAdvancedFilters
+        showAdvanced={form.showAdvanced}
+        onToggleAdvanced={form.onToggleAdvanced}
+      >
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <SlackChannelInput channel={form.channel} onChannelChange={form.onChannelChange} />
-          <SlackAuthorInput author={form.author} onAuthorChange={form.onAuthorChange} />
+          <SlackChannelInput
+            channel={form.channel}
+            onChannelChange={form.onChannelChange}
+          />
+          <SlackAuthorInput
+            author={form.author}
+            onAuthorChange={form.onAuthorChange}
+          />
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label htmlFor="startDate" className="block text-sm font-medium text-gray-700 mb-2">
+            <label
+              htmlFor="startDate"
+              className="block text-sm font-medium text-gray-700 mb-2"
+            >
               開始日
             </label>
             <input
@@ -52,7 +64,10 @@ export function SlackSearchForm({ form }: SlackSearchFormProps) {
             />
           </div>
           <div>
-            <label htmlFor="endDate" className="block text-sm font-medium text-gray-700 mb-2">
+            <label
+              htmlFor="endDate"
+              className="block text-sm font-medium text-gray-700 mb-2"
+            >
               終了日
             </label>
             <input
@@ -69,10 +84,12 @@ export function SlackSearchForm({ form }: SlackSearchFormProps) {
       {/* 検索ボタン */}
       <button
         type="submit"
-        disabled={form.isLoading || !form.token.trim() || !form.searchQuery.trim()}
+        disabled={
+          form.isLoading || !form.token.trim() || !form.searchQuery.trim()
+        }
         className="w-full bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
       >
-        {form.isLoading ? '検索中...' : 'Slackを検索'}
+        {form.isLoading ? "検索中..." : "Slackを検索"}
       </button>
 
       {/* 進行状況表示 */}
@@ -80,7 +97,10 @@ export function SlackSearchForm({ form }: SlackSearchFormProps) {
         <div className="mt-4 text-center text-sm text-gray-600">
           <div className="mb-2">{form.progressStatus.message}</div>
           <div className="w-full bg-gray-200 rounded-full h-2">
-            <div className="bg-blue-600 h-2 rounded-full animate-pulse" style={{ width: '60%' }} />
+            <div
+              className="bg-blue-600 h-2 rounded-full animate-pulse"
+              style={{ width: "60%" }}
+            />
           </div>
         </div>
       )}
@@ -92,5 +112,5 @@ export function SlackSearchForm({ form }: SlackSearchFormProps) {
         </div>
       )}
     </form>
-  )
+  );
 }

--- a/src/features/slack/components/SlackSearchInput.tsx
+++ b/src/features/slack/components/SlackSearchInput.tsx
@@ -5,12 +5,19 @@
  * - 無効化状態の対応
  */
 
-import type { SlackSearchInputProps } from '@/features/slack/types/forms'
+import type { SlackSearchInputProps } from "@/features/slack/types/forms";
 
-export function SlackSearchInput({ searchQuery, onSearchQueryChange, disabled = false }: SlackSearchInputProps) {
+export function SlackSearchInput({
+  searchQuery,
+  onSearchQueryChange,
+  disabled = false,
+}: SlackSearchInputProps) {
   return (
     <div>
-      <label htmlFor="searchQuery" className="block text-base font-medium text-gray-700 mb-1">
+      <label
+        htmlFor="searchQuery"
+        className="block text-base font-medium text-gray-700 mb-1"
+      >
         検索キーワード
       </label>
       <input
@@ -24,5 +31,5 @@ export function SlackSearchInput({ searchQuery, onSearchQueryChange, disabled = 
         required
       />
     </div>
-  )
+  );
 }

--- a/src/features/slack/components/SlackTokenInput.tsx
+++ b/src/features/slack/components/SlackTokenInput.tsx
@@ -1,36 +1,43 @@
-import type { SlackTokenInputProps, SlackTokenInputRef } from '@/features/slack/types/forms'
-import React, { type FC, forwardRef, useImperativeHandle, useRef } from 'react'
+import type {
+  SlackTokenInputProps,
+  SlackTokenInputRef,
+} from "@/features/slack/types/forms";
+import React, { type FC, forwardRef, useImperativeHandle, useRef } from "react";
 
-export const SlackTokenInput = forwardRef<SlackTokenInputRef, SlackTokenInputProps>(
-  ({ token, onTokenChange, error, disabled }, ref) => {
-    const inputRef = useRef<HTMLInputElement>(null)
-    useImperativeHandle(ref, () => ({
-      focus: () => {
-        inputRef.current?.focus()
-      },
-    }))
-    return (
-      <div className="mb-4">
-        <label htmlFor="slack-token" className="block text-base font-medium text-gray-700 mb-1">
-          Slack APIトークン
-        </label>
-        <input
-          type="password"
-          id="slack-token"
-          ref={inputRef}
-          value={token}
-          onChange={(e) => onTokenChange(e.target.value)}
-          placeholder="xoxp-..."
-          disabled={disabled}
-          className={`block w-full px-4 py-3 border ${error ? 'border-red-500' : 'border-gray-400'} rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500' : 'focus:ring-blue-400 focus:border-blue-400'} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
-          aria-describedby={error ? 'slack-token-error' : undefined}
-        />
-        {error && (
-          <p id="slack-token-error" className="mt-1 text-xs text-red-600">
-            {error}
-          </p>
-        )}
-      </div>
-    )
-  },
-)
+export const SlackTokenInput = forwardRef<
+  SlackTokenInputRef,
+  SlackTokenInputProps
+>(({ token, onTokenChange, error, disabled }, ref) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      inputRef.current?.focus();
+    },
+  }));
+  return (
+    <div className="mb-4">
+      <label
+        htmlFor="slack-token"
+        className="block text-base font-medium text-gray-700 mb-1"
+      >
+        Slack APIトークン
+      </label>
+      <input
+        type="password"
+        id="slack-token"
+        ref={inputRef}
+        value={token}
+        onChange={(e) => onTokenChange(e.target.value)}
+        placeholder="xoxp-..."
+        disabled={disabled}
+        className={`block w-full px-4 py-3 border ${error ? "border-red-500" : "border-gray-400"} rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-1 ${error ? "focus:ring-red-500 focus:border-red-500" : "focus:ring-blue-400 focus:border-blue-400"} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
+        aria-describedby={error ? "slack-token-error" : undefined}
+      />
+      {error && (
+        <p id="slack-token-error" className="mt-1 text-xs text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+});

--- a/src/features/slack/hooks/useSlackForm.ts
+++ b/src/features/slack/hooks/useSlackForm.ts
@@ -5,24 +5,24 @@
  * - プレゼンテーション層とロジック層の分離
  */
 
-import { useDownload } from '@/hooks/useDownload'
-import useLocalStorage from '@/hooks/useLocalStorage'
-import { useState } from 'react'
-import type React from 'react'
-import { useSlackSearchUnified } from './useSlackSearchUnified'
+import { useDownload } from "@/hooks/useDownload";
+import useLocalStorage from "@/hooks/useLocalStorage";
+import { useState } from "react";
+import type React from "react";
+import { useSlackSearchUnified } from "./useSlackSearchUnified";
 
 export function useSlackForm() {
   // フォーム状態
-  const [token, setToken] = useLocalStorage<string>('slackApiToken', '')
-  const [searchQuery, setSearchQuery] = useState<string>('')
-  const [startDate, setStartDate] = useState<string>('')
-  const [endDate, setEndDate] = useState<string>('')
-  const [channel, setChannel] = useState<string>('')
-  const [author, setAuthor] = useState<string>('')
-  const [showAdvanced, setShowAdvanced] = useState<boolean>(false)
+  const [token, setToken] = useLocalStorage<string>("slackApiToken", "");
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [startDate, setStartDate] = useState<string>("");
+  const [endDate, setEndDate] = useState<string>("");
+  const [channel, setChannel] = useState<string>("");
+  const [author, setAuthor] = useState<string>("");
+  const [showAdvanced, setShowAdvanced] = useState<boolean>(false);
 
   // フック統合
-  const { isDownloading, handleDownload } = useDownload()
+  const { isDownloading, handleDownload } = useDownload();
   const {
     isLoading,
     progressStatus,
@@ -34,11 +34,11 @@ export function useSlackForm() {
     threadMarkdowns,
     currentPreviewMarkdown,
     handleSearch: searchSlack,
-  } = useSlackSearchUnified()
+  } = useSlackSearchUnified();
 
   // イベントハンドラー
   const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
+    event.preventDefault();
     searchSlack({
       token,
       searchQuery,
@@ -46,28 +46,36 @@ export function useSlackForm() {
       author,
       startDate,
       endDate,
-    })
-  }
+    });
+  };
 
-  const handlePreviewDownload = (markdownContent: string, searchQuery: string, hasContent: boolean) => {
+  const handlePreviewDownload = (
+    markdownContent: string,
+    searchQuery: string,
+    hasContent: boolean
+  ) => {
     if (hasContent && currentPreviewMarkdown) {
-      handleDownload(currentPreviewMarkdown, searchQuery, hasContent, 'slack')
+      handleDownload(currentPreviewMarkdown, searchQuery, hasContent, "slack");
     } else {
-      handleDownload(markdownContent, searchQuery, hasContent, 'slack')
+      handleDownload(markdownContent, searchQuery, hasContent, "slack");
     }
-  }
+  };
 
-  const handleFullDownload = (markdownContent: string, searchQuery: string, hasContent: boolean) => {
+  const handleFullDownload = (
+    markdownContent: string,
+    searchQuery: string,
+    hasContent: boolean
+  ) => {
     if (hasContent && threadMarkdowns.length > 0) {
       // TODO: Issue #39で統一フックによるMarkdown生成実装
       // const fullMarkdown = generateSlackThreadsMarkdown(slackThreads, userMaps, permalinkMaps, searchQuery)
-      handleDownload(markdownContent, searchQuery, hasContent, 'slack')
+      handleDownload(markdownContent, searchQuery, hasContent, "slack");
     } else {
-      handleDownload(markdownContent, searchQuery, hasContent, 'slack')
+      handleDownload(markdownContent, searchQuery, hasContent, "slack");
     }
-  }
+  };
 
-  const toggleAdvanced = () => setShowAdvanced(!showAdvanced)
+  const toggleAdvanced = () => setShowAdvanced(!showAdvanced);
 
   return {
     // 検索条件
@@ -104,5 +112,5 @@ export function useSlackForm() {
     onSubmit: handleFormSubmit,
     onDownload: handlePreviewDownload,
     onFullDownload: handleFullDownload,
-  }
+  };
 }

--- a/src/features/slack/types/forms.ts
+++ b/src/features/slack/types/forms.ts
@@ -5,47 +5,55 @@
  * - フォーム状態とイベントハンドラーの型定義
  */
 
-import type { ProgressStatus, SlackThread } from './slack'
+import type { ProgressStatus, SlackThread } from "./slack";
 
 /**
  * useSlackForm フック戻り値の型
  */
 export type UseSlackFormResult = {
   // 検索条件
-  searchQuery: string
-  onSearchQueryChange: (query: string) => void
-  token: string
-  onTokenChange: (token: string) => void
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
+  token: string;
+  onTokenChange: (token: string) => void;
 
   // 詳細フィルター
-  showAdvanced: boolean
-  onToggleAdvanced: () => void
-  channel: string
-  onChannelChange: (channel: string) => void
-  author: string
-  onAuthorChange: (author: string) => void
-  startDate: string
-  onStartDateChange: (date: string) => void
-  endDate: string
-  onEndDateChange: (date: string) => void
+  showAdvanced: boolean;
+  onToggleAdvanced: () => void;
+  channel: string;
+  onChannelChange: (channel: string) => void;
+  author: string;
+  onAuthorChange: (author: string) => void;
+  startDate: string;
+  onStartDateChange: (date: string) => void;
+  endDate: string;
+  onEndDateChange: (date: string) => void;
 
   // 状態
-  isLoading: boolean
-  isDownloading: boolean
-  progressStatus: ProgressStatus
-  hasSearched: boolean
-  error: string | null
+  isLoading: boolean;
+  isDownloading: boolean;
+  progressStatus: ProgressStatus;
+  hasSearched: boolean;
+  error: string | null;
 
   // 結果
-  slackThreads: SlackThread[]
-  userMaps: Record<string, string>
-  permalinkMaps: Record<string, string>
+  slackThreads: SlackThread[];
+  userMaps: Record<string, string>;
+  permalinkMaps: Record<string, string>;
 
   // イベントハンドラー
-  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void
-  onDownload: (markdownContent: string, searchQuery: string, hasContent: boolean) => void
-  onFullDownload: (markdownContent: string, searchQuery: string, hasContent: boolean) => void
-}
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onDownload: (
+    markdownContent: string,
+    searchQuery: string,
+    hasContent: boolean
+  ) => void;
+  onFullDownload: (
+    markdownContent: string,
+    searchQuery: string,
+    hasContent: boolean
+  ) => void;
+};
 
 /**
  * Slack検索フォーム全体のProps型
@@ -54,161 +62,177 @@ export type UseSlackFormResult = {
  */
 export type SlackSearchFormProps = {
   // 検索条件
-  searchQuery: string
-  onSearchQueryChange: (query: string) => void
-  token: string
-  onTokenChange: (token: string) => void
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
+  token: string;
+  onTokenChange: (token: string) => void;
 
   // 詳細フィルター
-  showAdvanced: boolean
-  onToggleAdvanced: () => void
-  channel: string
-  onChannelChange: (channel: string) => void
-  author: string
-  onAuthorChange: (author: string) => void
-  startDate: string
-  onStartDateChange: (date: string) => void
-  endDate: string
-  onEndDateChange: (date: string) => void
+  showAdvanced: boolean;
+  onToggleAdvanced: () => void;
+  channel: string;
+  onChannelChange: (channel: string) => void;
+  author: string;
+  onAuthorChange: (author: string) => void;
+  startDate: string;
+  onStartDateChange: (date: string) => void;
+  endDate: string;
+  onEndDateChange: (date: string) => void;
 
   // 状態
-  isLoading: boolean
-  isDownloading: boolean
-  progressStatus: ProgressStatus
-  hasSearched: boolean
-  error: string | null
+  isLoading: boolean;
+  isDownloading: boolean;
+  progressStatus: ProgressStatus;
+  hasSearched: boolean;
+  error: string | null;
 
   // 結果
-  slackThreads: SlackThread[]
-  userMaps: Record<string, string>
-  permalinkMaps: Record<string, string>
+  slackThreads: SlackThread[];
+  userMaps: Record<string, string>;
+  permalinkMaps: Record<string, string>;
 
   // イベントハンドラー
-  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void
-  onDownload: (markdownContent: string, searchQuery: string, hasContent: boolean) => void
-  onFullDownload: (markdownContent: string, searchQuery: string, hasContent: boolean) => void
-}
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onDownload: (
+    markdownContent: string,
+    searchQuery: string,
+    hasContent: boolean
+  ) => void;
+  onFullDownload: (
+    markdownContent: string,
+    searchQuery: string,
+    hasContent: boolean
+  ) => void;
+};
 
 /**
  * Slack検索入力フィールドのProps型
  */
 export type SlackSearchInputProps = {
-  searchQuery: string
-  onSearchQueryChange: (query: string) => void
-  disabled?: boolean
-  isLoading?: boolean
-}
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
+  disabled?: boolean;
+  isLoading?: boolean;
+};
 
 /**
  * SlackトークンInput のProps型
  */
 export type SlackTokenInputProps = {
-  token: string
-  onTokenChange: (token: string) => void
-  error?: string
-  disabled?: boolean
-}
+  token: string;
+  onTokenChange: (token: string) => void;
+  error?: string;
+  disabled?: boolean;
+};
 
 /**
  * SlackトークンInputのref型
  */
 export type SlackTokenInputRef = {
-  focus: () => void
-}
+  focus: () => void;
+};
 
 /**
  * Slack詳細フィルターのProps型
  */
 export type SlackAdvancedFiltersProps = {
-  showAdvanced: boolean
-  onToggleAdvanced: () => void
-  channel?: string
-  onChannelChange?: (channel: string) => void
-  author?: string
-  onAuthorChange?: (author: string) => void
-  startDate?: string
-  onStartDateChange?: (date: string) => void
-  endDate?: string
-  onEndDateChange?: (date: string) => void
-  disabled?: boolean
-  children?: React.ReactNode
-}
+  showAdvanced: boolean;
+  onToggleAdvanced: () => void;
+  channel?: string;
+  onChannelChange?: (channel: string) => void;
+  author?: string;
+  onAuthorChange?: (author: string) => void;
+  startDate?: string;
+  onStartDateChange?: (date: string) => void;
+  endDate?: string;
+  onEndDateChange?: (date: string) => void;
+  disabled?: boolean;
+  children?: React.ReactNode;
+};
 
 /**
  * Slack検索アクションボタンのProps型
  */
 export type SlackSearchActionsProps = {
-  isLoading: boolean
-  isDownloading: boolean
-  progressStatus: ProgressStatus
-  hasResults: boolean
-  token: string
-  searchQuery: string
-  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void
-  onDownload: (markdownContent: string, searchQuery: string, hasContent: boolean) => void
-}
+  isLoading: boolean;
+  isDownloading: boolean;
+  progressStatus: ProgressStatus;
+  hasResults: boolean;
+  token: string;
+  searchQuery: string;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onDownload: (
+    markdownContent: string,
+    searchQuery: string,
+    hasContent: boolean
+  ) => void;
+};
 
 /**
  * Slackエラー表示のProps型
  */
 export type SlackErrorDisplayProps = {
-  error: string | null
-}
+  error: string | null;
+};
 
 /**
  * Slack結果表示のProps型
  */
 export type SlackResultsDisplayProps = {
-  slackThreads: SlackThread[]
-  userMaps: Record<string, string>
-  permalinkMaps: Record<string, string>
-  searchQuery: string
-  isLoading: boolean
-  isDownloading: boolean
-  hasSearched: boolean
-  error: string | null
-  onFullDownload: (markdownContent: string, searchQuery: string, hasContent: boolean) => void
-}
+  slackThreads: SlackThread[];
+  userMaps: Record<string, string>;
+  permalinkMaps: Record<string, string>;
+  searchQuery: string;
+  isLoading: boolean;
+  isDownloading: boolean;
+  hasSearched: boolean;
+  error: string | null;
+  onFullDownload: (
+    markdownContent: string,
+    searchQuery: string,
+    hasContent: boolean
+  ) => void;
+};
 
 /**
  * Slackチャンネル入力のProps型
  */
 export type SlackChannelInputProps = {
-  channel: string
-  onChannelChange: (channel: string) => void
-  error?: string
-  disabled?: boolean
-}
+  channel: string;
+  onChannelChange: (channel: string) => void;
+  error?: string;
+  disabled?: boolean;
+};
 
 /**
  * Slack投稿者入力のProps型
  */
 export type SlackAuthorInputProps = {
-  author: string
-  onAuthorChange: (author: string) => void
-  error?: string
-  disabled?: boolean
-}
+  author: string;
+  onAuthorChange: (author: string) => void;
+  error?: string;
+  disabled?: boolean;
+};
 
 /**
  * SlackMarkdownプレビューのProps型
  */
 export type SlackMarkdownPreviewProps = {
-  slackThreads: SlackThread[]
-  userMaps: Record<string, string>
-  permalinkMaps: Record<string, string>
-  searchQuery: string
-}
+  slackThreads: SlackThread[];
+  userMaps: Record<string, string>;
+  permalinkMaps: Record<string, string>;
+  searchQuery: string;
+};
 
 /**
  * スレッドカードのProps型
  */
 export type ThreadCardProps = {
-  thread: SlackThread
-  userMaps: Record<string, string>
-  permalinkMaps: Record<string, string>
-  searchQuery: string
-  index: number
-  showAllReplies: boolean
-  onToggleReplies: () => void
-}
+  thread: SlackThread;
+  userMaps: Record<string, string>;
+  permalinkMaps: Record<string, string>;
+  searchQuery: string;
+  index: number;
+  showAllReplies: boolean;
+  onToggleReplies: () => void;
+};

--- a/src/features/slack/types/slack.ts
+++ b/src/features/slack/types/slack.ts
@@ -8,89 +8,95 @@
  * Slackメッセージ1件分の型
  */
 export type SlackMessage = {
-  ts: string // メッセージのタイムスタンプ（スレッドIDにもなる）
-  user: string // ユーザーID
-  text: string // 本文
-  thread_ts?: string // スレッド親のts（親メッセージの場合は省略）
-  channel: { id: string; name?: string } // チャンネル情報（id, name）
-  permalink?: string // メッセージへのパーマリンク
-}
+  ts: string; // メッセージのタイムスタンプ（スレッドIDにもなる）
+  user: string; // ユーザーID
+  text: string; // 本文
+  thread_ts?: string; // スレッド親のts（親メッセージの場合は省略）
+  channel: { id: string; name?: string }; // チャンネル情報（id, name）
+  permalink?: string; // メッセージへのパーマリンク
+};
 
 /**
  * Slackスレッド全体の型
  */
 export type SlackThread = {
-  channel: string // チャンネルID
-  parent: SlackMessage // 親メッセージ
-  replies: SlackMessage[] // 返信メッセージ群
-}
+  channel: string; // チャンネルID
+  parent: SlackMessage; // 親メッセージ
+  replies: SlackMessage[]; // 返信メッセージ群
+};
 
 /**
  * Slackユーザー情報の型
  */
 export type SlackUser = {
-  id: string
-  name: string
-  real_name?: string
-}
+  id: string;
+  name: string;
+  real_name?: string;
+};
 
 /**
  * Slack検索パラメータの型
  * - useSlackSearchUnified フックで使用
  */
 export type SlackSearchParams = {
-  token: string
-  searchQuery: string
-  channel?: string
-  author?: string
-  startDate?: string
-  endDate?: string
-}
+  token: string;
+  searchQuery: string;
+  channel?: string;
+  author?: string;
+  startDate?: string;
+  endDate?: string;
+};
 
 /**
  * 進捗ステータスの型定義
  */
 export type ProgressStatus = {
-  phase: 'idle' | 'searching' | 'fetching_threads' | 'fetching_users' | 'generating_permalinks' | 'completed'
-  message: string
-  current?: number
-  total?: number
-}
+  phase:
+    | "idle"
+    | "searching"
+    | "fetching_threads"
+    | "fetching_users"
+    | "generating_permalinks"
+    | "completed";
+  message: string;
+  current?: number;
+  total?: number;
+};
 
 /**
  * Slack検索結果の状態
  */
 export type UseSlackSearchState = {
-  messages: SlackMessage[]
-  slackThreads: SlackThread[]
-  userMaps: Record<string, string>
-  permalinkMaps: Record<string, string>
-  threadMarkdowns: string[]
-  currentPreviewMarkdown: string
+  messages: SlackMessage[];
+  slackThreads: SlackThread[];
+  userMaps: Record<string, string>;
+  permalinkMaps: Record<string, string>;
+  threadMarkdowns: string[];
+  currentPreviewMarkdown: string;
   paginationInfo: {
-    currentPage: number
-    totalPages: number
-    totalResults: number
-    perPage: number
-  }
-  isLoading: boolean
-  progressStatus: ProgressStatus
-  hasSearched: boolean
-  error: import('@/types/error').ApiError | null
-}
+    currentPage: number;
+    totalPages: number;
+    totalResults: number;
+    perPage: number;
+  };
+  isLoading: boolean;
+  progressStatus: ProgressStatus;
+  hasSearched: boolean;
+  error: import("@/types/error").ApiError | null;
+};
 
 /**
  * useSlackSearchUnified フック戻り値の型
  */
 export type UseSlackSearchResult = UseSlackSearchState & {
-  handleSearch: (params: SlackSearchParams) => Promise<void>
-  canRetry: boolean
-  retrySearch: () => void
-}
+  handleSearch: (params: SlackSearchParams) => Promise<void>;
+  canRetry: boolean;
+  retrySearch: () => void;
+};
 
 /**
  * useSlackSearchUnified フックオプション（アダプター注入用）
  */
 export type UseSlackSearchOptions = {
-  adapter?: import('@/features/slack/adapters/slackAdapter').SlackAdapter
-}
+  adapter?: import("@/features/slack/adapters/slackAdapter").SlackAdapter;
+};

--- a/src/features/slack/utils/slackMarkdownGenerator.ts
+++ b/src/features/slack/utils/slackMarkdownGenerator.ts
@@ -1,5 +1,5 @@
-import type { SlackThread } from '../types/slack'
-import { convertToSlackThreadMarkdown } from './slackTextConverter'
+import type { SlackThread } from "../types/slack";
+import { convertToSlackThreadMarkdown } from "./slackTextConverter";
 
 /**
  * 複数のSlackスレッドをLLM最適化Markdown形式で統合
@@ -13,88 +13,97 @@ export const generateSlackThreadsMarkdown = (
   threads: SlackThread[],
   userMap: Record<string, string>,
   permalinkMap: Record<string, string>,
-  searchKeyword?: string,
+  searchKeyword?: string
 ): string => {
   if (!threads || threads.length === 0) {
-    return ''
+    return "";
   }
 
   // 全体のメタデータ作成
-  const allMessages = threads.flatMap((thread) => [thread.parent, ...thread.replies])
-  const dates = allMessages.map((msg) => new Date(Number.parseFloat(msg.ts) * 1000))
-  const minDate = new Date(Math.min(...dates.map((d) => d.getTime())))
-  const maxDate = new Date(Math.max(...dates.map((d) => d.getTime())))
+  const allMessages = threads.flatMap((thread) => [
+    thread.parent,
+    ...thread.replies,
+  ]);
+  const dates = allMessages.map(
+    (msg) => new Date(Number.parseFloat(msg.ts) * 1000)
+  );
+  const minDate = new Date(Math.min(...dates.map((d) => d.getTime())));
+  const maxDate = new Date(Math.max(...dates.map((d) => d.getTime())));
 
   // チャンネル・参加者情報
-  const channels = [...new Set(threads.map((thread) => thread.channel))]
-  const allParticipants = [...new Set(allMessages.map((msg) => userMap[msg.user] || msg.user))]
-  const totalMessages = allMessages.length
+  const channels = [...new Set(threads.map((thread) => thread.channel))];
+  const allParticipants = [
+    ...new Set(allMessages.map((msg) => userMap[msg.user] || msg.user)),
+  ];
+  const totalMessages = allMessages.length;
 
   // YAML Front Matter形式で全体メタデータ
-  let markdown = '---\n'
-  markdown += `source: "slack"\n`
-  markdown += `total_threads: ${threads.length}\n`
-  markdown += `total_messages: ${totalMessages}\n`
+  let markdown = "---\n";
+  markdown += `source: "slack"\n`;
+  markdown += `total_threads: ${threads.length}\n`;
+  markdown += `total_messages: ${totalMessages}\n`;
   if (searchKeyword) {
-    markdown += `search_keyword: "${searchKeyword}"\n`
+    markdown += `search_keyword: "${searchKeyword}"\n`;
   }
-  markdown += `channels: [${channels.map((c) => `"${c}"`).join(', ')}]\n`
+  markdown += `channels: [${channels.map((c) => `"${c}"`).join(", ")}]\n`;
   markdown += `participants: [${allParticipants
     .slice(0, 10)
     .map((p) => `"${p}"`)
-    .join(', ')}]\n`
+    .join(", ")}]\n`;
   if (allParticipants.length > 10) {
-    markdown += `total_participants: ${allParticipants.length}\n`
+    markdown += `total_participants: ${allParticipants.length}\n`;
   }
-  markdown += `date_range: "${minDate.toISOString().split('T')[0]} - ${maxDate.toISOString().split('T')[0]}"\n`
-  markdown += `generated_at: "${new Date().toISOString()}"\n`
-  markdown += '---\n\n'
+  markdown += `date_range: "${minDate.toISOString().split("T")[0]} - ${maxDate.toISOString().split("T")[0]}"\n`;
+  markdown += `generated_at: "${new Date().toISOString()}"\n`;
+  markdown += "---\n\n";
 
   // LLM理解しやすいタイトル
   const dateRange =
-    minDate.toLocaleDateString('ja-JP') === maxDate.toLocaleDateString('ja-JP')
-      ? minDate.toLocaleDateString('ja-JP')
-      : `${minDate.toLocaleDateString('ja-JP')} - ${maxDate.toLocaleDateString('ja-JP')}`
+    minDate.toLocaleDateString("ja-JP") === maxDate.toLocaleDateString("ja-JP")
+      ? minDate.toLocaleDateString("ja-JP")
+      : `${minDate.toLocaleDateString("ja-JP")} - ${maxDate.toLocaleDateString("ja-JP")}`;
 
-  markdown += '# Slack Threads Collection\n\n'
+  markdown += "# Slack Threads Collection\n\n";
 
-  markdown += '## Collection Overview\n'
-  markdown += `- **Total Threads**: ${threads.length}\n`
-  markdown += `- **Total Messages**: ${totalMessages}\n`
+  markdown += "## Collection Overview\n";
+  markdown += `- **Total Threads**: ${threads.length}\n`;
+  markdown += `- **Total Messages**: ${totalMessages}\n`;
   if (searchKeyword) {
-    markdown += `- **Search Keyword**: "${searchKeyword}"\n`
+    markdown += `- **Search Keyword**: "${searchKeyword}"\n`;
   }
-  markdown += `- **Channels**: ${channels.join(', ')}\n`
-  markdown += `- **Date Range**: ${dateRange}\n`
-  markdown += `- **Participants**: ${allParticipants.length} unique users\n`
-  markdown += '- **Source**: Slack Workspace\n\n'
+  markdown += `- **Channels**: ${channels.join(", ")}\n`;
+  markdown += `- **Date Range**: ${dateRange}\n`;
+  markdown += `- **Participants**: ${allParticipants.length} unique users\n`;
+  markdown += "- **Source**: Slack Workspace\n\n";
 
   // スレッド目次
-  markdown += '## Threads Index\n\n'
+  markdown += "## Threads Index\n\n";
   threads.forEach((thread, index) => {
-    const date = new Date(Number.parseFloat(thread.parent.ts) * 1000)
-    const formattedDate = date.toLocaleDateString('ja-JP')
-    const userName = userMap[thread.parent.user] || thread.parent.user
+    const date = new Date(Number.parseFloat(thread.parent.ts) * 1000);
+    const formattedDate = date.toLocaleDateString("ja-JP");
+    const userName = userMap[thread.parent.user] || thread.parent.user;
     const truncatedText =
-      thread.parent.text.length > 50 ? `${thread.parent.text.substring(0, 50)}...` : thread.parent.text
+      thread.parent.text.length > 50
+        ? `${thread.parent.text.substring(0, 50)}...`
+        : thread.parent.text;
     markdown += `${index + 1}. [Thread ${index + 1}](#thread-${
       index + 1
-    }) - ${userName} in ${thread.channel} (${formattedDate})\n`
-    markdown += `   "${truncatedText}"\n`
-  })
-  markdown += '\n---\n\n'
+    }) - ${userName} in ${thread.channel} (${formattedDate})\n`;
+    markdown += `   "${truncatedText}"\n`;
+  });
+  markdown += "\n---\n\n";
 
   // 各スレッドの詳細
-  markdown += '## Threads Content\n\n'
+  markdown += "## Threads Content\n\n";
 
   return (
     markdown +
     threads
       .map((thread, index) => {
-        let threadMd = `### Thread ${index + 1} {#thread-${index + 1}}\n\n`
-        threadMd += convertToSlackThreadMarkdown(thread, userMap, permalinkMap)
-        return threadMd
+        let threadMd = `### Thread ${index + 1} {#thread-${index + 1}}\n\n`;
+        threadMd += convertToSlackThreadMarkdown(thread, userMap, permalinkMap);
+        return threadMd;
       })
-      .join('\n\n')
-  ) // スレッド間に空行
-}
+      .join("\n\n")
+  ); // スレッド間に空行
+};

--- a/src/features/slack/utils/slackTextConverter.ts
+++ b/src/features/slack/utils/slackTextConverter.ts
@@ -1,4 +1,4 @@
-import type { SlackMessage, SlackThread, SlackUser } from '../types/slack'
+import type { SlackMessage, SlackThread, SlackUser } from "../types/slack";
 
 /**
  * SlackメッセージオブジェクトをMarkdown文字列に変換します。
@@ -7,31 +7,31 @@ import type { SlackMessage, SlackThread, SlackUser } from '../types/slack'
  * @returns Markdown形式の文字列
  */
 export const convertToSlackMarkdown = (message: SlackMessage): string => {
-  const { ts, user, text } = message
+  const { ts, user, text } = message;
 
   // タイムスタンプをDateオブジェクトに変換
-  const date = new Date(Number.parseFloat(ts) * 1000)
+  const date = new Date(Number.parseFloat(ts) * 1000);
   // YYYY-MM-DD HH:mm:ss 形式の文字列にフォーマット
   const formattedTimestamp = date
-    .toLocaleString('ja-JP', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
+    .toLocaleString("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
     })
-    .replace(/\//g, '-') // スラッシュをハイフンに置換
+    .replace(/\//g, "-"); // スラッシュをハイフンに置換
 
-  const markdownText = text || '' // textがundefinedの場合は空文字に
+  const markdownText = text || ""; // textがundefinedの場合は空文字に
 
   return `---
 Timestamp: ${formattedTimestamp}
-User: ${user || 'N/A'}
+User: ${user || "N/A"}
 ---
 
-${markdownText}`
-}
+${markdownText}`;
+};
 
 /**
  * Slackスレッド全体をLLM最適化Markdown形式に変換する関数
@@ -44,90 +44,96 @@ ${markdownText}`
 export function convertToSlackThreadMarkdown(
   thread: SlackThread,
   userMap: Record<string, string>,
-  permalinkMap: Record<string, string>,
+  permalinkMap: Record<string, string>
 ): string {
   // ユーザー名取得ヘルパー
-  const getUserName = (userId: string) => userMap[userId] || userId
+  const getUserName = (userId: string) => userMap[userId] || userId;
   // パーマリンク取得ヘルパー
-  const getPermalink = (ts: string) => permalinkMap[ts] || ''
+  const getPermalink = (ts: string) => permalinkMap[ts] || "";
 
   // 親メッセージ
-  const parent = thread.parent
-  const parentUser = getUserName(parent.user)
-  const parentPermalink = getPermalink(parent.ts)
+  const parent = thread.parent;
+  const parentUser = getUserName(parent.user);
+  const parentPermalink = getPermalink(parent.ts);
 
   // 日付フォーマット（ISO形式）
-  const parentDate = new Date(Number.parseFloat(parent.ts) * 1000)
-  const parentISODate = parentDate.toISOString()
-  const parentDisplayDate = parentDate.toLocaleDateString('ja-JP', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    timeZone: 'Asia/Tokyo',
-  })
+  const parentDate = new Date(Number.parseFloat(parent.ts) * 1000);
+  const parentISODate = parentDate.toISOString();
+  const parentDisplayDate = parentDate.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone: "Asia/Tokyo",
+  });
 
   // 参加者リスト作成
-  const allMessages = [parent, ...thread.replies]
-  const participants = [...new Set(allMessages.map((msg) => getUserName(msg.user)))]
+  const allMessages = [parent, ...thread.replies];
+  const participants = [
+    ...new Set(allMessages.map((msg) => getUserName(msg.user))),
+  ];
 
   // 時系列情報
-  const firstMessageTime = parentDate
+  const firstMessageTime = parentDate;
   const lastMessageTime =
     thread.replies.length > 0
-      ? new Date(Number.parseFloat(thread.replies[thread.replies.length - 1].ts) * 1000)
-      : parentDate
+      ? new Date(
+          Number.parseFloat(thread.replies[thread.replies.length - 1].ts) * 1000
+        )
+      : parentDate;
 
   // YAML Front Matter形式でメタデータを構造化
-  let md = '---\n'
-  md += `thread_id: "${parent.ts}"\n`
-  md += `channel: "${thread.channel}"\n`
-  md += `permalink: "${parentPermalink}"\n`
-  md += `participants: [${participants.map((p) => `"${p}"`).join(', ')}]\n`
-  md += `reply_count: ${thread.replies.length}\n`
-  md += `date: "${parentDisplayDate}"\n`
-  md += `created_at: "${parentISODate}"\n`
-  md += '---\n\n'
+  let md = "---\n";
+  md += `thread_id: "${parent.ts}"\n`;
+  md += `channel: "${thread.channel}"\n`;
+  md += `permalink: "${parentPermalink}"\n`;
+  md += `participants: [${participants.map((p) => `"${p}"`).join(", ")}]\n`;
+  md += `reply_count: ${thread.replies.length}\n`;
+  md += `date: "${parentDisplayDate}"\n`;
+  md += `created_at: "${parentISODate}"\n`;
+  md += "---\n\n";
 
   // LLM理解しやすい階層構造
-  md += `# Slack Thread: ${parentDisplayDate}\n\n`
+  md += `# Slack Thread: ${parentDisplayDate}\n\n`;
 
-  md += '## Thread Context\n'
-  md += `- **Channel**: ${thread.channel}\n`
-  md += `- **Started by**: ${parentUser}\n`
-  md += `- **Replies**: ${thread.replies.length} messages\n`
-  md += `- **Participants**: ${participants.join(', ')}\n`
+  md += "## Thread Context\n";
+  md += `- **Channel**: ${thread.channel}\n`;
+  md += `- **Started by**: ${parentUser}\n`;
+  md += `- **Replies**: ${thread.replies.length} messages\n`;
+  md += `- **Participants**: ${participants.join(", ")}\n`;
   if (thread.replies.length > 0) {
-    const duration = Math.ceil((lastMessageTime.getTime() - firstMessageTime.getTime()) / (1000 * 60))
-    md += `- **Duration**: ${duration} minutes\n`
+    const duration = Math.ceil(
+      (lastMessageTime.getTime() - firstMessageTime.getTime()) / (1000 * 60)
+    );
+    md += `- **Duration**: ${duration} minutes\n`;
   }
-  md += `- **Source**: [Slack Thread](${parentPermalink})\n\n`
+  md += `- **Source**: [Slack Thread](${parentPermalink})\n\n`;
 
-  md += '## Message Timeline\n\n'
+  md += "## Message Timeline\n\n";
 
   // 親メッセージ
-  md += '### Message 1 (Parent)\n'
-  md += `**Author**: ${parentUser}\n`
-  md += `**Time**: ${parentDate.toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}\n`
-  md += `**Link**: [Permalink](${parentPermalink})\n\n`
-  md += `${parent.text}\n\n`
+  md += "### Message 1 (Parent)\n";
+  md += `**Author**: ${parentUser}\n`;
+  md += `**Time**: ${parentDate.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}\n`;
+  md += `**Link**: [Permalink](${parentPermalink})\n\n`;
+  md += `${parent.text}\n\n`;
 
   // 返信メッセージ
   if (thread.replies.length > 0) {
     thread.replies.forEach((reply, index) => {
-      const replyUser = getUserName(reply.user)
-      const replyDate = new Date(Number.parseFloat(reply.ts) * 1000)
-      const replyPermalink = getPermalink(reply.ts)
+      const replyUser = getUserName(reply.user);
+      const replyDate = new Date(Number.parseFloat(reply.ts) * 1000);
+      const replyPermalink = getPermalink(reply.ts);
 
-      md += `### Message ${index + 2} (Reply)\n`
-      md += `**Author**: ${replyUser}\n`
-      md += `**Time**: ${replyDate.toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}\n`
+      md += `### Message ${index + 2} (Reply)\n`;
+      md += `**Author**: ${replyUser}\n`;
+      md += `**Time**: ${replyDate.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}\n`;
       if (replyPermalink) {
-        md += `**Link**: [Permalink](${replyPermalink})\n`
+        md += `**Link**: [Permalink](${replyPermalink})\n`;
       }
-      md += `\n${reply.text}\n\n`
-    })
+      md += `\n${reply.text}\n\n`;
+    });
   }
 
-  md += '---\n'
-  return md
+  md += "---\n";
+  return md;
 }

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -1,68 +1,78 @@
-import { useCallback, useState } from 'react'
-import toast from 'react-hot-toast'
-import { downloadMarkdownFile } from '../utils/fileDownloader'
+import { useCallback, useState } from "react";
+import toast from "react-hot-toast";
+import { downloadMarkdownFile } from "../utils/fileDownloader";
 
 interface UseDownloadResult {
-  isDownloading: boolean
+  isDownloading: boolean;
   handleDownload: (
     markdownContent: string,
     keyword: string,
     postsExist: boolean,
-    sourceType?: 'docbase' | 'slack',
-  ) => Promise<void>
+    sourceType?: "docbase" | "slack"
+  ) => Promise<void>;
 }
 
 /**
  * Markdownファイルのダウンロード処理と通知を行うカスタムフック
  */
 export const useDownload = (): UseDownloadResult => {
-  const [isDownloading, setIsDownloading] = useState<boolean>(false)
+  const [isDownloading, setIsDownloading] = useState<boolean>(false);
 
   const handleDownload = useCallback(
     async (
       markdownContent: string,
       keyword: string,
       postsExist: boolean,
-      sourceType: 'docbase' | 'slack' = 'docbase',
+      sourceType: "docbase" | "slack" = "docbase"
     ) => {
-      setIsDownloading(true)
+      setIsDownloading(true);
       // ダウンロード対象がない場合は、fileDownloaderからのメッセージをtoastで表示
       if (!postsExist || !markdownContent.trim()) {
-        const result = downloadMarkdownFile(markdownContent, keyword, postsExist, sourceType)
+        const result = downloadMarkdownFile(
+          markdownContent,
+          keyword,
+          postsExist,
+          sourceType
+        );
         if (result.message) {
-          toast.error(result.message)
+          toast.error(result.message);
         }
-        setIsDownloading(false)
-        return
+        setIsDownloading(false);
+        return;
       }
 
       // ダウンロード処理を実行
-      const toastId = toast.loading('Markdownファイルをダウンロード中です...')
+      const toastId = toast.loading("Markdownファイルをダウンロード中です...");
       try {
         // 非同期処理っぽく見せるために少し待つ（実際にはdownloadMarkdownFileは同期的）
-        await new Promise((resolve) => setTimeout(resolve, 500))
-        const result = downloadMarkdownFile(markdownContent, keyword, postsExist, sourceType)
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        const result = downloadMarkdownFile(
+          markdownContent,
+          keyword,
+          postsExist,
+          sourceType
+        );
 
         if (result.success) {
-          toast.success('Markdownファイルをダウンロードしました。', {
+          toast.success("Markdownファイルをダウンロードしました。", {
             id: toastId,
-          })
+          });
         } else {
-          toast.error(result.message || 'ダウンロードに失敗しました。', {
+          toast.error(result.message || "ダウンロードに失敗しました。", {
             id: toastId,
-          })
+          });
         }
       } catch (error) {
-        console.error('Download process error:', error)
-        toast.error('予期せぬエラーによりダウンロードに失敗しました。', {
+        console.error("Download process error:", error);
+        toast.error("予期せぬエラーによりダウンロードに失敗しました。", {
           id: toastId,
-        })
+        });
       } finally {
-        setIsDownloading(false)
+        setIsDownloading(false);
       }
     },
-    [],
-  )
+    []
+  );
 
-  return { isDownloading, handleDownload }
-}
+  return { isDownloading, handleDownload };
+};

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from "react";
 
 /**
  * localStorageと値を同期するためのカスタムフック
@@ -6,91 +6,95 @@ import { useEffect, useState } from 'react'
  * @param initialValue 初期値
  * @returns [storedValue, setValue] storedValueは現在の値、setValueは値を更新する関数
  */
-function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void] {
+function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T | ((val: T) => T)) => void] {
   // localStorageから初期値を取得、なければinitialValueを使用
   const [storedValue, setStoredValue] = useState<T>(() => {
     // windowオブジェクトが存在するか確認 (SSR対策)
-    if (typeof window === 'undefined') {
-      return initialValue
+    if (typeof window === "undefined") {
+      return initialValue;
     }
     try {
-      const item = window.localStorage.getItem(key)
+      const item = window.localStorage.getItem(key);
       if (item) {
         try {
-          return JSON.parse(item) as T
+          return JSON.parse(item) as T;
         } catch (parseError) {
           // パースに失敗した場合は警告を出し、初期値を返す
           console.warn(
             `Error parsing localStorage key "${key}" (value: "${item}"), falling back to initialValue:`,
-            parseError,
-          )
-          return initialValue
+            parseError
+          );
+          return initialValue;
         }
       }
-      return initialValue
+      return initialValue;
     } catch (error) {
-      console.error(`Error reading localStorage key "${key}":`, error)
-      return initialValue
+      console.error(`Error reading localStorage key "${key}":`, error);
+      return initialValue;
     }
-  })
+  });
 
   // storedValueが変更されたらlocalStorageに保存
   const setValue = (value: T | ((val: T) => T)) => {
     try {
-      const valueToStore = value instanceof Function ? value(storedValue) : value
-      setStoredValue(valueToStore)
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      setStoredValue(valueToStore);
       // windowオブジェクトが存在するか確認 (SSR対策)
-      if (typeof window !== 'undefined') {
-        window.localStorage.setItem(key, JSON.stringify(valueToStore))
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
       }
     } catch (error) {
-      console.error(`Error setting localStorage key "${key}":`, error)
+      console.error(`Error setting localStorage key "${key}":`, error);
     }
-  }
+  };
 
   // マウント時にlocalStorageの値でstateを更新する (別のタブでの変更に対応するため)
   useEffect(() => {
-    if (typeof window === 'undefined') return
+    if (typeof window === "undefined") return;
 
     const handleStorageChange = (event: StorageEvent) => {
       if (event.key === key && event.newValue) {
         try {
-          setStoredValue(JSON.parse(event.newValue) as T)
+          setStoredValue(JSON.parse(event.newValue) as T);
         } catch (error) {
           console.warn(
             `Error parsing localStorage key "${key}" on storage event (newValue: "${event.newValue}"), falling back to current value or initialValue if parsing fails elsewhere:`,
-            error,
-          )
+            error
+          );
           // ここでエラーが起きても、storedValueは以前の値のまま or 初期化時の値のまま
         }
       }
-    }
+    };
 
-    window.addEventListener('storage', handleStorageChange)
+    window.addEventListener("storage", handleStorageChange);
     // initialValueが変更された場合も考慮して、localStorageの値を再確認・初期化
-    const currentLocalItem = window.localStorage.getItem(key)
+    const currentLocalItem = window.localStorage.getItem(key);
     if (currentLocalItem === null) {
       // 文字列としての initialValue ではなく、JSON.stringifyされたものが保存されるべき
-      window.localStorage.setItem(key, JSON.stringify(initialValue))
+      window.localStorage.setItem(key, JSON.stringify(initialValue));
     } else {
       try {
-        JSON.parse(currentLocalItem) // 既存の値が有効なJSONかチェック
+        JSON.parse(currentLocalItem); // 既存の値が有効なJSONかチェック
       } catch (e) {
         // 既存の値が不正なJSONなら、initialValueで上書きする
         console.warn(
-          `Invalid JSON in localStorage for key "${key}" (value: "${currentLocalItem}"), overwriting with initialValue.`,
-        )
-        window.localStorage.setItem(key, JSON.stringify(initialValue))
-        setStoredValue(initialValue) // stateも更新
+          `Invalid JSON in localStorage for key "${key}" (value: "${currentLocalItem}"), overwriting with initialValue.`
+        );
+        window.localStorage.setItem(key, JSON.stringify(initialValue));
+        setStoredValue(initialValue); // stateも更新
       }
     }
 
     return () => {
-      window.removeEventListener('storage', handleStorageChange)
-    }
-  }, [key, initialValue]) // initialValueを依存配列に追加
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, [key, initialValue]); // initialValueを依存配列に追加
 
-  return [storedValue, setValue]
+  return [storedValue, setValue];
 }
 
-export default useLocalStorage
+export default useLocalStorage;

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -9,26 +9,26 @@
  * 基本エラー型（cause情報付き）
  */
 export type NetworkApiError = {
-  type: 'network'
-  message: string
-  cause?: unknown
-}
+  type: "network";
+  message: string;
+  cause?: unknown;
+};
 
 export type UnknownApiError = {
-  type: 'unknown'
-  message: string
-  cause?: unknown
-}
+  type: "unknown";
+  message: string;
+  cause?: unknown;
+};
 
 /**
  * シンプルエラー型（cause情報なし）
  */
-export type UnauthorizedApiError = { type: 'unauthorized'; message: string }
-export type RateLimitApiError = { type: 'rate_limit'; message: string }
-export type NotFoundApiError = { type: 'notFound'; message: string }
-export type ValidationApiError = { type: 'validation'; message: string }
-export type MissingScopeApiError = { type: 'missing_scope'; message: string }
-export type SlackSpecificApiError = { type: 'slack_api'; message: string }
+export type UnauthorizedApiError = { type: "unauthorized"; message: string };
+export type RateLimitApiError = { type: "rate_limit"; message: string };
+export type NotFoundApiError = { type: "notFound"; message: string };
+export type ValidationApiError = { type: "validation"; message: string };
+export type MissingScopeApiError = { type: "missing_scope"; message: string };
+export type SlackSpecificApiError = { type: "slack_api"; message: string };
 
 /**
  * 統一APIエラー型
@@ -43,7 +43,7 @@ export type ApiError =
   | NotFoundApiError
   | ValidationApiError
   | MissingScopeApiError
-  | SlackSpecificApiError
+  | SlackSpecificApiError;
 
 /**
  * エラーがApiError型であるかを判定する型ガード
@@ -51,20 +51,20 @@ export type ApiError =
  * @returns ApiErrorであればtrue、そうでなければfalse
  */
 export const isApiError = (error: unknown): error is ApiError => {
-  if (typeof error !== 'object' || error === null) {
-    return false
+  if (typeof error !== "object" || error === null) {
+    return false;
   }
-  const e = error as Record<string, unknown> // キャストの仕方を少し変更
+  const e = error as Record<string, unknown>; // キャストの仕方を少し変更
   return (
-    typeof e.type === 'string' &&
-    typeof e.message === 'string' &&
-    (e.type === 'network' ||
-      e.type === 'unknown' ||
-      e.type === 'unauthorized' ||
-      e.type === 'rate_limit' ||
-      e.type === 'notFound' ||
-      e.type === 'validation' || // 追加
-      e.type === 'missing_scope' || // 追加
-      e.type === 'slack_api') // 追加
-  )
-}
+    typeof e.type === "string" &&
+    typeof e.message === "string" &&
+    (e.type === "network" ||
+      e.type === "unknown" ||
+      e.type === "unauthorized" ||
+      e.type === "rate_limit" ||
+      e.type === "notFound" ||
+      e.type === "validation" || // 追加
+      e.type === "missing_scope" || // 追加
+      e.type === "slack_api") // 追加
+  );
+};

--- a/src/utils/errorMessage.ts
+++ b/src/utils/errorMessage.ts
@@ -1,4 +1,4 @@
-import type { ApiError } from '../types/error'
+import type { ApiError } from "../types/error";
 
 /**
  * APIエラーをユーザーフレンドリーなメッセージに変換するユーティリティ
@@ -6,54 +6,54 @@ import type { ApiError } from '../types/error'
  */
 export function getUserFriendlyErrorMessage(error: ApiError): string {
   switch (error.type) {
-    case 'unauthorized':
+    case "unauthorized":
       // DocbaseとSlackを区別してより具体的な指示を提供
-      if (error.message.includes('Slack')) {
-        return 'Slack APIトークンが無効または期限切れです。正しいUser Token (xoxp-で始まる) を入力してください。'
+      if (error.message.includes("Slack")) {
+        return "Slack APIトークンが無効または期限切れです。正しいUser Token (xoxp-で始まる) を入力してください。";
       }
-      if (error.message.includes('Docbase')) {
-        return 'Docbase APIトークンが無効です。正しいAPIトークンを入力してください。'
+      if (error.message.includes("Docbase")) {
+        return "Docbase APIトークンが無効です。正しいAPIトークンを入力してください。";
       }
-      return 'APIトークンが無効です。正しいトークンを入力してください。'
+      return "APIトークンが無効です。正しいトークンを入力してください。";
 
-    case 'rate_limit':
-      return 'API制限に達しました。しばらく時間をおいてから再試行してください。'
+    case "rate_limit":
+      return "API制限に達しました。しばらく時間をおいてから再試行してください。";
 
-    case 'network':
-      if (error.message.includes('何度か再試行')) {
-        return 'ネットワークエラーが発生し、自動で再試行しましたが改善しませんでした。ネットワーク接続を確認して再試行してください。'
+    case "network":
+      if (error.message.includes("何度か再試行")) {
+        return "ネットワークエラーが発生し、自動で再試行しましたが改善しませんでした。ネットワーク接続を確認して再試行してください。";
       }
-      return 'ネットワークエラーが発生しました。インターネット接続を確認して再試行してください。'
+      return "ネットワークエラーが発生しました。インターネット接続を確認して再試行してください。";
 
-    case 'notFound':
-      if (error.message.includes('チーム')) {
-        return 'Docbaseのチームドメインが見つかりません。正しいドメイン名を入力してください。'
+    case "notFound":
+      if (error.message.includes("チーム")) {
+        return "Docbaseのチームドメインが見つかりません。正しいドメイン名を入力してください。";
       }
-      if (error.message.includes('チャンネル')) {
-        return 'Slackのチャンネルまたはメッセージが見つかりません。アクセス権限があるか確認してください。'
+      if (error.message.includes("チャンネル")) {
+        return "Slackのチャンネルまたはメッセージが見つかりません。アクセス権限があるか確認してください。";
       }
-      if (error.message.includes('ユーザー')) {
-        return 'ユーザーが見つかりません。ユーザーIDを確認してください。'
+      if (error.message.includes("ユーザー")) {
+        return "ユーザーが見つかりません。ユーザーIDを確認してください。";
       }
-      return 'リソースが見つかりません。入力内容を確認してください。'
+      return "リソースが見つかりません。入力内容を確認してください。";
 
-    case 'validation':
-      return '入力内容に問題があります。必須項目をすべて入力してください。'
+    case "validation":
+      return "入力内容に問題があります。必須項目をすべて入力してください。";
 
-    case 'missing_scope':
-      return 'Slack APIトークンに必要な権限がありません。適切なスコープを持つトークンを使用してください。'
+    case "missing_scope":
+      return "Slack APIトークンに必要な権限がありません。適切なスコープを持つトークンを使用してください。";
 
-    case 'slack_api':
-      if (error.message.includes('missing_scope')) {
-        return 'Slack APIトークンに必要なスコープがありません。search:read権限を含むトークンを使用してください。'
+    case "slack_api":
+      if (error.message.includes("missing_scope")) {
+        return "Slack APIトークンに必要なスコープがありません。search:read権限を含むトークンを使用してください。";
       }
-      return 'Slack APIでエラーが発生しました。トークンの権限やアクセス設定を確認してください。'
+      return "Slack APIでエラーが発生しました。トークンの権限やアクセス設定を確認してください。";
 
-    case 'unknown':
-      return '予期しないエラーが発生しました。再試行しても問題が続く場合は、しばらく時間をおいてお試しください。'
+    case "unknown":
+      return "予期しないエラーが発生しました。再試行しても問題が続く場合は、しばらく時間をおいてお試しください。";
 
     default:
-      return 'エラーが発生しました。再試行してください。'
+      return "エラーが発生しました。再試行してください。";
   }
 }
 
@@ -62,53 +62,53 @@ export function getUserFriendlyErrorMessage(error: ApiError): string {
  */
 export function getErrorActionSuggestion(error: ApiError): string | null {
   switch (error.type) {
-    case 'unauthorized':
-      if (error.message.includes('Slack')) {
-        return 'Slack Appの設定でUser Tokenを確認し、適切な権限があることを確認してください。'
+    case "unauthorized":
+      if (error.message.includes("Slack")) {
+        return "Slack Appの設定でUser Tokenを確認し、適切な権限があることを確認してください。";
       }
-      if (error.message.includes('Docbase')) {
-        return 'Docbaseの設定画面でAPIトークンを再生成することをお試しください。'
+      if (error.message.includes("Docbase")) {
+        return "Docbaseの設定画面でAPIトークンを再生成することをお試しください。";
       }
-      return 'APIトークンを再確認し、必要に応じて再生成してください。'
+      return "APIトークンを再確認し、必要に応じて再生成してください。";
 
-    case 'rate_limit':
-      return '数分間待ってから再試行してください。大量のデータを取得する場合は、検索条件を絞り込むことをお勧めします。'
+    case "rate_limit":
+      return "数分間待ってから再試行してください。大量のデータを取得する場合は、検索条件を絞り込むことをお勧めします。";
 
-    case 'network':
-      return 'Wi-Fi接続を確認し、他のウェブサイトにアクセスできるか確認してください。'
+    case "network":
+      return "Wi-Fi接続を確認し、他のウェブサイトにアクセスできるか確認してください。";
 
-    case 'missing_scope':
-      return 'Slack Appの OAuth & Permissions 設定で「search:read」スコープを追加してください。'
+    case "missing_scope":
+      return "Slack Appの OAuth & Permissions 設定で「search:read」スコープを追加してください。";
 
     default:
-      return null
+      return null;
   }
 }
 
 /**
  * エラーの重要度を判定する（UI表示での色分けなどに使用）
  */
-export function getErrorSeverity(error: ApiError): 'low' | 'medium' | 'high' {
+export function getErrorSeverity(error: ApiError): "low" | "medium" | "high" {
   switch (error.type) {
-    case 'validation':
-      return 'low' // ユーザー入力の問題
+    case "validation":
+      return "low"; // ユーザー入力の問題
 
-    case 'unauthorized':
-    case 'missing_scope':
-      return 'medium' // 設定の問題
+    case "unauthorized":
+    case "missing_scope":
+      return "medium"; // 設定の問題
 
-    case 'rate_limit':
-      return 'medium' // 一時的な問題
+    case "rate_limit":
+      return "medium"; // 一時的な問題
 
-    case 'network':
-    case 'notFound':
-      return 'medium' // 外部要因
+    case "network":
+    case "notFound":
+      return "medium"; // 外部要因
 
-    case 'unknown':
-    case 'slack_api':
-      return 'high' // システム的な問題
+    case "unknown":
+    case "slack_api":
+      return "high"; // システム的な問題
 
     default:
-      return 'medium'
+      return "medium";
   }
 }

--- a/src/utils/errorStorage.ts
+++ b/src/utils/errorStorage.ts
@@ -5,40 +5,40 @@
  * LocalStorageに保存し、デバッグやサポートに活用する。
  */
 
-import type { ErrorInfo } from 'react'
+import type { ErrorInfo } from "react";
 
 interface ErrorLog {
-  id: string
-  timestamp: string
+  id: string;
+  timestamp: string;
   error: {
-    name: string
-    message: string
-    stack?: string
-  }
+    name: string;
+    message: string;
+    stack?: string;
+  };
   errorInfo: {
-    componentStack: string
-  }
+    componentStack: string;
+  };
   context: {
-    url: string
-    userAgent: string
+    url: string;
+    userAgent: string;
     viewport: {
-      width: number
-      height: number
-    }
-    userId?: string // 匿名ID
-  }
+      width: number;
+      height: number;
+    };
+    userId?: string; // 匿名ID
+  };
 }
 
 interface ErrorStorageMetadata {
-  version: string
-  maxLogs: number
-  lastCleanup: string
+  version: string;
+  maxLogs: number;
+  lastCleanup: string;
 }
 
-const ERROR_STORAGE_KEY = 'notebooklm_error_logs'
-const ERROR_METADATA_KEY = 'notebooklm_error_metadata'
-const MAX_ERROR_LOGS = 50
-const STORAGE_VERSION = '1.0'
+const ERROR_STORAGE_KEY = "notebooklm_error_logs";
+const ERROR_METADATA_KEY = "notebooklm_error_metadata";
+const MAX_ERROR_LOGS = 50;
+const STORAGE_VERSION = "1.0";
 
 /**
  * エラーログをLocalStorageに保存
@@ -47,11 +47,11 @@ export function logError(
   error: Error,
   errorInfo: ErrorInfo,
   additionalContext: {
-    url: string
-    userAgent: string
-    timestamp: string
-    userId?: string
-  },
+    url: string;
+    userAgent: string;
+    timestamp: string;
+    userId?: string;
+  }
 ): ErrorLog {
   try {
     const errorLog: ErrorLog = {
@@ -60,10 +60,10 @@ export function logError(
       error: {
         name: error.name,
         message: error.message,
-        stack: error.stack || '',
+        stack: error.stack || "",
       },
       errorInfo: {
-        componentStack: errorInfo.componentStack || '',
+        componentStack: errorInfo.componentStack || "",
       },
       context: {
         url: additionalContext.url,
@@ -74,28 +74,28 @@ export function logError(
         },
         userId: additionalContext.userId || getOrCreateUserId(),
       },
-    }
+    };
 
     // 既存のログを取得
-    const existingLogs = getErrorLogs()
+    const existingLogs = getErrorLogs();
 
     // 新しいログを先頭に追加
-    const updatedLogs = [errorLog, ...existingLogs]
+    const updatedLogs = [errorLog, ...existingLogs];
 
     // 最大件数を超えた場合は古いログを削除
-    const trimmedLogs = updatedLogs.slice(0, MAX_ERROR_LOGS)
+    const trimmedLogs = updatedLogs.slice(0, MAX_ERROR_LOGS);
 
     // LocalStorageに保存
-    localStorage.setItem(ERROR_STORAGE_KEY, JSON.stringify(trimmedLogs))
+    localStorage.setItem(ERROR_STORAGE_KEY, JSON.stringify(trimmedLogs));
 
     // メタデータを更新
-    updateMetadata()
+    updateMetadata();
 
-    return errorLog
+    return errorLog;
   } catch (storageError) {
     // LocalStorageの保存に失敗した場合はコンソールにログ出力
-    console.error('Failed to save error log to localStorage:', storageError)
-    console.error('Original error:', error)
+    console.error("Failed to save error log to localStorage:", storageError);
+    console.error("Original error:", error);
 
     // 最低限のログオブジェクトを返す
     return {
@@ -104,10 +104,10 @@ export function logError(
       error: {
         name: error.name,
         message: error.message,
-        stack: error.stack || '',
+        stack: error.stack || "",
       },
       errorInfo: {
-        componentStack: errorInfo.componentStack || '',
+        componentStack: errorInfo.componentStack || "",
       },
       context: {
         url: additionalContext.url,
@@ -117,7 +117,7 @@ export function logError(
           height: window.innerHeight || 0,
         },
       },
-    }
+    };
   }
 }
 
@@ -126,14 +126,14 @@ export function logError(
  */
 export function getErrorLogs(): ErrorLog[] {
   try {
-    const stored = localStorage.getItem(ERROR_STORAGE_KEY)
-    if (!stored) return []
+    const stored = localStorage.getItem(ERROR_STORAGE_KEY);
+    if (!stored) return [];
 
-    const logs = JSON.parse(stored)
-    return Array.isArray(logs) ? logs : []
+    const logs = JSON.parse(stored);
+    return Array.isArray(logs) ? logs : [];
   } catch (error) {
-    console.error('Failed to retrieve error logs:', error)
-    return []
+    console.error("Failed to retrieve error logs:", error);
+    return [];
   }
 }
 
@@ -141,8 +141,8 @@ export function getErrorLogs(): ErrorLog[] {
  * 特定のエラーログを取得
  */
 export function getErrorLog(id: string): ErrorLog | null {
-  const logs = getErrorLogs()
-  return logs.find((log) => log.id === id) || null
+  const logs = getErrorLogs();
+  return logs.find((log) => log.id === id) || null;
 }
 
 /**
@@ -150,12 +150,12 @@ export function getErrorLog(id: string): ErrorLog | null {
  */
 export function clearErrorLogs(): boolean {
   try {
-    localStorage.removeItem(ERROR_STORAGE_KEY)
-    localStorage.removeItem(ERROR_METADATA_KEY)
-    return true
+    localStorage.removeItem(ERROR_STORAGE_KEY);
+    localStorage.removeItem(ERROR_METADATA_KEY);
+    return true;
   } catch (error) {
-    console.error('Failed to clear error logs:', error)
-    return false
+    console.error("Failed to clear error logs:", error);
+    return false;
   }
 }
 
@@ -164,25 +164,25 @@ export function clearErrorLogs(): boolean {
  */
 export function cleanupOldErrorLogs(): number {
   try {
-    const logs = getErrorLogs()
-    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000
+    const logs = getErrorLogs();
+    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
 
     const recentLogs = logs.filter((log) => {
-      const logTime = new Date(log.timestamp).getTime()
-      return logTime > sevenDaysAgo
-    })
+      const logTime = new Date(log.timestamp).getTime();
+      return logTime > sevenDaysAgo;
+    });
 
-    const removedCount = logs.length - recentLogs.length
+    const removedCount = logs.length - recentLogs.length;
 
     if (removedCount > 0) {
-      localStorage.setItem(ERROR_STORAGE_KEY, JSON.stringify(recentLogs))
-      updateMetadata()
+      localStorage.setItem(ERROR_STORAGE_KEY, JSON.stringify(recentLogs));
+      updateMetadata();
     }
 
-    return removedCount
+    return removedCount;
   } catch (error) {
-    console.error('Failed to cleanup error logs:', error)
-    return 0
+    console.error("Failed to cleanup error logs:", error);
+    return 0;
   }
 }
 
@@ -190,30 +190,30 @@ export function cleanupOldErrorLogs(): number {
  * エラーログの統計情報を取得
  */
 export function getErrorLogStats(): {
-  totalLogs: number
-  lastError: string | null
-  errorTypes: Record<string, number>
+  totalLogs: number;
+  lastError: string | null;
+  errorTypes: Record<string, number>;
   timeRange: {
-    oldest: string | null
-    newest: string | null
-  }
+    oldest: string | null;
+    newest: string | null;
+  };
 } {
-  const logs = getErrorLogs()
+  const logs = getErrorLogs();
 
-  const errorTypes: Record<string, number> = {}
-  let oldest: string | null = null
-  let newest: string | null = null
+  const errorTypes: Record<string, number> = {};
+  let oldest: string | null = null;
+  let newest: string | null = null;
 
   for (const log of logs) {
     // エラータイプをカウント
-    errorTypes[log.error.name] = (errorTypes[log.error.name] || 0) + 1
+    errorTypes[log.error.name] = (errorTypes[log.error.name] || 0) + 1;
 
     // 時間範囲を更新
     if (!oldest || log.timestamp < oldest) {
-      oldest = log.timestamp
+      oldest = log.timestamp;
     }
     if (!newest || log.timestamp > newest) {
-      newest = log.timestamp
+      newest = log.timestamp;
     }
   }
 
@@ -225,25 +225,25 @@ export function getErrorLogStats(): {
       oldest,
       newest,
     },
-  }
+  };
 }
 
 /**
  * エラーログをCSV形式でエクスポート（デバッグ用）
  */
 export function exportErrorLogsAsCSV(): string {
-  const logs = getErrorLogs()
+  const logs = getErrorLogs();
 
   const headers = [
-    'ID',
-    'Timestamp',
-    'Error Name',
-    'Error Message',
-    'URL',
-    'User Agent',
-    'Viewport Width',
-    'Viewport Height',
-  ]
+    "ID",
+    "Timestamp",
+    "Error Name",
+    "Error Message",
+    "URL",
+    "User Agent",
+    "Viewport Width",
+    "Viewport Height",
+  ];
 
   const rows = logs.map((log) => [
     log.id,
@@ -254,36 +254,39 @@ export function exportErrorLogsAsCSV(): string {
     log.context.userAgent.replace(/"/g, '""'),
     log.context.viewport.width.toString(),
     log.context.viewport.height.toString(),
-  ])
+  ]);
 
-  const csvContent = [headers.join(','), ...rows.map((row) => row.map((cell) => `"${cell}"`).join(','))].join('\n')
+  const csvContent = [
+    headers.join(","),
+    ...rows.map((row) => row.map((cell) => `"${cell}"`).join(",")),
+  ].join("\n");
 
-  return csvContent
+  return csvContent;
 }
 
 /**
  * ユニークなエラーIDを生成
  */
 function generateErrorId(): string {
-  return Date.now().toString(36) + Math.random().toString(36).substr(2, 9)
+  return Date.now().toString(36) + Math.random().toString(36).substr(2, 9);
 }
 
 /**
  * 匿名ユーザーIDを取得または作成
  */
 function getOrCreateUserId(): string {
-  const USER_ID_KEY = 'notebooklm_user_id'
+  const USER_ID_KEY = "notebooklm_user_id";
 
   try {
-    let userId = localStorage.getItem(USER_ID_KEY)
+    let userId = localStorage.getItem(USER_ID_KEY);
     if (!userId) {
-      userId = `user_${Date.now().toString(36)}${Math.random().toString(36).substr(2, 9)}`
-      localStorage.setItem(USER_ID_KEY, userId)
+      userId = `user_${Date.now().toString(36)}${Math.random().toString(36).substr(2, 9)}`;
+      localStorage.setItem(USER_ID_KEY, userId);
     }
-    return userId
+    return userId;
   } catch {
     // LocalStorageにアクセスできない場合は一時的なIDを生成
-    return `temp_${Date.now().toString(36)}`
+    return `temp_${Date.now().toString(36)}`;
   }
 }
 
@@ -296,11 +299,11 @@ function updateMetadata(): void {
       version: STORAGE_VERSION,
       maxLogs: MAX_ERROR_LOGS,
       lastCleanup: new Date().toISOString(),
-    }
+    };
 
-    localStorage.setItem(ERROR_METADATA_KEY, JSON.stringify(metadata))
+    localStorage.setItem(ERROR_METADATA_KEY, JSON.stringify(metadata));
   } catch (error) {
-    console.error('Failed to update error storage metadata:', error)
+    console.error("Failed to update error storage metadata:", error);
   }
 }
 
@@ -308,14 +311,14 @@ function updateMetadata(): void {
  * 開発環境用: エラーログの詳細表示
  */
 export function debugErrorLogs(): void {
-  if (process.env.NODE_ENV !== 'development') return
+  if (process.env.NODE_ENV !== "development") return;
 
-  const logs = getErrorLogs()
-  const stats = getErrorLogStats()
+  const logs = getErrorLogs();
+  const stats = getErrorLogStats();
 
-  console.group('🐛 Error Logs Debug Info')
-  console.log('Stats:', stats)
-  console.log('All Logs:', logs)
-  console.log('CSV Export:', exportErrorLogsAsCSV())
-  console.groupEnd()
+  console.group("🐛 Error Logs Debug Info");
+  console.log("Stats:", stats);
+  console.log("All Logs:", logs);
+  console.log("CSV Export:", exportErrorLogsAsCSV());
+  console.groupEnd();
 }

--- a/src/utils/fileDownloader.ts
+++ b/src/utils/fileDownloader.ts
@@ -11,55 +11,57 @@ export const downloadMarkdownFile = (
   markdownContent: string,
   keyword: string,
   postsExist: boolean,
-  sourceType: 'docbase' | 'slack' = 'docbase',
+  sourceType: "docbase" | "slack" = "docbase"
 ): { success: boolean; message?: string } => {
   // 投稿が存在しない、またはMarkdownコンテントが空の場合はダウンロードしない
   if (!postsExist || !markdownContent.trim()) {
     // ユーザーに通知するかどうかは呼び出し側で判断するため、ここでは特別なメッセージは返さない
     return {
       success: false,
-      message: 'ダウンロードするコンテンツがありません。',
-    }
+      message: "ダウンロードするコンテンツがありません。",
+    };
   }
 
-  let url: string | null = null
+  let url: string | null = null;
   try {
     const blob = new Blob([markdownContent], {
-      type: 'text/markdown;charset=utf-8',
-    })
-    url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
+      type: "text/markdown;charset=utf-8",
+    });
+    url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
 
     // LLM最適化ファイル命名規則: {source}_YYYY-MM-DD_{keyword}_{type}.md
-    const now = new Date()
-    const year = now.getFullYear()
-    const month = String(now.getMonth() + 1).padStart(2, '0')
-    const day = String(now.getDate()).padStart(2, '0')
-    const dateStr = `${year}-${month}-${day}`
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    const dateStr = `${year}-${month}-${day}`;
 
     // キーワードをファイル名に安全な形式に変換
     const safeKeyword = keyword.trim()
-      ? keyword.trim().replace(/[^a-zA-Z0-9\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/g, '_')
-      : 'search'
+      ? keyword
+          .trim()
+          .replace(/[^a-zA-Z0-9\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/g, "_")
+      : "search";
 
     // ソースタイプ別のファイル名
-    const contentType = sourceType === 'slack' ? 'threads' : 'articles'
-    a.download = `${sourceType}_${dateStr}_${safeKeyword}_${contentType}.md`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-    return { success: true }
+    const contentType = sourceType === "slack" ? "threads" : "articles";
+    a.download = `${sourceType}_${dateStr}_${safeKeyword}_${contentType}.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    return { success: true };
   } catch (error) {
-    console.error('Markdown file download error:', error)
+    console.error("Markdown file download error:", error);
     // エラーの場合でもリソースをクリーンアップ
     if (url) {
-      URL.revokeObjectURL(url)
+      URL.revokeObjectURL(url);
     }
     return {
       success: false,
-      message: 'ファイルのダウンロード中にエラーが発生しました。',
-    }
+      message: "ファイルのダウンロード中にエラーが発生しました。",
+    };
   }
-}
+};

--- a/tests/storybook.spec.ts
+++ b/tests/storybook.spec.ts
@@ -1,102 +1,151 @@
-import { type Page, expect, test } from '@playwright/test'
+import { type Page, expect, test } from "@playwright/test";
 
 // テストのタイムアウトを延長
-test.setTimeout(60000)
+test.setTimeout(60000);
 
-test.describe('Storybook動作確認', () => {
-  test('Storybookが正常に起動する', async ({ page }: { page: Page }) => {
-    await page.goto('/')
+test.describe("Storybook動作確認", () => {
+  test("Storybookが正常に起動する", async ({ page }: { page: Page }) => {
+    await page.goto("/");
 
     // Storybookのタイトルが表示されることを確認
-    await expect(page).toHaveTitle(/Storybook/)
+    await expect(page).toHaveTitle(/Storybook/);
 
     // サイドバーが表示されることを確認（より汎用的なセレクター）
-    await expect(page.locator('[data-nodetype="component"]').first()).toBeVisible({ timeout: 10000 })
-  })
+    await expect(
+      page.locator('[data-nodetype="component"]').first()
+    ).toBeVisible({ timeout: 10000 });
+  });
 
-  test('Features構造が正しく表示される', async ({ page }: { page: Page }) => {
-    await page.goto('/')
+  test("Features構造が正しく表示される", async ({ page }: { page: Page }) => {
+    await page.goto("/");
 
     // サイドバーが表示されるまで待機
-    await page.locator('[data-nodetype="component"]').first().waitFor({ state: 'visible', timeout: 10000 })
+    await page
+      .locator('[data-nodetype="component"]')
+      .first()
+      .waitFor({ state: "visible", timeout: 10000 });
 
     // Features に関するコンポーネントが表示されることを確認
-    await expect(page.locator('button[data-action="collapse-root"]', { hasText: 'Features' })).toBeVisible({
+    await expect(
+      page.locator('button[data-action="collapse-root"]', {
+        hasText: "Features",
+      })
+    ).toBeVisible({
       timeout: 10000,
-    })
+    });
 
     // Docbase コンポーネントが表示されることを確認
-    await expect(page.locator('text=Docbase').first()).toBeVisible({ timeout: 10000 })
-  })
+    await expect(page.locator("text=Docbase").first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
 
-  test('DocbaseMarkdownPreview - Default Storyが表示される', async ({ page }: { page: Page }) => {
-    await page.goto('/')
+  test("DocbaseMarkdownPreview - Default Storyが表示される", async ({
+    page,
+  }: { page: Page }) => {
+    await page.goto("/");
 
     // サイドバーが表示されるまで待機
-    await page.locator('[data-nodetype="component"]').first().waitFor({ state: 'visible', timeout: 10000 })
+    await page
+      .locator('[data-nodetype="component"]')
+      .first()
+      .waitFor({ state: "visible", timeout: 10000 });
 
     // DocbaseMarkdownPreviewコンポーネントをクリック（サイドバーのボタン）
-    await page.locator('button#features-docbase-components-docbasemarkdownpreview').click()
-    await page.waitForTimeout(1000)
+    await page
+      .locator("button#features-docbase-components-docbasemarkdownpreview")
+      .click();
+    await page.waitForTimeout(1000);
 
     // Default Storyを選択（具体的なIDを使用）
-    await page.locator('#features-docbase-components-docbasemarkdownpreview--default').click()
-    await page.waitForTimeout(2000) // iframeロード待機
+    await page
+      .locator("#features-docbase-components-docbasemarkdownpreview--default")
+      .click();
+    await page.waitForTimeout(2000); // iframeロード待機
 
     // プレビューエリアでDocbaseMarkdownPreviewコンポーネントが表示されることを確認
-    const iframe = page.frameLocator('#storybook-preview-iframe')
+    const iframe = page.frameLocator("#storybook-preview-iframe");
     // iframeのコンテンツがロードされるまで待機
-    await iframe.locator('body').waitFor({ state: 'attached' })
+    await iframe.locator("body").waitFor({ state: "attached" });
     // h2タグのプレビュータイトルを確認
-    await expect(iframe.locator('h2').filter({ hasText: 'Docbase記事プレビュー' }).first()).toBeVisible()
+    await expect(
+      iframe.locator("h2").filter({ hasText: "Docbase記事プレビュー" }).first()
+    ).toBeVisible();
 
     // サンプルMarkdownの内容が表示されることを確認
-    await expect(iframe.locator('h1:has-text("Docbase記事サンプル")').first()).toBeVisible()
-    await expect(iframe.locator('h2:has-text("機能一覧")').first()).toBeVisible()
-  })
+    await expect(
+      iframe.locator('h1:has-text("Docbase記事サンプル")').first()
+    ).toBeVisible();
+    await expect(
+      iframe.locator('h2:has-text("機能一覧")').first()
+    ).toBeVisible();
+  });
 
-  test('DocbaseMarkdownPreview - Empty Storyが表示される', async ({ page }: { page: Page }) => {
-    await page.goto('/')
+  test("DocbaseMarkdownPreview - Empty Storyが表示される", async ({
+    page,
+  }: { page: Page }) => {
+    await page.goto("/");
 
     // サイドバーが表示されるまで待機
-    await page.locator('[data-nodetype="component"]').first().waitFor({ state: 'visible', timeout: 10000 })
+    await page
+      .locator('[data-nodetype="component"]')
+      .first()
+      .waitFor({ state: "visible", timeout: 10000 });
 
     // DocbaseMarkdownPreviewコンポーネントをクリック（サイドバーのボタン）
-    await page.locator('button#features-docbase-components-docbasemarkdownpreview').click()
-    await page.waitForTimeout(1000)
+    await page
+      .locator("button#features-docbase-components-docbasemarkdownpreview")
+      .click();
+    await page.waitForTimeout(1000);
 
     // Empty Storyを選択（具体的なIDを使用）
-    await page.locator('#features-docbase-components-docbasemarkdownpreview--empty').click()
-    await page.waitForTimeout(2000)
+    await page
+      .locator("#features-docbase-components-docbasemarkdownpreview--empty")
+      .click();
+    await page.waitForTimeout(2000);
 
     // 空状態のメッセージが表示されることを確認
-    const iframe = page.frameLocator('#storybook-preview-iframe')
+    const iframe = page.frameLocator("#storybook-preview-iframe");
     await expect(
-      iframe.locator('p:has-text("Docbase記事を検索すると、ここにプレビューが表示されます。")'),
-    ).toBeVisible()
-  })
+      iframe.locator(
+        'p:has-text("Docbase記事を検索すると、ここにプレビューが表示されます。")'
+      )
+    ).toBeVisible();
+  });
 
-  test('ダウンロードボタンが正常に動作する', async ({ page }: { page: Page }) => {
-    await page.goto('/')
+  test("ダウンロードボタンが正常に動作する", async ({
+    page,
+  }: { page: Page }) => {
+    await page.goto("/");
 
     // サイドバーが表示されるまで待機
-    await page.locator('[data-nodetype="component"]').first().waitFor({ state: 'visible', timeout: 10000 })
+    await page
+      .locator('[data-nodetype="component"]')
+      .first()
+      .waitFor({ state: "visible", timeout: 10000 });
 
     // DocbaseMarkdownPreview Default Storyを表示
-    await page.locator('button#features-docbase-components-docbasemarkdownpreview').click()
-    await page.waitForTimeout(1000)
-    await page.locator('#features-docbase-components-docbasemarkdownpreview--default').click()
-    await page.waitForTimeout(2000)
+    await page
+      .locator("button#features-docbase-components-docbasemarkdownpreview")
+      .click();
+    await page.waitForTimeout(1000);
+    await page
+      .locator("#features-docbase-components-docbasemarkdownpreview--default")
+      .click();
+    await page.waitForTimeout(2000);
 
-    const iframe = page.frameLocator('#storybook-preview-iframe')
+    const iframe = page.frameLocator("#storybook-preview-iframe");
 
     // ダウンロードボタンが表示されることを確認
     // iframeのコンテンツがロードされるまで待機
-    await iframe.locator('body').waitFor({ state: 'attached' })
-    const downloadButton = iframe.locator('button').filter({ hasText: 'ダウンロード' }).first()
-    await expect(downloadButton).toBeVisible()
+    await iframe.locator("body").waitFor({ state: "attached" });
+    const downloadButton = iframe
+      .locator("button")
+      .filter({ hasText: "ダウンロード" })
+      .first();
+    await expect(downloadButton).toBeVisible();
 
     // ボタンがクリック可能であることを確認
-    await expect(downloadButton).toBeEnabled()
-  })
-})
+    await expect(downloadButton).toBeEnabled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,40 +1,40 @@
-import { resolve } from 'node:path'
-import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vitest/config'
+import { resolve } from "node:path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],
   test: {
     // テスト環境の設定
-    environment: 'jsdom',
+    environment: "jsdom",
 
     // グローバル設定
     globals: true,
 
     // テストセットアップファイル
-    setupFiles: './src/__tests__/setup.ts',
+    setupFiles: "./src/__tests__/setup.ts",
 
     // テスト対象から除外
     exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/cypress/**',
-      '**/.{idea,git,cache,output,temp}/**',
-      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
-      '**/tests/**', // Playwrightテストディレクトリを除外
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/cypress/**",
+      "**/.{idea,git,cache,output,temp}/**",
+      "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*",
+      "**/tests/**", // Playwrightテストディレクトリを除外
     ],
 
     // カバレッジ設定
     coverage: {
-      reporter: ['text', 'json', 'html'],
+      reporter: ["text", "json", "html"],
       exclude: [
-        'node_modules/',
-        'src/__tests__/',
-        '*.config.*',
-        'src/types/',
-        'src/app/layout.tsx',
-        'src/app/page.tsx',
-        'src/app/*/page.tsx',
+        "node_modules/",
+        "src/__tests__/",
+        "*.config.*",
+        "src/types/",
+        "src/app/layout.tsx",
+        "src/app/page.tsx",
+        "src/app/*/page.tsx",
       ],
       thresholds: {
         global: {
@@ -48,20 +48,20 @@ export default defineConfig({
 
     // TypeScript設定
     typecheck: {
-      tsconfig: './tsconfig.json',
+      tsconfig: "./tsconfig.json",
     },
   },
 
   // エイリアス設定（Next.jsのパスエイリアスと同期）
   resolve: {
     alias: {
-      '@': resolve(__dirname, './src'),
-      '@/components': resolve(__dirname, './src/components'),
-      '@/lib': resolve(__dirname, './src/lib'),
-      '@/hooks': resolve(__dirname, './src/hooks'),
-      '@/utils': resolve(__dirname, './src/utils'),
-      '@/types': resolve(__dirname, './src/types'),
-      '@/adapters': resolve(__dirname, './src/adapters'),
+      "@": resolve(__dirname, "./src"),
+      "@/components": resolve(__dirname, "./src/components"),
+      "@/lib": resolve(__dirname, "./src/lib"),
+      "@/hooks": resolve(__dirname, "./src/hooks"),
+      "@/utils": resolve(__dirname, "./src/utils"),
+      "@/types": resolve(__dirname, "./src/types"),
+      "@/adapters": resolve(__dirname, "./src/adapters"),
     },
   },
-})
+});


### PR DESCRIPTION
## Summary
- Docbaseプレビュー機能の使いやすさとデザインを大幅改善
- パット見で記事内容を確認できるよう最適化
- 洗練されたモダンデザインを採用
- **詳細検索からグループフィールドを削除し、より直感的な検索体験を提供**

## Changes
### プレビュー機能改善
- **プレビュー専用関数の実装**: ダウンロード用とは別の最適化されたMarkdown生成
- **タイトル表示の除去**: 「Markdownプレビュー」「ダウンロード」ボタンを削除
- **記事間余白の拡大**: 視覚的な区切りを明確化
- **メタデータと本文間の余白調整**: CSSによる適切なスペーシング
- **デザインの統一**: 
  - プレビューコンテナを白背景+シャドウに変更
  - Docbase記事タイトルをエレガントなカードデザインに
  - 記事内Markdownタイトルを階層的なスタイルで統一
  - slate系カラーパレットで洗練された印象

### 詳細検索機能改善
- **グループ名入力フィールドを削除**: より直感的な検索体験を提供
- **型定義からグループ関連プロパティを削除**: `DocbaseGroup`、`groups`プロパティ
- **検索クエリ構築ロジックからグループ処理を削除**: シンプルで高速な検索
- **Markdownジェネレーターからグループ情報表示を削除**: 統一されたメタデータ表示

### コード品質向上
- **Biome設定をPrettier形式に統一**: 全コードベースの再フォーマット
- **関連テストケースとドキュメントを更新**: 37個のテストケース追加

## Background
- **プレビュー機能**: ユーザーが記事内容を素早く確認できるよう最適化
- **グループ機能削除**: 使用頻度が低く、検索条件を過度に複雑化していたため削除

## Remaining Search Features
- ✅ タグ検索（カンマ区切り）
- ✅ 投稿者検索（ユーザーID）
- ✅ タイトルキーワード検索
- ✅ 投稿期間検索（開始日・終了日）

## Test Results
- ✅ TypeScript型チェック: エラーなし
- ✅ 全テスト（203件）: PASS
- ✅ Next.jsビルド: 成功
- ✅ Biome lintチェック通過
- ✅ ブラウザでのプレビュー動作確認

resolves #218