### PR TITLE
fix(slack): CORSエラー修正とUI改善

### DIFF
--- a/src/__tests__/adapters/slackAdapter.test.ts
+++ b/src/__tests__/adapters/slackAdapter.test.ts
@@ -278,8 +278,8 @@ describe("SlackAdapter", () => {
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: "https://slack.com/api/chat.getPermalink?channel=C123456&message_ts=1234567890.123456",
-          method: "GET",
+          url: "https://slack.com/api/chat.getPermalink",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },
@@ -306,8 +306,8 @@ describe("SlackAdapter", () => {
 
       const mockHttpClient = createMockHttpClient([
         {
-          url: "https://slack.com/api/chat.getPermalink?channel=C123456&message_ts=invalid-ts",
-          method: "GET",
+          url: "https://slack.com/api/chat.getPermalink",
+          method: "POST",
           status: 200,
           data: mockResponse,
         },

--- a/src/app/slack/page.tsx
+++ b/src/app/slack/page.tsx
@@ -69,22 +69,95 @@ export default function SlackPage() {
 
               {/* 右側: プレビューエリア */}
               <div className="space-y-6">
-                <SlackMarkdownPreview
-                  threads={slackForm.slackThreads}
-                  userMaps={slackForm.userMaps}
-                  permalinkMaps={slackForm.permalinkMaps}
-                  searchQuery={slackForm.searchQuery}
-                  title="検索結果プレビュー"
-                  onDownload={() =>
-                    slackForm.onDownload(
-                      "",
-                      slackForm.searchQuery,
-                      slackForm.slackThreads.length > 0
-                    )
-                  }
-                  emptyMessage="Slackスレッドの検索結果がここに表示されます。"
-                  className=""
-                />
+                {!slackForm.isLoading && (
+                  <SlackMarkdownPreview
+                    threads={slackForm.slackThreads}
+                    userMaps={slackForm.userMaps}
+                    permalinkMaps={slackForm.permalinkMaps}
+                    searchQuery={slackForm.searchQuery}
+                    title="検索結果プレビュー"
+                    onDownload={() =>
+                      slackForm.onDownload(
+                        "",
+                        slackForm.searchQuery,
+                        slackForm.slackThreads.length > 0
+                      )
+                    }
+                    emptyMessage="Slackスレッドの検索結果がここに表示されます。"
+                    className=""
+                  />
+                )}
+                {slackForm.isLoading && (
+                  <div className="bg-white shadow-md rounded-lg p-6 border border-gray-200">
+                    <h3 className="text-lg font-semibold text-gray-800 mb-4">
+                      検索結果プレビュー
+                    </h3>
+                    <div className="flex items-center justify-center py-12">
+                      <div className="text-center space-y-4">
+                        <svg
+                          className="animate-spin h-8 w-8 text-docbase-primary mx-auto"
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                        >
+                          <title>検索処理ローディング</title>
+                          <circle
+                            className="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                          />
+                          <path
+                            className="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                          />
+                        </svg>
+                        <div className="space-y-2">
+                          <p className="text-gray-800 font-medium">
+                            {slackForm.progressStatus?.message || "検索中..."}
+                          </p>
+                          {slackForm.progressStatus?.current &&
+                            slackForm.progressStatus?.total && (
+                              <p className="text-sm text-gray-600">
+                                {slackForm.progressStatus.current} /{" "}
+                                {slackForm.progressStatus.total}
+                              </p>
+                            )}
+                        </div>
+                        {/* プログレスバー */}
+                        <div className="w-64 mx-auto">
+                          <div className="w-full bg-gray-200 rounded-full h-2">
+                            <div
+                              className="bg-docbase-primary h-2 rounded-full transition-all duration-300"
+                              style={{
+                                width:
+                                  slackForm.progressStatus?.phase ===
+                                  "searching"
+                                    ? "25%"
+                                    : slackForm.progressStatus?.phase ===
+                                        "fetching_threads"
+                                      ? "50%"
+                                      : slackForm.progressStatus?.phase ===
+                                          "fetching_users"
+                                        ? "75%"
+                                        : slackForm.progressStatus?.phase ===
+                                            "generating_permalinks"
+                                          ? "90%"
+                                          : slackForm.progressStatus?.phase ===
+                                              "completed"
+                                            ? "100%"
+                                            : "10%",
+                              }}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/features/slack/adapters/slackAdapter.ts
+++ b/src/features/slack/adapters/slackAdapter.ts
@@ -251,16 +251,22 @@ export function createSlackAdapter(httpClient: HttpClient): SlackAdapter {
     ): Promise<Result<string, ApiError>> {
       const { token, channel, messageTs } = params;
 
-      const url = `${API_BASE_URL}/chat.getPermalink?channel=${encodeURIComponent(
-        channel
-      )}&message_ts=${encodeURIComponent(messageTs)}`;
-
-      const result = await httpClient.fetch<SlackApiResponse>(url, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
+      const formParams = new URLSearchParams({
+        token,
+        channel,
+        message_ts: messageTs,
       });
+
+      const result = await httpClient.fetch<SlackApiResponse>(
+        `${API_BASE_URL}/chat.getPermalink`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: formParams.toString(),
+        }
+      );
 
       if (result.isErr()) {
         return err(result.error);

--- a/src/features/slack/components/SlackSearchForm.tsx
+++ b/src/features/slack/components/SlackSearchForm.tsx
@@ -78,27 +78,88 @@ export function SlackSearchForm({ form }: SlackSearchFormProps) {
         </div>
       </SlackAdvancedFilters>
 
-      {/* 検索ボタン */}
-      <button
-        type="submit"
-        disabled={form.isLoading || !form.token.trim()}
-        className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-transparent shadow-sm text-sm font-medium rounded-sm text-white bg-docbase-primary hover:bg-docbase-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
-      >
-        {form.isLoading ? "検索中..." : "Slackを検索"}
-      </button>
-
-      {/* 進行状況表示 */}
-      {form.isLoading && form.progressStatus && (
-        <div className="mt-4 text-center text-sm text-gray-600">
-          <div className="mb-2">{form.progressStatus.message}</div>
-          <div className="w-full bg-gray-200 rounded-full h-2">
-            <div
-              className="bg-blue-600 h-2 rounded-full animate-pulse"
-              style={{ width: "60%" }}
-            />
-          </div>
-        </div>
-      )}
+      {/* 検索ボタンとダウンロードボタン */}
+      <div className="flex flex-col sm:flex-row space-y-3 sm:space-y-0 sm:space-x-3">
+        <button
+          type="submit"
+          disabled={form.isLoading || form.isDownloading || !form.token.trim()}
+          className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-transparent shadow-sm text-sm font-medium rounded-sm text-white bg-docbase-primary hover:bg-docbase-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
+        >
+          {form.isLoading ? (
+            <>
+              <svg
+                className="animate-spin -ml-1 mr-2 h-5 w-5"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <title>検索処理ローディング</title>
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              検索中...
+            </>
+          ) : (
+            "Slackを検索"
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            form.onFullDownload(
+              "",
+              form.searchQuery,
+              form.slackThreads.length > 0
+            )
+          }
+          className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-docbase-primary shadow-sm text-sm font-medium rounded-sm text-docbase-primary bg-white hover:bg-docbase-primary/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
+          disabled={
+            form.isLoading ||
+            form.isDownloading ||
+            form.slackThreads.length === 0
+          }
+        >
+          {form.isDownloading ? (
+            <>
+              <svg
+                className="animate-spin -ml-1 mr-2 h-5 w-5"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <title>ダウンロード処理ローディング</title>
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              ダウンロード中...
+            </>
+          ) : (
+            "Markdownをダウンロード"
+          )}
+        </button>
+      </div>
 
       {/* エラー表示 */}
       {form.error && (

--- a/src/features/slack/hooks/useSlackForm.ts
+++ b/src/features/slack/hooks/useSlackForm.ts
@@ -76,15 +76,26 @@ export function useSlackForm() {
     }
   };
 
-  const handleFullDownload = (
+  const handleFullDownload = async (
     markdownContent: string,
     searchQuery: string,
     hasContent: boolean
   ) => {
-    if (hasContent && threadMarkdowns.length > 0) {
-      // TODO: Issue #39で統一フックによるMarkdown生成実装
-      // const fullMarkdown = generateSlackThreadsMarkdown(slackThreads, userMaps, permalinkMaps, searchQuery)
-      handleDownload(markdownContent, searchQuery, hasContent, "slack");
+    if (hasContent && slackThreads.length > 0) {
+      // 全スレッドのMarkdownを生成
+      const { generateSlackThreadsMarkdown } = await import(
+        "../utils/slackMarkdownGenerator"
+      );
+      const fullMarkdown = generateSlackThreadsMarkdown(
+        slackThreads,
+        userMaps,
+        permalinkMaps,
+        searchQuery
+      );
+      handleDownload(fullMarkdown, searchQuery, true, "slack");
+    } else if (currentPreviewMarkdown) {
+      // プレビューのMarkdownをダウンロード
+      handleDownload(currentPreviewMarkdown, searchQuery, true, "slack");
     } else {
       handleDownload(markdownContent, searchQuery, hasContent, "slack");
     }


### PR DESCRIPTION
## 概要
Issue #233 の修正と、Slack検索機能のUI改善を実装しました。

## 変更内容

### 1. chat.getPermalinkのCORSエラーを修正 🐛
- **問題**: Slack APIの`chat.getPermalink`エンドポイントへのリクエストがCORSエラーで失敗
- **原因**: GETメソッド + Authorizationヘッダーによりプリフライトリクエストが発生
- **解決**: POSTメソッドでトークンをbodyに含める形式に変更

### 2. ダウンロードボタンの追加 ✨
- 検索ボタンの横にDocbaseと同じデザインでダウンロードボタンを配置
- 全スレッドのMarkdownをダウンロード可能に（プレビューは10件まで）

### 3. 検索中のUX改善 🎨
- 検索中はプレビューを非表示にし、進捗状況を表示
- 各処理フェーズに応じたメッセージとプログレスバーを表示
  - メッセージ検索中 (25%)
  - スレッド構築中 (50%)
  - ユーザー情報取得中 (75%)
  - パーマリンク生成中 (90%)
  - 完了 (100%)

### 4. UI整理 🧹
- 検索ボタン下部の重複した進捗表示を削除

## 動作確認
- [x] chat.getPermalinkがCORSエラーなく動作すること
- [x] ダウンロードボタンから全スレッドのMarkdownがダウンロードできること
- [x] 検索中の進捗状況が正しく表示されること
- [x] Lintチェックをパス

Fixes #233