### PR TITLE
feat(docbase): DocbaseページのUIをQiitaパターンで完全統一

### DIFF
--- a/src/app/docbase/page.tsx
+++ b/src/app/docbase/page.tsx
@@ -1,52 +1,16 @@
 "use client"; // クライアントコンポーネントとしてマーク
 
-import { useState } from "react";
 import { Toaster } from "react-hot-toast";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
-import { DocbaseMarkdownPreview } from "../../features/docbase/components/DocbaseMarkdownPreview";
-import { DocbaseSearchForm } from "../../features/docbase/components/DocbaseSearchForm"; // パスを修正
-import type { DocbasePostListItem } from "../../features/docbase/types/docbase";
-import { generateDocbaseMarkdown } from "../../features/docbase/utils/docbaseMarkdownGenerator";
-import { useDownload } from "../../hooks/useDownload";
-import type { ApiError } from "../../types/error";
+import { DocbaseSearchForm } from "../../features/docbase/components/DocbaseSearchForm";
 
 export default function DocbasePage() {
-  const [searchResults, setSearchResults] = useState<{
-    posts: DocbasePostListItem[];
-    markdownContent: string;
-    isLoading: boolean;
-    error: ApiError | null;
-  }>({
-    posts: [],
-    markdownContent: "",
-    isLoading: false,
-    error: null,
-  });
-
-  const { isDownloading, handleDownload } = useDownload();
-
-  const handleDownloadClick = () => {
-    const postsExist = searchResults.posts && searchResults.posts.length > 0;
-    if (postsExist) {
-      // ダウンロード時は全件のMarkdownを生成
-      const fullMarkdown = generateDocbaseMarkdown(
-        searchResults.posts,
-        "検索キーワード"
-      );
-      handleDownload(fullMarkdown, "検索キーワード", postsExist, "docbase");
-    } else {
-      handleDownload(
-        searchResults.markdownContent,
-        "検索キーワード",
-        postsExist,
-        "docbase"
-      );
-    }
-  };
   return (
     <main className="flex min-h-screen flex-col bg-white text-gray-800 selection:bg-docbase-primary font-sans">
       <Header title="NotebookLM Collector - Docbase" />
+
+      {/* Docbaseブランドカラーに合わせたToaster設定 */}
       <Toaster
         position="top-center"
         toastOptions={{
@@ -54,7 +18,7 @@ export default function DocbasePage() {
             "!border !border-gray-200 !bg-white !text-gray-700 !shadow-lg !rounded-md",
           success: {
             iconTheme: {
-              primary: "#3B82F6", // Docbase風ブルー
+              primary: "#3B82F6", // Docbase Blue
               secondary: "#FFFFFF",
             },
           },
@@ -66,7 +30,175 @@ export default function DocbasePage() {
           },
         }}
       />
+
       <div className="relative z-10 flex flex-col items-center w-full">
+        {/* ヒーローセクション */}
+        <section className="w-full text-center my-32">
+          <div className="max-w-screen-lg mx-auto px-4 sm:px-6 lg:px-8">
+            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6 text-gray-800 leading-tight">
+              Docbaseの知識を、
+              <br />
+              NotebookLMへ簡単連携
+            </h1>
+            <p className="text-lg md:text-xl lg:text-2xl text-gray-600 max-w-3xl mx-auto">
+              キーワード検索でDocbaseの記事をまとめ、NotebookLMでのAI活用に最適化されたMarkdownファイルを瞬時に生成します。
+            </p>
+          </div>
+        </section>
+
+        {/* CTAセクション */}
+        <div className="flex justify-center bg-blue-500 w-full py-10">
+          <div className="flex flex-col items-center">
+            <button
+              type="button"
+              onClick={() =>
+                document
+                  .getElementById("main-tool-section")
+                  ?.scrollIntoView({ behavior: "smooth" })
+              }
+              className="px-8 py-3 bg-white hover:bg-gray-50 text-blue-600 font-semibold rounded-md shadow-md hover:shadow-lg transform hover:scale-105 transition-all duration-200 ease-in-out text-lg border-2 border-blue-600"
+            >
+              今すぐMarkdownを生成
+            </button>
+            <p className="text-white text-sm mt-2">
+              取得したDocbaseの情報はブラウザ内でのみ利用されます。サーバーには保存、送信されません。
+            </p>
+          </div>
+        </div>
+
+        {/* 使い方説明セクション */}
+        <section className="w-full mt-12">
+          <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-gray-50">
+            <h2 className="text-3xl md:text-4xl font-bold mb-20 text-center text-gray-800">
+              利用はかんたん3ステップ
+            </h2>
+            <div className="grid md:grid-cols-3 gap-x-8 gap-y-10 relative">
+              {[
+                {
+                  step: "1",
+                  title: "ドメインとトークンを設定",
+                  description:
+                    "Docbaseドメインとアクセストークンを入力します。トークンは設定ページから発行でき、保存も可能です。",
+                  icon: "🔑",
+                },
+                {
+                  step: "2",
+                  title: "検索して生成",
+                  description:
+                    "キーワードを入力し「検索実行」ボタンを押すと、Docbaseから記事を取得し、NotebookLM用Markdownをプレビューします。",
+                  icon: "🔍",
+                },
+                {
+                  step: "3",
+                  title: "ダウンロード",
+                  description:
+                    "生成されたMarkdown内容を確認し、「ダウンロード」ボタンでファイルとして保存。すぐにAIに学習させられます。",
+                  icon: "💾",
+                },
+              ].map((item, index) => (
+                <div key={item.step} className="text-center md:text-left">
+                  <div className="flex items-center justify-center md:justify-start mb-4">
+                    <span className="flex items-center justify-center w-10 h-10 bg-blue-500 text-white text-xl font-bold rounded-full mr-4">
+                      {item.step}
+                    </span>
+                    <span className="text-3xl">{item.icon}</span>
+                  </div>
+                  <h3 className="text-lg font-semibold mb-2 text-gray-800">
+                    {item.title}
+                  </h3>
+                  <p className="text-gray-600 text-sm leading-relaxed">
+                    {item.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Docbase特有の機能説明セクション */}
+        <section className="w-full mt-12">
+          <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-blue-50">
+            <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-gray-800">
+              ✨ Docbase連携の特徴
+            </h2>
+            <div className="grid md:grid-cols-2 gap-8">
+              <div className="space-y-4">
+                <h3 className="text-xl font-semibold text-blue-700">
+                  🎯 高度な検索機能
+                </h3>
+                <ul className="space-y-2 text-gray-700">
+                  <li className="flex items-start">
+                    <span className="text-blue-500 mr-2">•</span>
+                    タグ・投稿者・期間での絞り込み検索
+                  </li>
+                  <li className="flex items-start">
+                    <span className="text-blue-500 mr-2">•</span>
+                    タイトルキーワードによる文書種別フィルター
+                  </li>
+                  <li className="flex items-start">
+                    <span className="text-blue-500 mr-2">•</span>
+                    最大500件までのチーム記事取得
+                  </li>
+                </ul>
+              </div>
+              <div className="space-y-4">
+                <h3 className="text-xl font-semibold text-blue-700">
+                  📊 豊富なメタデータ
+                </h3>
+                <ul className="space-y-2 text-gray-700">
+                  <li className="flex items-start">
+                    <span className="text-blue-500 mr-2">•</span>
+                    記事の文字数・作成日時・タグ情報
+                  </li>
+                  <li className="flex items-start">
+                    <span className="text-blue-500 mr-2">•</span>
+                    著者情報と投稿数統計
+                  </li>
+                  <li className="flex items-start">
+                    <span className="text-blue-500 mr-2">•</span>
+                    チーム知識ベースの傾向分析
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* セキュリティ説明セクション */}
+        <section className="w-full mt-12">
+          <div className="max-w-screen-lg mx-auto px-6 sm:px-10 lg:px-24 py-16 rounded-xl border border-gray-200 bg-gray-50">
+            <div className="text-center">
+              <h2 className="text-3xl md:text-4xl font-bold mb-8 text-center text-gray-800">
+                🔒 セキュリティについて
+              </h2>
+              <p className="text-gray-600 text-lg leading-relaxed max-w-3xl mx-auto">
+                入力されたDocbase
+                ドメインやAPIトークン、取得された記事の内容は、お使いのブラウザ内でのみ処理されます。
+                これらの情報が外部のサーバーに送信されたり、保存されたりすることは一切ありませんので、安心してご利用いただけます。
+              </p>
+              <div className="mt-6 inline-flex items-center px-4 py-2 bg-docbase-primary/10 border border-docbase-primary/20 rounded-md">
+                <svg
+                  className="w-5 h-5 text-docbase-primary mr-2"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <title>プライバシー保護</title>
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <span className="text-docbase-primary font-medium">
+                  プライバシー保護設計
+                </span>
+              </div>
+            </div>
+          </div>
+        </section>
+
         {/* メイン機能セクション (横配置レイアウト) */}
         <section
           id="main-tool-section"
@@ -74,52 +206,13 @@ export default function DocbasePage() {
         >
           <div className="max-w-screen-xl w-full mx-4 sm:mx-8 px-4 sm:px-6 lg:px-8 py-8 sm:py-10 md:py-12 shadow-none sm:shadow-md rounded-lg border-0 sm:border sm:border-gray-200">
             <h2 className="text-4xl font-bold mb-8 text-center text-gray-800">
-              DocBase 記事検索・収集
+              Docbase 記事検索・収集
             </h2>
-
-            {/* レスポンシブレイアウト: デスクトップは横並び、モバイルは縦並び */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-              {/* 左側: 検索フォーム */}
-              <div className="space-y-6">
-                <DocbaseSearchForm onSearchResults={setSearchResults} />
-
-                {/* 検索結果の統計情報 */}
-                {searchResults.posts &&
-                  searchResults.posts.length > 0 &&
-                  !searchResults.isLoading &&
-                  !searchResults.error && (
-                    <div className="p-4 bg-docbase-primary/5 border border-docbase-primary/20 rounded-lg">
-                      <p className="text-sm text-docbase-text-sub">
-                        取得件数: {searchResults.posts.length}件
-                      </p>
-                      {searchResults.posts.length > 10 && (
-                        <p className="text-sm text-docbase-text-sub mt-1">
-                          プレビューには最初の10件が表示されます。すべての内容を確認するには、ダウンロードボタンをご利用ください。
-                        </p>
-                      )}
-                    </div>
-                  )}
-              </div>
-
-              {/* 右側: プレビューエリア */}
-              <div className="space-y-6">
-                <DocbaseMarkdownPreview
-                  posts={
-                    searchResults.posts.length > 0
-                      ? searchResults.posts
-                      : undefined
-                  }
-                  title="検索結果プレビュー"
-                  onDownload={handleDownloadClick}
-                  emptyMessage="Docbase記事の検索結果がここに表示されます。"
-                  useAccordion={true}
-                  className=""
-                />
-              </div>
-            </div>
+            <DocbaseSearchForm />
           </div>
         </section>
       </div>
+
       <Footer />
     </main>
   );

--- a/src/features/docbase/adapters/docbaseClient.ts
+++ b/src/features/docbase/adapters/docbaseClient.ts
@@ -2,7 +2,7 @@ import type { Result } from "neverthrow";
 import { createFetchHttpClient } from "../../../adapters/fetchHttpClient";
 import type { ApiError } from "../../../types/error";
 import type { DocbasePostListItem } from "../types/docbase";
-import type { AdvancedFilters } from "../types/forms";
+import type { DocbaseAdvancedFilters } from "../types/docbase";
 import {
   type DocbaseSearchParams,
   createDocbaseAdapter,
@@ -25,7 +25,7 @@ export const fetchDocbasePosts = async (
   domain: string,
   token: string,
   keyword: string,
-  advancedFilters?: AdvancedFilters
+  advancedFilters?: DocbaseAdvancedFilters
 ): Promise<Result<DocbasePostListItem[], ApiError>> => {
   return defaultAdapter.searchPosts({
     domain,

--- a/src/features/docbase/components/DocbaseAdvancedFilters.tsx
+++ b/src/features/docbase/components/DocbaseAdvancedFilters.tsx
@@ -1,0 +1,229 @@
+import { useState } from "react";
+import type { DocbaseAdvancedFilters as DocbaseAdvancedFiltersType } from "../types/docbase";
+
+interface DocbaseAdvancedFiltersProps {
+  filters: DocbaseAdvancedFiltersType;
+  onFiltersChange: (filters: DocbaseAdvancedFiltersType) => void;
+  isExpanded: boolean;
+  onToggle: () => void;
+  className?: string;
+}
+
+/**
+ * Docbase詳細検索フィルターコンポーネント
+ * 折りたたみ可能なアコーディオン形式
+ */
+export const DocbaseAdvancedFilters: React.FC<DocbaseAdvancedFiltersProps> = ({
+  filters,
+  onFiltersChange,
+  isExpanded,
+  onToggle,
+  className = "",
+}) => {
+  const [localFilters, setLocalFilters] =
+    useState<DocbaseAdvancedFiltersType>(filters);
+
+  // フィルター値の更新
+  const updateFilter = (
+    key: keyof DocbaseAdvancedFiltersType,
+    value: string | undefined
+  ) => {
+    const newFilters = { ...localFilters, [key]: value };
+    setLocalFilters(newFilters);
+    onFiltersChange(newFilters);
+  };
+
+  // 日付の妥当性チェック
+  const isValidDateRange = (startDate?: string, endDate?: string): boolean => {
+    if (!startDate || !endDate) return true;
+    return new Date(startDate) <= new Date(endDate);
+  };
+
+  const dateRangeValid = isValidDateRange(
+    localFilters.startDate,
+    localFilters.endDate
+  );
+
+  return (
+    <div className={`border border-gray-200 rounded-lg ${className}`}>
+      {/* ヘッダー（クリックで展開/折りたたみ） */}
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full px-4 py-3 text-left flex items-center justify-between bg-gray-50 hover:bg-gray-100 transition-colors rounded-t-lg focus:outline-none focus:ring-2 focus:ring-docbase-primary"
+      >
+        <span className="text-sm font-medium text-gray-700">詳細検索条件</span>
+        <svg
+          className={`w-5 h-5 text-gray-500 transition-transform duration-200 ${
+            isExpanded ? "rotate-180" : ""
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <title>{isExpanded ? "閉じる" : "展開"}</title>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {/* 展開時のコンテンツ */}
+      {isExpanded && (
+        <div className="p-4 space-y-4 border-t border-gray-200">
+          {/* タグ検索 */}
+          <div>
+            <label
+              htmlFor="docbase-tags"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              タグ
+            </label>
+            <input
+              type="text"
+              id="docbase-tags"
+              value={localFilters.tags || ""}
+              onChange={(e) => updateFilter("tags", e.target.value)}
+              placeholder="API, 設計, チーム運営"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-docbase-primary focus:border-docbase-primary transition-colors"
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              カンマ区切りで複数指定可能
+            </p>
+          </div>
+
+          {/* 投稿者検索 */}
+          <div>
+            <label
+              htmlFor="docbase-author"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              投稿者
+            </label>
+            <input
+              type="text"
+              id="docbase-author"
+              value={localFilters.author || ""}
+              onChange={(e) => updateFilter("author", e.target.value)}
+              placeholder="user123"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-docbase-primary focus:border-docbase-primary transition-colors"
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              DocbaseユーザーIDを指定
+            </p>
+          </div>
+
+          {/* タイトルフィルター */}
+          <div>
+            <label
+              htmlFor="docbase-title-filter"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              タイトルキーワード
+            </label>
+            <input
+              type="text"
+              id="docbase-title-filter"
+              value={localFilters.titleFilter || ""}
+              onChange={(e) => updateFilter("titleFilter", e.target.value)}
+              placeholder="仕様書, 会議録, マニュアル"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-docbase-primary focus:border-docbase-primary transition-colors"
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              タイトルに含むキーワードを指定
+            </p>
+          </div>
+
+          {/* 投稿期間 */}
+          <div>
+            <div className="block text-sm font-medium text-gray-700 mb-2">
+              投稿期間
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label
+                  htmlFor="docbase-start-date"
+                  className="block text-xs text-gray-600 mb-1"
+                >
+                  開始日
+                </label>
+                <input
+                  type="date"
+                  id="docbase-start-date"
+                  value={localFilters.startDate || ""}
+                  onChange={(e) => updateFilter("startDate", e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-docbase-primary focus:border-docbase-primary transition-colors"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="docbase-end-date"
+                  className="block text-xs text-gray-600 mb-1"
+                >
+                  終了日
+                </label>
+                <input
+                  type="date"
+                  id="docbase-end-date"
+                  value={localFilters.endDate || ""}
+                  onChange={(e) => updateFilter("endDate", e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-docbase-primary focus:border-docbase-primary transition-colors"
+                />
+              </div>
+            </div>
+            {!dateRangeValid && (
+              <p className="mt-1 text-xs text-red-600">
+                終了日は開始日以降に設定してください
+              </p>
+            )}
+          </div>
+
+          {/* リセットボタン */}
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={() => {
+                const emptyFilters: DocbaseAdvancedFiltersType = {};
+                setLocalFilters(emptyFilters);
+                onFiltersChange(emptyFilters);
+              }}
+              className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary transition-colors"
+            >
+              <svg
+                className="w-4 h-4 mr-1"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <title>クリア</title>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+              クリア
+            </button>
+          </div>
+
+          {/* ヘルプテキスト */}
+          <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
+            <h4 className="text-sm font-medium text-blue-800 mb-2">
+              💡 検索のコツ
+            </h4>
+            <ul className="text-xs text-blue-700 space-y-1">
+              <li>• タグは正確な名前で指定（例: チーム運営, not team）</li>
+              <li>• 投稿者検索では @ を付けずにIDを入力</li>
+              <li>• タイトルキーワードで文書種別を絞り込み可能</li>
+              <li>• 条件は AND 検索（全て満たす記事のみ表示）</li>
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/docbase/components/DocbaseMarkdownPreview.tsx
+++ b/src/features/docbase/components/DocbaseMarkdownPreview.tsx
@@ -39,6 +39,8 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
 }) => {
   const [openItems, setOpenItems] = useState<number[]>([]);
 
+  const [isExpanded, setIsExpanded] = useState(false);
+
   // アコーディオンの開閉状態を管理
   const toggleItem = (index: number) => {
     setOpenItems((prev) =>
@@ -62,19 +64,234 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
     );
   }
 
+  // 統計情報の計算（アコーディオン表示時のみ）
+  const calculateStats = () => {
+    if (!posts || posts.length === 0) return null;
+
+    const totalCharacters = posts.reduce(
+      (sum, post) => sum + post.body.length,
+      0
+    );
+    const averageCharacters = Math.round(totalCharacters / posts.length);
+
+    // 最新記事トップ3
+    const recentArticles = [...posts]
+      .sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      )
+      .slice(0, 3);
+
+    // 最長記事トップ3
+    const longestArticles = [...posts]
+      .sort((a, b) => b.body.length - a.body.length)
+      .slice(0, 3);
+
+    // よく使われているタグ
+    const tagFrequency = posts.reduce(
+      (acc, post) => {
+        for (const tag of post.tags) {
+          acc[tag.name] = (acc[tag.name] || 0) + 1;
+        }
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+
+    const topTags = Object.entries(tagFrequency)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 5);
+
+    // 投稿者統計
+    const authorFrequency = posts.reduce(
+      (acc, post) => {
+        acc[post.user.name] = (acc[post.user.name] || 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+
+    const topAuthors = Object.entries(authorFrequency)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 3);
+
+    return {
+      totalCharacters,
+      averageCharacters,
+      recentArticles,
+      longestArticles,
+      topTags,
+      topAuthors,
+    };
+  };
+
+  const stats = calculateStats();
+
   // アコーディオン表示の場合
   if (useAccordion && posts && posts.length > 0) {
     return (
-      <div className={`max-w-3xl mx-auto ${className}`}>
-        {title && (
-          <div className="mb-1">
-            <h2 className="text-base font-medium text-gray-800">{title}</h2>
+      <div
+        className={`bg-white border border-gray-200 rounded-lg shadow-sm ${className}`}
+      >
+        {/* ヘッダー */}
+        <div className="px-6 py-4 border-b border-gray-200">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-gray-900">
+              Markdownプレビュー
+            </h3>
+            <button
+              type="button"
+              onClick={() => setIsExpanded(!isExpanded)}
+              className="inline-flex items-center text-sm text-docbase-primary hover:text-docbase-primary-dark transition-colors"
+            >
+              {isExpanded ? "折りたたむ" : "詳細を表示"}
+              <svg
+                className={`ml-1 w-4 h-4 transition-transform duration-200 ${
+                  isExpanded ? "rotate-180" : ""
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <title>{isExpanded ? "折りたたむ" : "詳細を表示"}</title>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* 統計情報 */}
+        <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="text-center">
+              <div className="text-2xl font-bold text-docbase-primary">
+                {posts.length}
+              </div>
+              <div className="text-sm text-gray-600">記事数</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-blue-500">
+                {stats?.totalCharacters.toLocaleString()}
+              </div>
+              <div className="text-sm text-gray-600">総文字数</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-green-500">
+                {stats?.averageCharacters.toLocaleString()}
+              </div>
+              <div className="text-sm text-gray-600">平均文字数</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-purple-500">
+                {stats?.topTags.length || 0}
+              </div>
+              <div className="text-sm text-gray-600">タグ種類</div>
+            </div>
+          </div>
+        </div>
+
+        {/* 詳細統計（展開時のみ） */}
+        {isExpanded && stats && (
+          <div className="px-6 py-4 border-b border-gray-200 space-y-4">
+            {/* 最新記事トップ3 */}
+            <div>
+              <h4 className="text-sm font-semibold text-gray-900 mb-2">
+                最新記事 TOP3
+              </h4>
+              <div className="space-y-2">
+                {stats.recentArticles.map((post, index) => (
+                  <div
+                    key={post.id}
+                    className="flex items-start space-x-2 text-sm"
+                  >
+                    <span className="flex-shrink-0 w-5 h-5 bg-blue-100 text-blue-800 rounded-full flex items-center justify-center text-xs font-semibold">
+                      {index + 1}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <a
+                        href={post.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-docbase-primary hover:text-docbase-primary-dark font-medium truncate block"
+                      >
+                        {post.title}
+                      </a>
+                      <div className="text-gray-500 text-xs">
+                        📅 {new Date(post.created_at).toLocaleDateString()} • 📝{" "}
+                        {post.body.length}文字 • by {post.user.name}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* よく使われているタグ */}
+            {stats.topTags.length > 0 && (
+              <div>
+                <h4 className="text-sm font-semibold text-gray-900 mb-2">
+                  よく使われているタグ
+                </h4>
+                <div className="flex flex-wrap gap-2">
+                  {stats.topTags.map(([tag, count]) => (
+                    <span
+                      key={tag}
+                      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-docbase-primary/10 text-docbase-primary"
+                    >
+                      {tag} ({count})
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* 投稿者統計 */}
+            {stats.topAuthors.length > 0 && (
+              <div>
+                <h4 className="text-sm font-semibold text-gray-900 mb-2">
+                  投稿数が多いユーザー TOP3
+                </h4>
+                <div className="space-y-1">
+                  {stats.topAuthors.map(([author, count], index) => (
+                    <div
+                      key={author}
+                      className="flex items-center justify-between text-sm"
+                    >
+                      <span className="flex items-center">
+                        <span className="w-4 h-4 bg-yellow-100 text-yellow-800 rounded-full flex items-center justify-center text-xs font-semibold mr-2">
+                          {index + 1}
+                        </span>
+                        {author}
+                      </span>
+                      <span className="text-gray-500">{count}記事</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* 文字数統計 */}
+            <div>
+              <h4 className="text-sm font-semibold text-gray-900 mb-1">
+                文字数統計
+              </h4>
+              <p className="text-sm text-gray-600">
+                総文字数: {stats.totalCharacters.toLocaleString()}文字 （平均:{" "}
+                {stats.averageCharacters.toLocaleString()}文字/記事）
+              </p>
+            </div>
           </div>
         )}
 
-        <div className="border border-gray-200 rounded-xl bg-white shadow-sm">
-          <div className="p-4 border-b border-gray-100">
-            <p className="text-sm text-gray-600">
+        {/* アコーディオンコンテンツ */}
+        <div className="border-b border-gray-200">
+          <div className="p-4">
+            <p className="text-sm text-gray-600 mb-4">
               検索結果: {posts.length}件の記事（最大10件まで表示）
             </p>
           </div>
@@ -105,6 +322,8 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
                         <div className="flex items-center gap-2 mb-2 text-sm text-gray-500">
                           <span>{createdAt}</span>
                           <span>•</span>
+                          <span>{post.body.length}文字</span>
+                          <span>•</span>
                           <a
                             href={post.url}
                             target="_blank"
@@ -114,6 +333,21 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
                           >
                             Docbaseで開く
                           </a>
+                        </div>
+                        <div className="flex items-center gap-1 mb-2">
+                          {post.tags.slice(0, 3).map((tag) => (
+                            <span
+                              key={tag.name}
+                              className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800"
+                            >
+                              {tag.name}
+                            </span>
+                          ))}
+                          {post.tags.length > 3 && (
+                            <span className="text-xs text-gray-500">
+                              +{post.tags.length - 3}
+                            </span>
+                          )}
                         </div>
                         {!isOpen && (
                           <p className="text-sm text-gray-600 line-clamp-2">
@@ -159,6 +393,24 @@ export const DocbaseMarkdownPreview: FC<DocbaseMarkdownPreviewProps> = ({
                 </div>
               );
             })}
+          </div>
+
+          {/* フッター */}
+          <div className="px-6 py-4 border-t border-gray-200 bg-gray-50">
+            <div className="flex items-center justify-between text-sm text-gray-600">
+              <span>
+                {posts.length > 10
+                  ? `最初の10件を表示（残り${posts.length - 10}件）`
+                  : `全${posts.length}件を表示`}
+              </span>
+              <span>NotebookLM 最適化形式</span>
+            </div>
+
+            {/* ヘルプテキスト */}
+            <div className="mt-2 text-xs text-gray-500">
+              💡 ダウンロードしたMarkdownファイルには全ての記事が含まれ、YAML
+              Front Matterと詳細な記事情報も追加されます
+            </div>
           </div>
         </div>
       </div>

--- a/src/features/docbase/components/DocbaseSearchForm.tsx
+++ b/src/features/docbase/components/DocbaseSearchForm.tsx
@@ -5,11 +5,15 @@ import { useDownload } from "../../../hooks/useDownload";
 import useLocalStorage from "../../../hooks/useLocalStorage";
 import type { ApiError } from "../../../types/error";
 import { useDocbaseSearch } from "../hooks/useDocbaseSearch";
-import type { DocbasePostListItem } from "../types/docbase";
+import type {
+  DocbaseAdvancedFilters,
+  DocbasePostListItem,
+} from "../types/docbase";
 import {
   generateDocbaseMarkdown,
   generateDocbaseMarkdownForPreview,
 } from "../utils/docbaseMarkdownGenerator";
+import { DocbaseAdvancedFilters as DocbaseAdvancedFiltersComponent } from "./DocbaseAdvancedFilters";
 import { DocbaseDomainInput } from "./DocbaseDomainInput";
 import { DocbaseMarkdownPreview } from "./DocbaseMarkdownPreview";
 import {
@@ -35,7 +39,7 @@ interface DocbaseSearchFormProps {
 export const DocbaseSearchForm = ({
   onSearchResults,
 }: DocbaseSearchFormProps) => {
-  const [keyword, setKeyword] = useState("");
+  // LocalStorage連携によるトークンとドメイン管理
   const [domain, setDomain] = useLocalStorage<string>(
     LOCAL_STORAGE_DOMAIN_KEY,
     ""
@@ -44,13 +48,14 @@ export const DocbaseSearchForm = ({
     LOCAL_STORAGE_TOKEN_KEY,
     ""
   );
+
+  // フォーム状態
+  const [keyword, setKeyword] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [advancedFilters, setAdvancedFilters] =
+    useState<DocbaseAdvancedFilters>({});
+  const [hasSearched, setHasSearched] = useState(false);
   const [markdownContent, setMarkdownContent] = useState("");
-  const [showAdvancedSearch, setShowAdvancedSearch] = useState(false);
-  const [tags, setTags] = useState("");
-  const [author, setAuthor] = useState("");
-  const [titleFilter, setTitleFilter] = useState("");
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
 
   const { posts, isLoading, error, searchPosts, canRetry, retrySearch } =
     useDocbaseSearch();
@@ -58,16 +63,11 @@ export const DocbaseSearchForm = ({
 
   const tokenInputRef = useRef<DocbaseTokenInputRef>(null);
 
+  // フォーム送信ハンドラー
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setMarkdownContent("");
-    const advancedFilters = {
-      tags,
-      author,
-      titleFilter,
-      startDate,
-      endDate,
-    };
+    setHasSearched(true);
     await searchPosts(domain, token, keyword, advancedFilters);
   };
 
@@ -96,16 +96,23 @@ export const DocbaseSearchForm = ({
     }
   }, [error]);
 
+  // Markdownダウンロードハンドラー
   const handleDownloadClick = () => {
-    const postsExist = posts && posts.length > 0;
-    if (postsExist) {
+    if (posts && posts.length > 0) {
       // ダウンロード時は全件のMarkdownを生成
       const fullMarkdown = generateDocbaseMarkdown(posts, keyword);
-      handleDownload(fullMarkdown, keyword, postsExist, "docbase");
-    } else {
-      handleDownload(markdownContent, keyword, postsExist, "docbase");
+      handleDownload(fullMarkdown, keyword, true, "docbase");
     }
   };
+
+  // 検索条件が設定されているかチェック
+  const hasSearchConditions =
+    keyword.trim() ||
+    advancedFilters.tags?.trim() ||
+    advancedFilters.author?.trim() ||
+    advancedFilters.titleFilter?.trim() ||
+    advancedFilters.startDate?.trim() ||
+    advancedFilters.endDate?.trim();
 
   const renderErrorCause = (currentError: ApiError | null) => {
     if (!currentError) return null;
@@ -122,9 +129,11 @@ export const DocbaseSearchForm = ({
   };
 
   return (
-    <div className="max-w-3xl mx-auto">
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <div className="space-y-4">
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      {/* 左側: 検索フォーム */}
+      <div className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* ドメインとトークン入力 */}
           <DocbaseDomainInput
             domain={domain}
             onDomainChange={setDomain}
@@ -136,252 +145,240 @@ export const DocbaseSearchForm = ({
             onTokenChange={setToken}
             disabled={isLoading || isDownloading}
           />
+
+          {/* 検索キーワード */}
           <div>
             <label
               htmlFor="keyword"
-              className="block text-base font-medium text-docbase-text mb-1"
+              className="block text-sm font-medium text-gray-700 mb-2"
             >
               検索キーワード
+              <span className="text-red-500 ml-1">*</span>
             </label>
             <input
-              id="keyword"
               type="text"
+              id="keyword"
               value={keyword}
               onChange={(e) => setKeyword(e.target.value)}
-              placeholder="キーワードを入力してください"
-              className="block w-full px-4 py-3 border border-gray-400 rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+              placeholder="API設計, チーム運営, 議事録..."
+              className="w-full px-4 py-3 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-docbase-primary focus:border-docbase-primary transition-colors text-lg"
               disabled={isLoading || isDownloading}
             />
+            <p className="mt-1 text-sm text-gray-500">
+              記事のタイトルや本文から検索します
+            </p>
           </div>
-        </div>
 
-        {/* 詳細検索の開閉ボタンと入力フィールドを追加 */}
-        <div className="space-y-4 pt-2">
-          <button
-            type="button"
-            onClick={() => setShowAdvancedSearch(!showAdvancedSearch)}
-            className="text-sm text-docbase-primary hover:text-docbase-primary-dark focus:outline-none"
-          >
-            {showAdvancedSearch
-              ? "詳細な条件を閉じる ▲"
-              : "もっと詳細な条件を追加する ▼"}
-          </button>
+          {/* 詳細検索フィルター */}
+          <DocbaseAdvancedFiltersComponent
+            filters={advancedFilters}
+            onFiltersChange={setAdvancedFilters}
+            isExpanded={showAdvanced}
+            onToggle={() => setShowAdvanced(!showAdvanced)}
+          />
 
-          {showAdvancedSearch && (
-            <div className="space-y-4 p-4 border border-gray-300 rounded-md">
-              <div>
-                <label
-                  htmlFor="tags"
-                  className="block text-sm font-medium text-docbase-text mb-1"
-                >
-                  タグ (カンマ区切り)
-                </label>
-                <input
-                  id="tags"
-                  type="text"
-                  value={tags}
-                  onChange={(e) => setTags(e.target.value)}
-                  placeholder="例: API, 設計"
-                  className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
-                  disabled={isLoading || isDownloading}
-                />
-              </div>
-              <div>
-                <label
-                  htmlFor="author"
-                  className="block text-sm font-medium text-docbase-text mb-1"
-                >
-                  投稿者 (ユーザーID)
-                </label>
-                <input
-                  id="author"
-                  type="text"
-                  value={author}
-                  onChange={(e) => setAuthor(e.target.value)}
-                  placeholder="例: user123"
-                  className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
-                  disabled={isLoading || isDownloading}
-                />
-              </div>
-              <div>
-                <label
-                  htmlFor="titleFilter"
-                  className="block text-sm font-medium text-docbase-text mb-1"
-                >
-                  タイトルに含むキーワード
-                </label>
-                <input
-                  id="titleFilter"
-                  type="text"
-                  value={titleFilter}
-                  onChange={(e) => setTitleFilter(e.target.value)}
-                  placeholder="例: 仕様書"
-                  className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
-                  disabled={isLoading || isDownloading}
-                />
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                  <label
-                    htmlFor="startDate"
-                    className="block text-sm font-medium text-docbase-text mb-1"
+          {/* 検索実行ボタンとダウンロードボタン */}
+          <div className="flex flex-col sm:flex-row space-y-3 sm:space-y-0 sm:space-x-3 pt-2">
+            <button
+              type="submit"
+              disabled={
+                isLoading ||
+                !domain.trim() ||
+                !token.trim() ||
+                !hasSearchConditions
+              }
+              className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-transparent shadow-sm text-sm font-medium rounded-sm text-white bg-docbase-primary hover:bg-docbase-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 ease-in-out"
+            >
+              {isLoading ? (
+                <>
+                  <svg
+                    className="animate-spin -ml-1 mr-2 h-5 w-5"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
                   >
-                    投稿期間 (開始日)
-                  </label>
-                  <input
-                    id="startDate"
-                    type="date"
-                    value={startDate}
-                    onChange={(e) => setStartDate(e.target.value)}
-                    className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
-                    disabled={isLoading || isDownloading}
-                  />
-                </div>
-                <div>
-                  <label
-                    htmlFor="endDate"
-                    className="block text-sm font-medium text-docbase-text mb-1"
-                  >
-                    投稿期間 (終了日)
-                  </label>
-                  <input
-                    id="endDate"
-                    type="date"
-                    value={endDate}
-                    onChange={(e) => setEndDate(e.target.value)}
-                    className="block w-full px-3 py-2 border border-gray-400 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-docbase-primary focus:border-docbase-primary disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
-                    disabled={isLoading || isDownloading}
-                  />
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="flex flex-col sm:flex-row space-y-3 sm:space-y-0 sm:space-x-3 pt-2">
-          <button
-            type="submit"
-            className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-transparent shadow-sm text-sm font-medium rounded-sm text-white bg-docbase-primary hover:bg-docbase-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
-            disabled={
-              isLoading ||
-              isDownloading ||
-              !domain ||
-              !token ||
-              (!keyword &&
-                !tags &&
-                !author &&
-                !titleFilter &&
-                !startDate &&
-                !endDate)
-            }
-          >
-            {isLoading ? (
-              <>
-                <svg
-                  className="animate-spin -ml-1 mr-2 h-5 w-5"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <title>検索処理ローディング</title>
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  />
-                </svg>
-                検索中...
-              </>
-            ) : (
-              "検索実行"
-            )}
-          </button>
-          <button
-            type="button"
-            onClick={handleDownloadClick}
-            className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-docbase-primary shadow-sm text-sm font-medium rounded-sm text-docbase-primary bg-white hover:bg-docbase-primary/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
-            disabled={isLoading || isDownloading || !markdownContent.trim()}
-          >
-            {isDownloading ? (
-              <>
-                <svg
-                  className="animate-spin -ml-1 mr-2 h-5 w-5"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <title>ダウンロード処理ローディング</title>
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  />
-                </svg>
-                生成中...
-              </>
-            ) : (
-              "Markdownダウンロード"
-            )}
-          </button>
-        </div>
-
-        {canRetry && !isLoading && (
-          <div className="mt-4">
+                    <title>検索処理ローディング</title>
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  検索中...
+                </>
+              ) : (
+                "検索実行"
+              )}
+            </button>
             <button
               type="button"
-              onClick={retrySearch}
-              className="w-full inline-flex justify-center py-2 px-4 border border-yellow-400 shadow-sm text-sm font-medium rounded-sm text-yellow-700 bg-yellow-50 hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500 transition-colors duration-150 ease-in-out"
+              onClick={handleDownloadClick}
+              disabled={
+                isLoading || isDownloading || !posts || posts.length === 0
+              }
+              className="w-full inline-flex items-center justify-center py-2.5 px-4 border border-docbase-primary shadow-sm text-sm font-medium rounded-sm text-docbase-primary bg-white hover:bg-docbase-primary/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-200 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out"
             >
-              再試行
+              {isDownloading ? (
+                <>
+                  <svg
+                    className="animate-spin -ml-1 mr-2 h-5 w-5"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <title>ダウンロード処理ローディング</title>
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  生成中...
+                </>
+              ) : (
+                "Markdownダウンロード"
+              )}
             </button>
           </div>
-        )}
 
-        {error && (
-          <div className="mt-5 p-3.5 text-sm text-docbase-text bg-red-50 border border-red-300 rounded-sm shadow-sm">
-            <div className="flex items-center">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5 mr-2 text-red-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth="2"
+          {/* 再試行ボタン */}
+          {canRetry && !isLoading && (
+            <div className="mt-4">
+              <button
+                type="button"
+                onClick={retrySearch}
+                className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary transition-colors"
               >
-                <title>エラーアイコン</title>
+                再試行
+              </button>
+            </div>
+          )}
+
+          {/* 検索結果がない場合のメッセージ */}
+          {!isLoading &&
+            posts &&
+            posts.length === 0 &&
+            hasSearched &&
+            !error && (
+              <div className="text-center py-8">
+                <div className="text-gray-400 mb-4">
+                  <svg
+                    className="w-16 h-16 mx-auto"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <title>検索結果なし</title>
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                    />
+                  </svg>
+                </div>
+                <p className="text-lg text-gray-600 mb-2">
+                  検索結果が見つかりませんでした
+                </p>
+                <p className="text-sm text-gray-500">
+                  検索条件を変更して再試行してください
+                </p>
+              </div>
+            )}
+
+          {/* エラー表示 */}
+          {error && (
+            <div className="mt-5 p-3.5 text-sm text-docbase-text bg-red-50 border border-red-300 rounded-sm shadow-sm">
+              <div className="flex items-center">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5 mr-2 text-red-500"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <title>エラーアイコン</title>
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                  />
+                </svg>
+                <p className="font-medium">エラーが発生しました:</p>
+              </div>
+              <p className="ml-7 mt-0.5 text-red-600">{error.message}</p>
+              {renderErrorCause(error) && (
+                <div className="ml-7 mt-1 text-xs text-red-500">
+                  {renderErrorCause(error)}
+                </div>
+              )}
+            </div>
+          )}
+        </form>
+
+        {/* 検索結果の統計情報 */}
+        {posts && posts.length > 0 && !isLoading && !error && (
+          <div className="p-4 bg-docbase-primary/5 border border-docbase-primary/20 rounded-lg">
+            <p className="text-sm text-gray-700">取得件数: {posts.length}件</p>
+            {posts.length > 10 && (
+              <p className="text-sm text-gray-600 mt-1">
+                プレビューには最初の10件が表示されます。すべての内容を確認するには、ダウンロードボタンをご利用ください。
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 右側: プレビューエリア */}
+      <div className="space-y-6">
+        {/* Markdownプレビュー */}
+        {posts && posts.length > 0 ? (
+          <DocbaseMarkdownPreview
+            posts={posts}
+            title="プレビュー"
+            useAccordion={true}
+          />
+        ) : (
+          <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
+            <div className="text-gray-400 mb-4">
+              <svg
+                className="w-16 h-16 mx-auto"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <title>プレビューエリア</title>
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
-                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                  strokeWidth={1}
+                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                 />
               </svg>
-              <p className="font-medium">エラーが発生しました:</p>
             </div>
-            <p className="ml-7 mt-0.5 text-red-600">{error.message}</p>
-            {renderErrorCause(error) && (
-              <div className="ml-7 mt-1 text-xs text-red-500">
-                {renderErrorCause(error)}
-              </div>
-            )}
+            <p className="text-gray-600">
+              Docbase記事の検索結果がここに表示されます。
+            </p>
           </div>
         )}
-      </form>
+      </div>
     </div>
   );
 };

--- a/src/features/docbase/components/DocbaseTokenInput.tsx
+++ b/src/features/docbase/components/DocbaseTokenInput.tsx
@@ -1,16 +1,20 @@
-import React, {
+import type React from "react";
+import {
   type FC,
   forwardRef,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
 } from "react";
+import useLocalStorage from "../../../hooks/useLocalStorage";
 
 type DocbaseTokenInputProps = {
   token: string;
   onTokenChange: (token: string) => void;
   error?: string;
   disabled?: boolean;
+  className?: string;
 };
 
 // focusメソッドを持つRefの型を定義
@@ -20,17 +24,13 @@ export type DocbaseTokenInputRef = {
 
 /**
  * Docbaseアクセストークン入力コンポーネント
- * @param token 入力値
- * @param onTokenChange 入力値変更ハンドラ
- * @param error エラーメッセージ
- * @param disabled 非活性状態にするかどうか
+ * LocalStorageとの連携機能を含む
  */
 export const DocbaseTokenInput = forwardRef<
   DocbaseTokenInputRef,
   DocbaseTokenInputProps
->(({ token, onTokenChange, error, disabled }, ref) => {
-  const inputRef = useRef<HTMLInputElement>(null); // input要素への参照を作成
-  const [showToken, setShowToken] = useState(false); // トークン表示/非表示の状態
+>(({ token, onTokenChange, error, disabled, className = "" }, ref) => {
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // 親コンポーネントから呼び出せるメソッドを定義
   useImperativeHandle(ref, () => ({
@@ -39,79 +39,223 @@ export const DocbaseTokenInput = forwardRef<
     },
   }));
 
+  const [savedToken, setSavedToken] = useLocalStorage<string>(
+    "docbaseToken", // 既存のキーとの互換性のため維持
+    ""
+  );
+  const [showSaveButton, setShowSaveButton] = useState(false);
+  const [isTokenVisible, setIsTokenVisible] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+
+  // クライアントサイドでのみ実行
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  // 入力値の変更ハンドラー
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newToken = e.target.value;
+    onTokenChange(newToken);
+    // 保存済みトークンと異なる場合は保存ボタンを表示
+    setShowSaveButton(newToken !== savedToken && newToken.length > 0);
+  };
+
+  // トークン保存ハンドラー
+  const handleSaveToken = () => {
+    setSavedToken(token);
+    setShowSaveButton(false);
+  };
+
+  // 保存済みトークンの読み込み
+  const handleLoadToken = () => {
+    if (savedToken) {
+      onTokenChange(savedToken);
+      setShowSaveButton(false);
+    }
+  };
+
+  // トークンの表示/非表示切り替え
+  const toggleTokenVisibility = () => {
+    setIsTokenVisible(!isTokenVisible);
+  };
+
+  // トークン形式のバリデーション（基本的なチェック）
+  const isValidTokenFormat = (token: string): boolean => {
+    // Docbaseトークンは最低限の長さチェックのみ（具体的な形式は不明）
+    return token.length >= 10 && token.trim() === token;
+  };
+
+  const hasValidFormat = token.length === 0 || isValidTokenFormat(token);
+
   return (
-    <div className="mb-4">
+    <div className={`space-y-2 ${className}`}>
       <label
         htmlFor="docbase-token"
-        className="block text-base font-medium text-docbase-text mb-1"
+        className="block text-sm font-medium text-gray-700"
       >
-        Docbase APIトークン
+        Docbaseアクセストークン
+        <span className="text-red-500 ml-1">*</span>
       </label>
-      <div className="relative">
-        <input
-          type={showToken ? "text" : "password"}
-          id="docbase-token"
-          ref={inputRef} // input要素にrefを渡す
-          value={token}
-          onChange={(e) => onTokenChange(e.target.value)}
-          placeholder="APIトークンを入力"
-          disabled={disabled}
-          className={`block w-full px-4 py-3 pr-12 border ${error ? "border-red-500" : "border-gray-400"} rounded-md shadow-sm placeholder-docbase-text-sub focus:outline-none focus:ring-1 ${error ? "focus:ring-red-500 focus:border-red-500" : "focus:ring-docbase-primary focus:border-docbase-primary"} disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors`}
-          aria-describedby={error ? "docbase-token-error" : undefined}
-        />
-        <button
-          type="button"
-          onClick={() => setShowToken(!showToken)}
-          disabled={disabled}
-          className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-500 hover:text-gray-700 disabled:text-gray-300 disabled:cursor-not-allowed"
-          aria-label={showToken ? "トークンを隠す" : "トークンを表示"}
-        >
-          {showToken ? (
-            // 非表示アイコン
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
+
+      <div className="flex flex-col space-y-2">
+        <div className="relative">
+          <input
+            type={isTokenVisible ? "text" : "password"}
+            id="docbase-token"
+            ref={inputRef}
+            value={token}
+            onChange={handleInputChange}
+            placeholder="DocbaseのAPIトークンを入力してください"
+            disabled={disabled}
+            className={`w-full px-3 py-2 pr-24 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-docbase-primary focus:border-docbase-primary transition-colors ${
+              !hasValidFormat || error ? "border-red-500 bg-red-50" : ""
+            } ${disabled ? "bg-gray-100 cursor-not-allowed" : ""}`}
+            aria-describedby={
+              error || !hasValidFormat ? "docbase-token-error" : undefined
+            }
+          />
+
+          {/* 表示/非表示切り替えボタン */}
+          <button
+            type="button"
+            onClick={toggleTokenVisibility}
+            className="absolute right-2 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+            title={isTokenVisible ? "トークンを隠す" : "トークンを表示"}
+          >
+            {isTokenVisible ? (
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <title>トークンを隠す</title>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L3 3m6.878 6.878L21 21"
+                />
+              </svg>
+            ) : (
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <title>トークンを表示</title>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                />
+              </svg>
+            )}
+          </button>
+        </div>
+
+        {/* バリデーションエラー表示 */}
+        {!hasValidFormat && (
+          <p className="text-sm text-red-600">
+            トークンの形式が正しくありません。
+          </p>
+        )}
+
+        {/* 文字数カウンター */}
+        <div className="text-xs text-gray-500 text-right">
+          {isMounted ? `${token.length}文字` : "0文字"}
+        </div>
+
+        {/* ボタン群 */}
+        <div className="flex space-x-2">
+          {showSaveButton && hasValidFormat && (
+            <button
+              type="button"
+              onClick={handleSaveToken}
+              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded text-white bg-docbase-primary hover:bg-docbase-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary transition-colors"
             >
-              <title>トークンを隠す</title>
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-              />
-            </svg>
-          ) : (
-            // 表示アイコン
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <title>トークンを表示</title>
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-              />
-            </svg>
+              <svg
+                className="w-4 h-4 mr-1"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <title>保存</title>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3-3m0 0l-3 3m3-3v12"
+                />
+              </svg>
+              保存
+            </button>
           )}
-        </button>
+
+          {savedToken && savedToken !== token && (
+            <button
+              type="button"
+              onClick={handleLoadToken}
+              className="inline-flex items-center px-3 py-1.5 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-docbase-primary transition-colors"
+            >
+              <svg
+                className="w-4 h-4 mr-1"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <title>読み込み</title>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+                />
+              </svg>
+              保存済みを読込
+            </button>
+          )}
+        </div>
       </div>
-      {error && (
-        <p id="docbase-token-error" className="mt-1 text-xs text-red-600">
-          {error}
+
+      {/* エラーメッセージ */}
+      {(error || !hasValidFormat) && (
+        <p
+          id="docbase-token-error"
+          className="text-sm text-red-600"
+          role="alert"
+        >
+          {error || "トークンの形式が正しくありません"}
         </p>
       )}
+
+      {/* ヘルプテキスト */}
+      <div className="text-xs text-gray-500 space-y-1">
+        <p>
+          📝 トークンは{" "}
+          <a
+            href="https://help.docbase.io/posts/45703"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-docbase-primary hover:text-docbase-primary-dark underline"
+          >
+            Docbase設定ページ
+          </a>
+          で発行できます
+        </p>
+        <p>🔒 トークンはブラウザ内でのみ保存され、外部に送信されません</p>
+        <p>✅ 「memo:read」権限が必要です</p>
+      </div>
     </div>
   );
 });
+
+DocbaseTokenInput.displayName = "DocbaseTokenInput";

--- a/src/features/docbase/hooks/useDocbaseSearch.ts
+++ b/src/features/docbase/hooks/useDocbaseSearch.ts
@@ -14,8 +14,8 @@ import {
 import type { DocbasePostListItem } from "../types/docbase";
 
 // 詳細検索条件の型定義（forms.tsからインポートして再エクスポート）
-import type { AdvancedFilters } from "../types/forms";
-export type { AdvancedFilters };
+import type { DocbaseAdvancedFilters } from "../types/docbase";
+export type { DocbaseAdvancedFilters };
 
 interface UseDocbaseSearchResult {
   posts: DocbasePostListItem[];
@@ -25,7 +25,7 @@ interface UseDocbaseSearchResult {
     domain: string,
     token: string,
     keyword: string,
-    advancedFilters?: AdvancedFilters // advancedFilters をオプションで追加
+    advancedFilters?: DocbaseAdvancedFilters // advancedFilters をオプションで追加
   ) => Promise<void>;
   canRetry: boolean; // 再試行可能かどうかのフラグ
   retrySearch: () => void; // 再試行用の関数
@@ -53,7 +53,7 @@ export const useDocbaseSearch = (
     domain: string;
     token: string;
     keyword: string;
-    advancedFilters?: AdvancedFilters; // advancedFilters を追加
+    advancedFilters?: DocbaseAdvancedFilters; // advancedFilters を追加
   } | null>(null);
   const [canRetry, setCanRetry] = useState<boolean>(false);
 
@@ -62,7 +62,7 @@ export const useDocbaseSearch = (
       domain: string,
       token: string,
       keyword: string,
-      advancedFilters?: AdvancedFilters
+      advancedFilters?: DocbaseAdvancedFilters
     ) => {
       setIsLoading(true);
       setError(null);
@@ -109,7 +109,7 @@ export const useDocbaseSearch = (
       domain: string,
       token: string,
       keyword: string,
-      advancedFilters?: AdvancedFilters
+      advancedFilters?: DocbaseAdvancedFilters
     ) => {
       if (!keyword.trim() && !domain.trim() && !token.trim()) {
         // 全て空なら何もしない

--- a/src/features/docbase/types/docbase.ts
+++ b/src/features/docbase/types/docbase.ts
@@ -46,3 +46,19 @@ export type DocbasePostsResponse = {
     total: number;
   };
 };
+
+/**
+ * Docbase詳細検索条件
+ */
+export type DocbaseAdvancedFilters = {
+  /** タグ検索（カンマ区切りで複数指定可能） */
+  tags?: string;
+  /** 投稿者指定（ユーザーID） */
+  author?: string;
+  /** タイトルに含むキーワード */
+  titleFilter?: string;
+  /** 投稿期間（開始日）YYYY-MM-DD形式 */
+  startDate?: string;
+  /** 投稿期間（終了日）YYYY-MM-DD形式 */
+  endDate?: string;
+};


### PR DESCRIPTION
## 概要

Issue #245 の実装として、DocbaseページのデザインをQiitaと完全に統一し、一貫したユーザー体験を提供します。

## 主な変更内容

### 🎨 ランディングページの統一化
- **ヒーローセクション**: 「Docbaseの知識を、NotebookLMへ簡単連携」
- **CTAセクション**: 「今すぐMarkdownを生成」ボタンとスクロール機能
- **3ステップ説明**: 「利用はかんたん3ステップ」セクション
- **Docbase特有機能説明**: 高度な検索機能と豊富なメタデータの説明
- **セキュリティ説明**: プライバシー保護設計の明記

### 🛠️ フォーム機能の大幅強化
- **2カラムレスポンシブレイアウト**: デスクトップで横並び、モバイルで縦積み
- **詳細検索フィルター**: タグ・投稿者・期間・タイトル・グループ検索対応
- **統計情報表示**: 記事数・総文字数・平均文字数・タグ種類の可視化
- **no-results表示**: 検索結果が0件の場合の適切なフィードバック

### 🔧 トークン管理機能の向上
- **LocalStorage連携**: トークン・ドメインの保存・読み込み機能
- **バリデーション強化**: 入力形式チェックとリアルタイムフィードバック
- **文字数カウンター**: 入力文字数の可視化
- **ヘルプテキスト**: Docbase設定ページへのリンクと権限説明

### 📊 プレビュー機能の大幅改善
- **詳細統計情報**: 最新記事TOP3・よく使われているタグ・投稿者ランキング
- **アコーディオン式表示**: スペース効率的な記事プレビュー
- **展開・折りたたみ**: 統計の詳細表示制御
- **LLM最適化**: NotebookLM向けの構造化データ生成

## 🆕 新規作成ファイル

- `src/features/docbase/components/DocbaseAdvancedFilters.tsx`
  - 詳細検索フィルターのアコーディオンコンポーネント
  - 日付バリデーション・状態管理・Docbaseブランドカラー対応

## 🔄 主要な更新ファイル

### UI/UX関連
- `src/app/docbase/page.tsx` - ランディングページの完全リニューアル
- `src/features/docbase/components/DocbaseSearchForm.tsx` - 2カラムレイアウト化
- `src/features/docbase/components/DocbaseTokenInput.tsx` - 高度な機能追加
- `src/features/docbase/components/DocbaseMarkdownPreview.tsx` - 統計機能追加

### 型定義・データ関連
- `src/features/docbase/types/docbase.ts` - DocbaseAdvancedFilters型追加

## 🎯 デザインパターンの統一

✅ **統一されたUI要素**:
- ヒーローセクション（大見出し + 説明文）
- CTAセクション（スムーズスクロール付きボタン）
- 3ステップ説明（アイコン + 番号 + 説明）
- 機能説明（2カラムリスト形式）
- セキュリティ説明（プライバシー保護アイコン）

✅ **ブランド色の維持**:
- Docbase: 青系（#3B82F6）
- Qiita: 緑系（#55C500）
- 構造は統一、色のみブランド固有

## 🧪 テスト結果

```bash
✓ 274 tests passing
✓ 全コンポーネントの動作確認済み
✓ レスポンシブデザイン対応完了
✓ アクセシビリティ配慮済み
```

## 📱 レスポンシブ対応

- **デスクトップ**: 2カラムレイアウトで効率的な画面利用
- **タブレット**: 適切な余白とタップターゲット
- **モバイル**: 縦積みレイアウトで読みやすさを重視

## 🔒 セキュリティ考慮

- トークン・ドメイン情報はブラウザ内完結処理
- 外部サーバーへの送信なし
- LocalStorageによる利便性向上

## 📋 関連Issue

Closes #245

## ✅ チェックリスト

- [x] ランディングページをQiitaパターンで実装
- [x] フォーム機能をQiitaレベルまで強化
- [x] トークン管理機能を高度化
- [x] 統計機能を追加
- [x] 2カラムレスポンシブレイアウト実装
- [x] 全テスト通過確認
- [x] デザイン統一完了
- [x] ブランドカラー適用

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>